### PR TITLE
Allow the user of the link to determine if it should detach on disposition errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -608,6 +608,17 @@ func LinkSourceTimeout(timeout uint32) LinkOption {
 	}
 }
 
+// LinkDetachOnDispositionError controls whether you detach on disposition
+// errors (subject to some simple logic) or do NOT detach at all on disposition
+// errors.
+// Defaults to true.
+func LinkDetachOnDispositionError(detachOnDispositionError bool) LinkOption {
+	return func(l *link) error {
+		l.detachOnDispositionError = detachOnDispositionError
+		return nil
+	}
+}
+
 const maxTransferFrameHeader = 66 // determined by calcMaxTransferFrameHeader
 
 func calcMaxTransferFrameHeader() int {


### PR DESCRIPTION
This allows us (in Event Hubs) to choose whether we want to actually disconnect the link on disposition errors. There's a good performance optimization to be had if we can avoid that.

By default, we use the old logic, to remain compatible with previous go-amqp releases.