### PR TITLE
Add option to set int32 properties on links

### DIFF
--- a/client.go
+++ b/client.go
@@ -1567,6 +1567,13 @@ func LinkPropertyInt64(key string, value int64) LinkOption {
 	return linkProperty(key, value)
 }
 
+// LinkPropertyInt32 sets an entry in the link properties map sent to the server.
+//
+// This option can be set multiple times.
+func LinkPropertyInt32(key string, value int32) LinkOption {
+	return linkProperty(key, value)
+}
+
 func linkProperty(key string, value interface{}) LinkOption {
 	return func(l *link) error {
 		if key == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -24,6 +24,7 @@ func TestLinkOptions(t *testing.T) {
 				LinkProperty("x-opt-test2", "test2"),
 				LinkProperty("x-opt-test1", "test3"),
 				LinkPropertyInt64("x-opt-test4", 1),
+				LinkPropertyInt32("x-opt-test5", 2),
 				LinkSourceFilter("com.microsoft:session-filter", 0x00000137000000C, "123"),
 			},
 
@@ -43,6 +44,7 @@ func TestLinkOptions(t *testing.T) {
 				"x-opt-test1": "test3",
 				"x-opt-test2": "test2",
 				"x-opt-test4": int64(1),
+				"x-opt-test5": int32(2),
 			},
 		},
 		{


### PR DESCRIPTION
Some servers are opinionated about the encoded type that they expect specific link properties to have. The existing int64 property option encodes the property value as a long/64-bit integer. This option allows 32-bit integers to be sent, which are needed for numeric values sent to some servers.