### PR TITLE
Avoid double-closing message channel

### DIFF
--- a/link.go
+++ b/link.go
@@ -232,9 +232,6 @@ func (l *link) addUnsettled(msg *Message) {
 }
 
 func (l *link) deleteUnsettled(msg *Message) {
-	if len(msg.DeliveryTag) == 0 {
-		return
-	}
 	l.unsettledMessagesLock.Lock()
 	delete(l.unsettledMessages, string(msg.DeliveryTag))
 	l.unsettledMessagesLock.Unlock()

--- a/link.go
+++ b/link.go
@@ -223,12 +223,18 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 }
 
 func (l *link) addUnsettled(msg *Message) {
+	if len(msg.DeliveryTag) == 0 {
+		return
+	}
 	l.unsettledMessagesLock.Lock()
 	l.unsettledMessages[string(msg.DeliveryTag)] = struct{}{}
 	l.unsettledMessagesLock.Unlock()
 }
 
 func (l *link) deleteUnsettled(msg *Message) {
+	if len(msg.DeliveryTag) == 0 {
+		return
+	}
 	l.unsettledMessagesLock.Lock()
 	delete(l.unsettledMessages, string(msg.DeliveryTag))
 	l.unsettledMessagesLock.Unlock()

--- a/receiver.go
+++ b/receiver.go
@@ -31,6 +31,9 @@ func (r *Receiver) HandleMessage(ctx context.Context, handle func(*Message) erro
 	debug(3, "Entering link %s Receive()", r.link.key.name)
 
 	trackCompletion := func(msg *Message) {
+		if msg.doneSignal == nil {
+			msg.doneSignal = make(chan struct{})
+		}
 		<-msg.doneSignal
 		r.link.deleteUnsettled(msg)
 		debug(3, "Receive() deleted unsettled %d", msg.deliveryID)
@@ -48,9 +51,6 @@ func (r *Receiver) HandleMessage(ctx context.Context, handle func(*Message) erro
 		// we only need to track message disposition for mode second
 		// spec : http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-receiver-settle-mode
 		if r.link.receiverSettleMode.value() == ModeSecond {
-			if msg.doneSignal == nil {
-				msg.doneSignal = make(chan struct{})
-			}
 			go trackCompletion(msg)
 		}
 		// tracks messages until exiting handler

--- a/receiver.go
+++ b/receiver.go
@@ -45,16 +45,13 @@ func (r *Receiver) HandleMessage(ctx context.Context, handle func(*Message) erro
 	callHandler := func(msg *Message) error {
 		debug(3, "Receive() blocking %d", msg.deliveryID)
 		msg.receiver = r
-		if msg.doneSignal == nil {
-			msg.doneSignal = make(chan struct{})
-		}
-		go trackCompletion(msg)
-		// accept spontaneously when receiver is in ModeFirst
+		// we only need to track message disposition for mode second
 		// spec : http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-receiver-settle-mode
-		if r.link.receiverSettleMode.value() == ModeFirst {
-			if err := msg.Accept(ctx); err != nil {
-				return err
+		if r.link.receiverSettleMode.value() == ModeSecond {
+			if msg.doneSignal == nil {
+				msg.doneSignal = make(chan struct{})
 			}
+			go trackCompletion(msg)
 		}
 		// tracks messages until exiting handler
 		if err := handle(msg); err != nil {

--- a/types.go
+++ b/types.go
@@ -1674,6 +1674,7 @@ type Message struct {
 	Format uint32
 
 	// The DeliveryTag can be up to 32 octets of binary data.
+	// Note that when mode one is enabled there will be no delivery tag.
 	DeliveryTag []byte
 
 	// The header section carries standard delivery details about the transfer

--- a/types.go
+++ b/types.go
@@ -1798,10 +1798,10 @@ func (m *Message) GetData() []byte {
 // Accept notifies the server that the message has been
 // accepted and does not require redelivery.
 func (m *Message) Accept(ctx context.Context) error {
-	defer m.done()
 	if !m.shouldSendDisposition() {
 		return nil
 	}
+	defer m.done()
 	return m.receiver.messageDisposition(ctx, m.deliveryID, &stateAccepted{})
 }
 
@@ -1809,20 +1809,20 @@ func (m *Message) Accept(ctx context.Context) error {
 //
 // Rejection error is optional.
 func (m *Message) Reject(ctx context.Context, e *Error) error {
-	defer m.done()
 	if !m.shouldSendDisposition() {
 		return nil
 	}
+	defer m.done()
 	return m.receiver.messageDisposition(ctx, m.deliveryID, &stateRejected{Error: e})
 }
 
 // Release releases the message back to the server. The message
 // may be redelivered to this or another consumer.
 func (m *Message) Release(ctx context.Context) error {
-	defer m.done()
 	if !m.shouldSendDisposition() {
 		return nil
 	}
+	defer m.done()
 	return m.receiver.messageDisposition(ctx, m.deliveryID, &stateReleased{})
 }
 
@@ -1839,10 +1839,10 @@ func (m *Message) Release(ctx context.Context) error {
 // with the existing message annotations, overwriting existing keys
 // if necessary.
 func (m *Message) Modify(ctx context.Context, deliveryFailed, undeliverableHere bool, messageAnnotations Annotations) error {
-	defer m.done()
 	if !m.shouldSendDisposition() {
 		return nil
 	}
+	defer m.done()
 	return m.receiver.messageDisposition(ctx,
 		m.deliveryID, &stateModified{
 			DeliveryFailed:     deliveryFailed,
@@ -1855,7 +1855,9 @@ func (m *Message) Modify(ctx context.Context, deliveryFailed, undeliverableHere 
 // without any disposition. It frees the amqp receiver to get the next message
 // this is implicitly done after calling message dispositions (Accept/Release/Reject/Modify)
 func (m *Message) Ignore() {
-	m.done()
+	if m.shouldSendDisposition() {
+		m.done()
+	}
 }
 
 // MarshalBinary encodes the message into binary form.


### PR DESCRIPTION
Only call done() if the message hasn't been settled.  This showed up
after recent changes to mode first to correctly settle messages.