### PR TITLE
Access the associated link name

### DIFF
--- a/message.go
+++ b/message.go
@@ -142,9 +142,9 @@ func (m *Message) GetData() []byte {
 }
 
 // GetLinkName returns associated link name or empty string if receiver or link is not defined.
-func (m *Message) GetLinkName() string {
-	if m.receiver != nil && m.receiver.link != nil {
-		return m.receiver.link.key.name
+func (m *Message) LinkName() string {
+	if m.receiver != nil {
+		return m.receiver.LinkName()
 	}
 	return ""
 }

--- a/receiver.go
+++ b/receiver.go
@@ -151,10 +151,7 @@ func (r *Receiver) Address() string {
 
 // LinkName returns associated link name or an empty string if link is not defined.
 func (r *Receiver) LinkName() string {
-	if r.link != nil {
-		return r.link.key.name
-	}
-	return ""
+	return r.link.key.name
 }
 
 // LinkSourceFilterValue retrieves the specified link source filter value or nil if it doesn't exist.

--- a/receiver.go
+++ b/receiver.go
@@ -149,6 +149,14 @@ func (r *Receiver) Address() string {
 	return r.link.source.Address
 }
 
+// LinkName returns associated link name or an empty string if link is not defined.
+func (r *Receiver) LinkName() string {
+	if r.link != nil {
+		return r.link.key.name
+	}
+	return ""
+}
+
 // LinkSourceFilterValue retrieves the specified link source filter value or nil if it doesn't exist.
 func (r *Receiver) LinkSourceFilterValue(name string) interface{} {
 	if r.link.source == nil {

--- a/sender.go
+++ b/sender.go
@@ -21,8 +21,8 @@ type Sender struct {
 	nextDeliveryTag uint64
 }
 
-// ID() is the ID of the link used for this Sender.
-func (s *Sender) ID() string {
+// LinkName() is the name of the link used for this Sender.
+func (s *Sender) LinkName() string {
 	return s.link.key.name
 }
 
@@ -148,14 +148,6 @@ func (s *Sender) Address() string {
 		return ""
 	}
 	return s.link.target.Address
-}
-
-// LinkName returns associated link name or an empty string if link is not defined.
-func (r *Sender) LinkName() string {
-	if r.link != nil {
-		return r.link.key.name
-	}
-	return ""
 }
 
 // Close closes the Sender and AMQP link.

--- a/sender.go
+++ b/sender.go
@@ -150,6 +150,14 @@ func (s *Sender) Address() string {
 	return s.link.target.Address
 }
 
+// LinkName returns associated link name or an empty string if link is not defined.
+func (r *Sender) LinkName() string {
+	if r.link != nil {
+		return r.link.key.name
+	}
+	return ""
+}
+
 // Close closes the Sender and AMQP link.
 func (s *Sender) Close(ctx context.Context) error {
 	return s.link.Close(ctx)

--- a/sender_test.go
+++ b/sender_test.go
@@ -29,5 +29,5 @@ func TestSenderId(t *testing.T) {
 	require.NoError(t, err)
 
 	sender := &Sender{link: link}
-	require.NotEmpty(t, sender.ID())
+	require.NotEmpty(t, sender.LinkName())
 }


### PR DESCRIPTION
This PR adds `LinkName()` functions exposing associated link name.
The associated link name passed as a property to the management messages helps keep the session and link active.
This change supports implementation of https://github.com/Azure/azure-service-bus-go/issues/226