### PR TITLE
Fix chan double close on message disposition

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -418,6 +418,7 @@ func (c *conn) mux() {
 				nextSession = newSessionResp{err: errorErrorf("reached connection channel max (%d)", c.channelMax)}
 				continue
 			}
+			debug(1, "NS(%d) new session", next)
 
 			// create the next session to send
 			nextSession = newSessionResp{session: newSession(c, uint16(next))}

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 	"unicode/utf8"
 )
@@ -1765,6 +1766,7 @@ type Message struct {
 
 	// doneSignal is a channel that indicate when a message is considered acted upon by downstream handler
 	doneSignal chan struct{}
+	doneMutex  sync.Mutex
 }
 
 // NewMessage returns a *Message with data as the payload.
@@ -1782,8 +1784,11 @@ func NewMessage(data []byte) *Message {
 // done closes the internal doneSignal channel to let the receiver know that this message has been acted upon
 func (m *Message) done() {
 	// TODO: move initialization in ctor and use ctor everywhere?
+	m.doneMutex.Lock()
 	if m.doneSignal != nil {
 		close(m.doneSignal)
+		m.doneSignal = nil
+		m.doneMutex.Unlock()
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1786,9 +1786,12 @@ func (m *Message) done() {
 	if m.doneSignal == nil {
 		return
 	}
-	m.closeOnce.Do(func() {
-		close(m.doneSignal)
-	})
+	func(once *sync.Once) {
+		once.Do(func() {
+			close(m.doneSignal)
+		})
+	}(&m.closeOnce)
+
 }
 
 // GetData returns the first []byte from the Data field

--- a/types_test.go
+++ b/types_test.go
@@ -39,3 +39,19 @@ func TestMarshalArrayInt64AsSmallLongArray(t *testing.T) {
 
 	require.EqualValues(t, arrayInt64([]int64{math.MaxInt8, math.MinInt8}), unmarshalled)
 }
+
+func TestMessageCallDoneMultipleTimes(t *testing.T) {
+	messageNilDoneChannel := &Message{}
+	require.NotPanics(t, func() {
+		messageNilDoneChannel.done()
+		messageNilDoneChannel.done()
+	})
+
+	messageWithDoneChannel := &Message{
+		doneSignal: make(chan struct{}, 1),
+	}
+	require.NotPanics(t, func() {
+		messageWithDoneChannel.done()
+		messageWithDoneChannel.done()
+	})
+}


### PR DESCRIPTION
if a handler calls 2 message dispositions in a close loop (which is almost certainly a bug in the code), the code will panic.
ensure we don't panic by only ever closing the channel once.
even bad code from the user should not cause a panic.