### PR TITLE
Add some changes to make connection recovery easier for senders

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,9 +20,13 @@ var (
 	// when Session.Close() is called.
 	ErrSessionClosed = errors.New("amqp: session closed")
 
-	// ErrLinkClosed returned by send and receive operations when
+	// ErrLinkClosed is returned by send and receive operations when
 	// Sender.Close() or Receiver.Close() are called.
 	ErrLinkClosed = errors.New("amqp: link closed")
+
+	// ErrLinkDetached is returned by operations when the
+	// link is in a detached state.
+	ErrLinkDetached = errors.New("amqp: link detached")
 )
 
 // Client is an AMQP client connection.

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/google/go-cmp v0.5.1
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/link.go
+++ b/link.go
@@ -19,8 +19,8 @@ type link struct {
 	rx            chan frameBody       // sessions sends frames for this link on this channel
 	transfers     chan performTransfer // sender uses to send transfer frames
 	closeOnce     sync.Once            // closeOnce protects close from being closed multiple times
-	close         chan struct{}        // close signals the mux to shutdown
-	done          chan struct{}        // done is closed by mux/muxDetach when the link is fully detached
+	close         chan struct{}        // close signals the mux to shutdown.
+	detach        chan struct{}        // done is closed by mux/muxDetach when the link is fully detached.
 	detachErrorMu sync.Mutex           // protects detachError
 	detachError   *Error               // error to send to remote on detach, set by closeWithError
 	session       *Session             // parent session
@@ -60,7 +60,7 @@ func newLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 		session:       s,
 		receiver:      r,
 		close:         make(chan struct{}),
-		done:          make(chan struct{}),
+		detach:        make(chan struct{}),
 		receiverReady: make(chan struct{}, 1),
 	}
 
@@ -648,7 +648,7 @@ func (l *link) muxHandleFrame(fr frameBody) error {
 func (l *link) Close(ctx context.Context) error {
 	l.closeOnce.Do(func() { close(l.close) })
 	select {
-	case <-l.done:
+	case <-l.detach:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -681,7 +681,7 @@ func (l *link) muxDetach() {
 		}
 
 		// signal other goroutines that link is done
-		close(l.done)
+		close(l.detach)
 
 		// unblock any in flight message dispositions
 		if l.receiver != nil {

--- a/receiver.go
+++ b/receiver.go
@@ -73,7 +73,7 @@ func (r *Receiver) HandleMessage(ctx context.Context, handle func(*Message) erro
 	select {
 	case msg := <-r.link.messages:
 		return callHandler(&msg)
-	case <-r.link.done:
+	case <-r.link.detach:
 		return r.link.err
 	case <-ctx.Done():
 		return ctx.Err()
@@ -118,7 +118,7 @@ func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
 		debug(3, "Receive() blocking %d", msg.deliveryID)
 		msg.receiver = r
 		return &msg, nil
-	case <-r.link.done:
+	case <-r.link.detach:
 		return nil, r.link.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -232,7 +232,7 @@ func (r *Receiver) dispositionBatcher() {
 			batchStarted = false
 			batchTimer.Stop()
 
-		case <-r.link.done:
+		case <-r.link.detach:
 			return
 		}
 	}

--- a/receiver.go
+++ b/receiver.go
@@ -73,7 +73,7 @@ func (r *Receiver) HandleMessage(ctx context.Context, handle func(*Message) erro
 	select {
 	case msg := <-r.link.messages:
 		return callHandler(&msg)
-	case <-r.link.detach:
+	case <-r.link.detached:
 		return r.link.err
 	case <-ctx.Done():
 		return ctx.Err()
@@ -118,7 +118,7 @@ func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
 		debug(3, "Receive() blocking %d", msg.deliveryID)
 		msg.receiver = r
 		return &msg, nil
-	case <-r.link.detach:
+	case <-r.link.detached:
 		return nil, r.link.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -232,7 +232,7 @@ func (r *Receiver) dispositionBatcher() {
 			batchStarted = false
 			batchTimer.Stop()
 
-		case <-r.link.detach:
+		case <-r.link.detached:
 			return
 		}
 	}

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -9,7 +9,7 @@ import (
 func makeLink(mode ReceiverSettleMode) *link {
 	return &link{
 		close:              make(chan struct{}),
-		done:               make(chan struct{}),
+		detach:               make(chan struct{}),
 		receiverReady:      make(chan struct{}, 1),
 		messages:           make(chan Message, 1),
 		receiverSettleMode: &mode,

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -9,7 +9,7 @@ import (
 func makeLink(mode ReceiverSettleMode) *link {
 	return &link{
 		close:              make(chan struct{}),
-		detach:               make(chan struct{}),
+		detached:               make(chan struct{}),
 		receiverReady:      make(chan struct{}, 1),
 		messages:           make(chan Message, 1),
 		receiverSettleMode: &mode,

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -9,7 +9,7 @@ import (
 func makeLink(mode ReceiverSettleMode) *link {
 	return &link{
 		close:              make(chan struct{}),
-		detached:               make(chan struct{}),
+		detached:           make(chan struct{}),
 		receiverReady:      make(chan struct{}, 1),
 		messages:           make(chan Message, 1),
 		receiverSettleMode: &mode,

--- a/sender.go
+++ b/sender.go
@@ -31,9 +31,7 @@ func (s *Sender) ID() string {
 // additional messages can be sent while the current goroutine is waiting
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
-	err := s.link.Check()
-
-	if err != nil {
+	if err := s.link.Check(); err != nil {
 		return err
 	}
 

--- a/sender.go
+++ b/sender.go
@@ -32,7 +32,7 @@ func (s *Sender) ID() string {
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	select {
-	case <-s.link.done:
+	case <-s.link.detach:
 		// Do a quick check that the link is closed before we try to do anything. Without
 		// this the caller can get caught in an endless loop trying to use a link that
 		// has detached (and thus keeps returning s.link.err over and over again).
@@ -55,7 +55,7 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 			return state.Error
 		}
 		return nil
-	case <-s.link.done:
+	case <-s.link.detach:
 		return s.link.err
 	case <-ctx.Done():
 		return errorWrapf(ctx.Err(), "awaiting send")
@@ -124,7 +124,7 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan deliveryState, er
 
 		select {
 		case s.link.transfers <- fr:
-		case <-s.link.done:
+		case <-s.link.detach:
 			return nil, s.link.err
 		case <-ctx.Done():
 			return nil, errorWrapf(ctx.Err(), "awaiting send")

--- a/sender.go
+++ b/sender.go
@@ -16,8 +16,8 @@ type Sender struct {
 	nextDeliveryTag uint64
 }
 
-// Id() is the ID of the link used for this Sender.
-func (s *Sender) Id() string {
+// ID() is the ID of the link used for this Sender.
+func (s *Sender) ID() string {
 	return s.link.key.name
 }
 

--- a/sender.go
+++ b/sender.go
@@ -31,16 +31,10 @@ func (s *Sender) ID() string {
 // additional messages can be sent while the current goroutine is waiting
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
-	select {
-	case <-s.link.detached:
-		// Do a quick check that the link is closed before we try to do anything. Without
-		// this the caller can get caught in an endless loop trying to use a link that
-		// has detached (and thus keeps returning s.link.err over and over again).
-		//
-		// By using ErrLinkClosed they will see something they can (and should be) programatically
-		// reacting to.
-		return ErrLinkClosed
-	default:
+	err := s.link.Check()
+
+	if err != nil {
+		return err
 	}
 
 	done, err := s.send(ctx, msg)

--- a/sender.go
+++ b/sender.go
@@ -16,6 +16,11 @@ type Sender struct {
 	nextDeliveryTag uint64
 }
 
+// Id() is the ID of the link used for this Sender.
+func (s *Sender) Id() string {
+	return s.link.key.name
+}
+
 // Send sends a Message.
 //
 // Blocks until the message is sent, ctx completes, or an error occurs.

--- a/sender.go
+++ b/sender.go
@@ -32,7 +32,7 @@ func (s *Sender) ID() string {
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	select {
-	case <-s.link.detach:
+	case <-s.link.detached:
 		// Do a quick check that the link is closed before we try to do anything. Without
 		// this the caller can get caught in an endless loop trying to use a link that
 		// has detached (and thus keeps returning s.link.err over and over again).
@@ -55,7 +55,7 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 			return state.Error
 		}
 		return nil
-	case <-s.link.detach:
+	case <-s.link.detached:
 		return s.link.err
 	case <-ctx.Done():
 		return errorWrapf(ctx.Err(), "awaiting send")
@@ -124,7 +124,7 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan deliveryState, er
 
 		select {
 		case s.link.transfers <- fr:
-		case <-s.link.detach:
+		case <-s.link.detached:
 			return nil, s.link.err
 		case <-ctx.Done():
 			return nil, errorWrapf(ctx.Err(), "awaiting send")

--- a/sender_test.go
+++ b/sender_test.go
@@ -1,0 +1,23 @@
+package amqp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClosedSenderReturnsErrClosed(t *testing.T) {
+	// this feels a bit _too_ fake, should revisit.
+	link, err := newLink(newSession(nil, 0), &Receiver{}, nil)
+	require.NoError(t, err)
+
+	sender := &Sender{link: link}
+
+	// simulate a detach happening before the send()
+	// link.muxDetach()
+	close(link.done)
+
+	err = sender.Send(context.TODO(), &Message{})
+	require.EqualError(t, ErrLinkClosed, err.Error())
+}

--- a/sender_test.go
+++ b/sender_test.go
@@ -21,3 +21,11 @@ func TestClosedSenderReturnsErrClosed(t *testing.T) {
 	err = sender.Send(context.TODO(), &Message{})
 	require.EqualError(t, ErrLinkClosed, err.Error())
 }
+
+func TestSenderId(t *testing.T) {
+	link, err := newLink(newSession(nil, 0), &Receiver{}, nil)
+	require.NoError(t, err)
+
+	sender := &Sender{link: link}
+	require.NotEmpty(t, sender.Id())
+}

--- a/sender_test.go
+++ b/sender_test.go
@@ -27,5 +27,5 @@ func TestSenderId(t *testing.T) {
 	require.NoError(t, err)
 
 	sender := &Sender{link: link}
-	require.NotEmpty(t, sender.Id())
+	require.NotEmpty(t, sender.ID())
 }

--- a/sender_test.go
+++ b/sender_test.go
@@ -17,7 +17,7 @@ func TestClosedSenderReturnsErrClosed(t *testing.T) {
 	// simulate the detach happening before the send. This happens in cases
 	// where we get an error back from the AMQP service (for instance, throttling)
 	// which calls link.muxDetach() (artifical detach)
-	close(link.detach)
+	close(link.detached)
 	require.NoError(t, err)
 
 	err = sender.Send(context.TODO(), &Message{})

--- a/sender_test.go
+++ b/sender_test.go
@@ -21,7 +21,7 @@ func TestClosedSenderReturnsErrClosed(t *testing.T) {
 	require.NoError(t, err)
 
 	err = sender.Send(context.TODO(), &Message{})
-	require.EqualError(t, ErrLinkClosed, err.Error())
+	require.EqualError(t, ErrLinkDetached, err.Error())
 }
 
 func TestSenderId(t *testing.T) {

--- a/sender_test.go
+++ b/sender_test.go
@@ -14,9 +14,11 @@ func TestClosedSenderReturnsErrClosed(t *testing.T) {
 
 	sender := &Sender{link: link}
 
-	// simulate a detach happening before the send()
-	// link.muxDetach()
-	close(link.done)
+	// simulate the detach happening before the send. This happens in cases
+	// where we get an error back from the AMQP service (for instance, throttling)
+	// which calls link.muxDetach() (artifical detach)
+	close(link.detach)
+	require.NoError(t, err)
 
 	err = sender.Send(context.TODO(), &Message{})
 	require.EqualError(t, ErrLinkClosed, err.Error())

--- a/session.go
+++ b/session.go
@@ -448,7 +448,7 @@ func (s *Session) mux(remoteBegin *performBegin) {
 func (s *Session) muxFrameToLink(l *link, fr frameBody) {
 	select {
 	case l.rx <- fr:
-	case <-l.detach:
+	case <-l.detached:
 	case <-s.conn.done:
 	}
 }

--- a/session.go
+++ b/session.go
@@ -448,7 +448,7 @@ func (s *Session) mux(remoteBegin *performBegin) {
 func (s *Session) muxFrameToLink(l *link, fr frameBody) {
 	select {
 	case l.rx <- fr:
-	case <-l.done:
+	case <-l.detach:
 	case <-s.conn.done:
 	}
 }


### PR DESCRIPTION
As part of an investigation into an issue in Event Hubs I found a couple of cases that were problematic when attempting to do recovery.

First, if an error happens (and the sender is subsequently closed) that same error will get repeatedly returned by the sender. The error itself is actually a throttling error (and was relevant the first time it was returned) but after that we really should be indicating the link will _never_ work again because it has been closed.

The second is just exposing the link ID so it's simpler, from the outside, to tell one sender apart from another. As part of a separate change I want to make in Event Hubs I need to be able to see if the sender that I'm about to close/remove is actually the same one I started with (if it's not then I don't have to recover since the 'bad' link has already been cycled out).