### PR TITLE
Allow receive to close if blocked on channel send

### DIFF
--- a/link.go
+++ b/link.go
@@ -579,13 +579,13 @@ func (l *link) muxReceive(fr frames.PerformTransfer) error {
 	var closed bool
 	select {
 	case l.messages <- l.msg:
-		// Sent. No-op
+		// Sent
+		debug(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
 	case <-l.close:
 		// Link was closed
 		debug(1, "deliveryID %d skipping push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
 		closed = true
 	}
-	debug(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
 
 	// reset progress
 	l.buf.Reset()

--- a/link.go
+++ b/link.go
@@ -572,8 +572,19 @@ func (l *link) muxReceive(fr frames.PerformTransfer) error {
 	if receiverSettleModeValue(l.receiverSettleMode) == ModeSecond {
 		l.addUnsettled(&l.msg)
 	}
-	l.messages <- l.msg
 
+	// send to receiver, this should never block due to buffering and flow
+	// control, but we still check for link close in case something unexpected
+	// happens so that we can shut down properly.
+	var closed bool
+	select {
+	case l.messages <- l.msg:
+		// Sent. No-op
+	case <-l.close:
+		// Link was closed
+		debug(1, "deliveryID %d skipping push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
+		closed = true
+	}
 	debug(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages), len(l.receiver.inFlight.m))
 
 	// reset progress
@@ -584,6 +595,14 @@ func (l *link) muxReceive(fr frames.PerformTransfer) error {
 	l.deliveryCount++
 	l.linkCredit--
 	debug(1, "deliveryID %d before exit - deliveryCount : %d - linkCredit: %d, len(messages): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.messages))
+
+	// we defer returning on close until after we've updated our counters just
+	// to be safe. returning a link closed error allows the shutdown to complete
+	// normally
+	if closed {
+		return ErrLinkClosed
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Changes forwarding of received messages to not block if a close is received. This allows the receiver to shut down correctly even in the case of some AMQP link credit bug or protocol violation on the part of a server. It has been tested in an application actively having issues with hanging close calls and this change fixes the problem without other ill effects.

Fixes #38 