### PR TITLE
Fix remote outgoing window handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,7 +162,7 @@ func (c *Client) NewSession(opts ...SessionOption) (*Session, error) {
 // Default session options
 const (
 	DefaultMaxLinks = 4294967296
-	DefaultWindow   = 100
+	DefaultWindow   = 1000
 )
 
 // SessionOption is an function for configuring an AMQP session.


### PR DESCRIPTION
At moderate concurrency, we could eat up the session window which was defaulted to a low value (100)
This caused a nasty bug to manifest. the window values are stored as uint.
it is decremented at each transfer. in some cases the uint would loop to intMax.
Once the window would have such a high value, the client stops sending Flow frames, because it thinks its window is huge.
eventually, no messages would get sent, because the remote peer and the local peer are out of sync, and no flow is sent across to reconciliate their state.

This PR fixes the window decrement by stopping it at 0 to prevent looping to int max.

- removes 2 places in the code where go-amqp was pre-emptively setting the outgoing window, probably as a workaround to the uint looping to max int. it now relies on the protocol, only ever updating the remote outgoing window based on communication from the remote peer, as per the protocol.
- sets the DefaultWindow to 1000, as a more sensible value (ServiceBus endpoints advertise a window of 5000)


fixes #15 