### PR TITLE
Only track unsettled messages in ModeSecond

### DIFF
--- a/link.go
+++ b/link.go
@@ -223,9 +223,6 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 }
 
 func (l *link) addUnsettled(msg *Message) {
-	if len(msg.DeliveryTag) == 0 {
-		return
-	}
 	l.unsettledMessagesLock.Lock()
 	l.unsettledMessages[string(msg.DeliveryTag)] = struct{}{}
 	l.unsettledMessagesLock.Unlock()
@@ -512,7 +509,9 @@ func (l *link) muxReceive(fr performTransfer) error {
 	debug(1, "deliveryID %d before push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
 	// send to receiver, this should never block due to buffering
 	// and flow control.
-	l.addUnsettled(&l.msg)
+	if l.receiverSettleMode.value() == ModeSecond {
+		l.addUnsettled(&l.msg)
+	}
 	l.messages <- l.msg
 
 	debug(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -47,7 +47,6 @@ func TestReceiver_HandleMessageModeFirst_AutoAccept(t *testing.T) {
 	}
 	msg := makeMessage(ModeFirst)
 	r.link.messages <- msg
-	r.link.addUnsettled(&msg)
 	if r.link.countUnsettled() != 0 {
 		// mode first messages have no delivery tag, thus there should be no unsettled message
 		t.Fatal("expected zero unsettled count")


### PR DESCRIPTION
This should fix #33 by running `addUnsettled` only in ModeSecond, same as trackCompletion:

https://github.com/Azure/go-amqp/blob/51f7e70071303e8e3e3e867fc068dedeb2f31e44/receiver.go#L53-L55