### PR TITLE
Expose the max message size so we can use it when creating a batch

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -25,6 +25,11 @@ func (s *Sender) ID() string {
 	return s.link.key.name
 }
 
+// MaxMessageSize is the maximum size of a single message.
+func (s *Sender) MaxMessageSize() uint64 {
+	return s.link.maxMessageSize
+}
+
 // Send sends a Message.
 //
 // Blocks until the message is sent, ctx completes, or an error occurs.


### PR DESCRIPTION
The AMQP broker should (on attaching) return the actual max message size for the link.

Both Azure Event Hubs and Azure Service Bus SDKs can use this to dynamically determine the maximum size allowed, rather than attempting to hard code it using constants for each tier.

This information was already being stored, so this PR just makes it so you can access that data from the outside.