### PR TITLE
Fix some race conditions

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -199,7 +199,7 @@ func newTestLink(t *testing.T) *link {
 		Source: &frames.Source{},
 		receiver: &Receiver{
 			// adding just enough so the debug() print will still work...
-			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, len(l.receiver.inFlight.m), l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
+			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
 			inFlight: inFlight{},
 		},
 		Session: &Session{

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -28,7 +28,6 @@ func (mc *manualCreditor) EndDrain() {
 
 	if mc.drained != nil {
 		close(mc.drained)
-		mc.drained = nil
 	}
 }
 
@@ -63,6 +62,10 @@ func (mc *manualCreditor) Drain(ctx context.Context) error {
 	// send drain, wait for responding flow frame
 	select {
 	case <-mc.drained:
+		// reset state here after the channel has been closed.
+		// we must do this here and not EndDrain() since we don't
+		// hold mu at this point.
+		mc.drained = nil
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -57,10 +57,10 @@ func TestManualCreditorDrain(t *testing.T) {
 
 	// unblock the last of the drainers
 	mc.EndDrain()
-	require.Nil(t, mc.drained, "drain completes and removes the drained channel")
 
 	// wait for all the drain routines to end
 	drainRoutines.Wait()
+	require.Nil(t, mc.drained, "drain completes and removes the drained channel")
 
 	// one of them should have failed (if both succeeded we've somehow let them both run)
 	require.False(t, err1 == nil && err2 == nil)

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -57,10 +57,10 @@ func TestManualCreditorDrain(t *testing.T) {
 
 	// unblock the last of the drainers
 	mc.EndDrain()
+	require.Nil(t, mc.drained, "drain completes and removes the drained channel")
 
 	// wait for all the drain routines to end
 	drainRoutines.Wait()
-	require.Nil(t, mc.drained, "drain completes and removes the drained channel")
 
 	// one of them should have failed (if both succeeded we've somehow let them both run)
 	require.False(t, err1 == nil && err2 == nil)

--- a/receiver.go
+++ b/receiver.go
@@ -305,7 +305,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, id uint32, state enco
 // to block waiting for the server to respond when an appropriate
 // settlement mode is configured.
 type inFlight struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 	m  map[uint32]chan error
 }
 
@@ -354,4 +354,10 @@ func (f *inFlight) clear(err error) {
 		delete(f.m, id)
 	}
 	f.mu.Unlock()
+}
+
+func (f *inFlight) len() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.m)
 }

--- a/session.go
+++ b/session.go
@@ -363,7 +363,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
 				if !body.Settled && body.DeliveryID != nil && link.ReceiverSettleMode != nil && *link.ReceiverSettleMode == ModeSecond {
-					debug(1, "TX(Session): adding handle to handlesByRemoteDeliveryID. linkCredit: %d", link.linkCredit)
+					debug(1, "TX(Session): adding handle to handlesByRemoteDeliveryID. delivery ID: %d", *body.DeliveryID)
 					handlesByRemoteDeliveryID[*body.DeliveryID] = body.Handle
 				}
 


### PR DESCRIPTION
Added inFlight.len method for safe reading of in-flight count.
Set the drained channel to nil once the drain is complete.
Don't read linkCredit from outside link type.