### PR TITLE
Don't set dispositionError to encoding.Error(nil)

### DIFF
--- a/link.go
+++ b/link.go
@@ -707,7 +707,11 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 			// bubble disposition error up to the receiver
 			var dispositionError error
 			if state, ok := fr.State.(*encoding.StateRejected); ok {
-				dispositionError = state.Error
+				// state.Error isn't required to be filled out. For instance if you dead letter a message
+				// you will get a rejected response that doesn't contain an error.
+				if state.Error != nil {
+					dispositionError = state.Error
+				}
 			}
 			l.receiver.inFlight.remove(fr.First, fr.Last, dispositionError)
 		}


### PR DESCRIPTION
When a reject disposition comes back to us it doesn't have to have an error in it. 

We were propagating it when we did have an error, which was good, but we need to make sure we properly "erase" the type on the 'nil' when it's not.

Part of a fix for a bug found in Service Bus: https://github.com/Azure/azure-service-bus-go/issues/215