### PR TITLE
Expose setting the Timeout property of source and target from the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1810,6 +1810,20 @@ func LinkTargetExpiryPolicy(p ExpiryPolicy) LinkOption {
 	}
 }
 
+// LinkTargetTimeout sets the duration that an expiring target will be retained.
+//
+// Default: 0.
+func LinkTargetTimeout(timeout uint32) LinkOption {
+	return func(l *link) error {
+		if l.target == nil {
+			l.target = new(target)
+		}
+		l.target.Timeout = timeout
+
+		return nil
+	}
+}
+
 // LinkSourceDurability sets the source durability policy.
 //
 // Default: DurabilityNone.
@@ -1842,6 +1856,20 @@ func LinkSourceExpiryPolicy(p ExpiryPolicy) LinkOption {
 			l.source = new(source)
 		}
 		l.source.ExpiryPolicy = p
+
+		return nil
+	}
+}
+
+// LinkSourceTimeout sets the duration that an expiring source will be retained.
+//
+// Default: 0.
+func LinkSourceTimeout(timeout uint32) LinkOption {
+	return func(l *link) error {
+		if l.source == nil {
+			l.source = new(source)
+		}
+		l.source.Timeout = timeout
 
 		return nil
 	}


### PR DESCRIPTION
The MQ broker I am using does not support durable subscriptions without an expiration, so I need to be able to set the timeout to something non-zero. The timeout parameter already exists internally; this PR is just allowing it to be configured from the client.