### PR TITLE
Add mocks package for unit testing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -26,8 +26,6 @@ const (
 	DefaultMaxSessions  = 65536
 )
 
-const frameHeaderSize = 8
-
 // Errors
 var (
 	ErrTimeout = errors.New("amqp: timeout waiting for response")
@@ -504,9 +502,9 @@ func (c *conn) connReader() {
 	buf := &buffer.Buffer{}
 
 	var (
-		negotiating     = true      // true during conn establishment, check for protoHeaders
-		currentHeader   frameHeader // keep track of the current header, for frames split across multiple TCP packets
-		frameInProgress bool        // true if in the middle of receiving data for currentHeader
+		negotiating     = true        // true during conn establishment, check for protoHeaders
+		currentHeader   frames.Header // keep track of the current header, for frames split across multiple TCP packets
+		frameInProgress bool          // true if in the middle of receiving data for currentHeader
 	)
 
 	for {
@@ -522,7 +520,7 @@ func (c *conn) connReader() {
 
 		// need to read more if buf doesn't contain the complete frame
 		// or there's not enough in buf to parse the header
-		if frameInProgress || buf.Len() < frameHeaderSize {
+		if frameInProgress || buf.Len() < frames.HeaderSize {
 			if c.idleTimeout > 0 {
 				_ = c.net.SetReadDeadline(time.Now().Add(c.idleTimeout))
 			}
@@ -548,7 +546,7 @@ func (c *conn) connReader() {
 		}
 
 		// read more if buf doesn't contain enough to parse the header
-		if buf.Len() < frameHeaderSize {
+		if buf.Len() < frames.HeaderSize {
 			continue
 		}
 
@@ -578,7 +576,7 @@ func (c *conn) connReader() {
 		// parse the header if a frame isn't in progress
 		if !frameInProgress {
 			var err error
-			currentHeader, err = parseFrameHeader(buf)
+			currentHeader, err = frames.ParseHeader(buf)
 			if err != nil {
 				c.connErr <- err
 				return
@@ -592,7 +590,7 @@ func (c *conn) connReader() {
 			return
 		}
 
-		bodySize := int64(currentHeader.Size - frameHeaderSize)
+		bodySize := int64(currentHeader.Size - frames.HeaderSize)
 
 		// the full frame has been received
 		if int64(buf.Len()) < bodySize {
@@ -612,7 +610,7 @@ func (c *conn) connReader() {
 			return
 		}
 
-		parsedBody, err := parseFrameBody(buffer.New(b))
+		parsedBody, err := frames.ParseBody(buffer.New(b))
 		if err != nil {
 			c.connErr <- err
 			return
@@ -998,56 +996,6 @@ type protoHeader struct {
 	Revision uint8
 }
 
-// Frame structure:
-//
-//     header (8 bytes)
-//       0-3: SIZE (total size, at least 8 bytes for header, uint32)
-//       4:   DOFF (data offset,at least 2, count of 4 bytes words, uint8)
-//       5:   TYPE (frame type)
-//                0x0: AMQP
-//                0x1: SASL
-//       6-7: type dependent (channel for AMQP)
-//     extended header (opt)
-//     body (opt)
-
-// frameHeader in a structure appropriate for use with binary.Read()
-type frameHeader struct {
-	// size: an unsigned 32-bit integer that MUST contain the total frame size of the frame header,
-	// extended header, and frame body. The frame is malformed if the size is less than the size of
-	// the frame header (8 bytes).
-	Size uint32
-	// doff: gives the position of the body within the frame. The value of the data offset is an
-	// unsigned, 8-bit integer specifying a count of 4-byte words. Due to the mandatory 8-byte
-	// frame header, the frame is malformed if the value is less than 2.
-	DataOffset uint8
-	FrameType  uint8
-	Channel    uint16
-}
-
-// parseFrameHeader reads the header from r and returns the result.
-//
-// No validation is done.
-func parseFrameHeader(r *buffer.Buffer) (frameHeader, error) {
-	buf, ok := r.Next(8)
-	if !ok {
-		return frameHeader{}, errors.New("invalid frameHeader")
-	}
-	_ = buf[7]
-
-	fh := frameHeader{
-		Size:       binary.BigEndian.Uint32(buf[0:4]),
-		DataOffset: buf[4],
-		FrameType:  buf[5],
-		Channel:    binary.BigEndian.Uint16(buf[6:8]),
-	}
-
-	if fh.Size < frameHeaderSize {
-		return fh, fmt.Errorf("received frame header with invalid size %d", fh.Size)
-	}
-
-	return fh, nil
-}
-
 // parseProtoHeader reads the proto header from r and returns the results
 //
 // An error is returned if the protocol is not "AMQP" or if the version is not 1.0.0.
@@ -1074,68 +1022,6 @@ func parseProtoHeader(r *buffer.Buffer) (protoHeader, error) {
 		return p, fmt.Errorf("unexpected protocol version %d.%d.%d", p.Major, p.Minor, p.Revision)
 	}
 	return p, nil
-}
-
-// parseFrameBody reads and unmarshals an AMQP frame.
-func parseFrameBody(r *buffer.Buffer) (frames.FrameBody, error) {
-	payload := r.Bytes()
-
-	if r.Len() < 3 || payload[0] != 0 || encoding.AMQPType(payload[1]) != encoding.TypeCodeSmallUlong {
-		return nil, errors.New("invalid frame body header")
-	}
-
-	switch pType := encoding.AMQPType(payload[2]); pType {
-	case encoding.TypeCodeOpen:
-		t := new(frames.PerformOpen)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeBegin:
-		t := new(frames.PerformBegin)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeAttach:
-		t := new(frames.PerformAttach)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeFlow:
-		t := new(frames.PerformFlow)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeTransfer:
-		t := new(frames.PerformTransfer)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeDisposition:
-		t := new(frames.PerformDisposition)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeDetach:
-		t := new(frames.PerformDetach)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeEnd:
-		t := new(frames.PerformEnd)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeClose:
-		t := new(frames.PerformClose)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeSASLMechanism:
-		t := new(frames.SASLMechanisms)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeSASLChallenge:
-		t := new(frames.SASLChallenge)
-		err := t.Unmarshal(r)
-		return t, err
-	case encoding.TypeCodeSASLOutcome:
-		t := new(frames.SASLOutcome)
-		err := t.Unmarshal(r)
-		return t, err
-	default:
-		return nil, fmt.Errorf("unknown preformative type %02x", pType)
-	}
 }
 
 // writesFrame encodes fr into buf.

--- a/integration_test.go
+++ b/integration_test.go
@@ -309,7 +309,6 @@ func TestIntegrationReceiverModeSecond(t *testing.T) {
 	if localBrokerAddr == "" {
 		t.Skip()
 	}
-	t.Skip("test fails due to race condition")
 	tests := []struct {
 		label    string
 		sessions int

--- a/internal/frames/parsing.go
+++ b/internal/frames/parsing.go
@@ -1,0 +1,124 @@
+package frames
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/go-amqp/internal/buffer"
+	"github.com/Azure/go-amqp/internal/encoding"
+)
+
+const HeaderSize = 8
+
+// Frame structure:
+//
+//     header (8 bytes)
+//       0-3: SIZE (total size, at least 8 bytes for header, uint32)
+//       4:   DOFF (data offset,at least 2, count of 4 bytes words, uint8)
+//       5:   TYPE (frame type)
+//                0x0: AMQP
+//                0x1: SASL
+//       6-7: type dependent (channel for AMQP)
+//     extended header (opt)
+//     body (opt)
+
+// Header in a structure appropriate for use with binary.Read()
+type Header struct {
+	// size: an unsigned 32-bit integer that MUST contain the total frame size of the frame header,
+	// extended header, and frame body. The frame is malformed if the size is less than the size of
+	// the frame header (8 bytes).
+	Size uint32
+	// doff: gives the position of the body within the frame. The value of the data offset is an
+	// unsigned, 8-bit integer specifying a count of 4-byte words. Due to the mandatory 8-byte
+	// frame header, the frame is malformed if the value is less than 2.
+	DataOffset uint8
+	FrameType  uint8
+	Channel    uint16
+}
+
+// ParseHeader reads the header from r and returns the result.
+//
+// No validation is done.
+func ParseHeader(r *buffer.Buffer) (Header, error) {
+	buf, ok := r.Next(8)
+	if !ok {
+		return Header{}, errors.New("invalid frameHeader")
+	}
+	_ = buf[7]
+
+	fh := Header{
+		Size:       binary.BigEndian.Uint32(buf[0:4]),
+		DataOffset: buf[4],
+		FrameType:  buf[5],
+		Channel:    binary.BigEndian.Uint16(buf[6:8]),
+	}
+
+	if fh.Size < HeaderSize {
+		return fh, fmt.Errorf("received frame header with invalid size %d", fh.Size)
+	}
+
+	return fh, nil
+}
+
+// ParseBody reads and unmarshals an AMQP frame.
+func ParseBody(r *buffer.Buffer) (FrameBody, error) {
+	payload := r.Bytes()
+
+	if r.Len() < 3 || payload[0] != 0 || encoding.AMQPType(payload[1]) != encoding.TypeCodeSmallUlong {
+		return nil, errors.New("invalid frame body header")
+	}
+
+	switch pType := encoding.AMQPType(payload[2]); pType {
+	case encoding.TypeCodeOpen:
+		t := new(PerformOpen)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeBegin:
+		t := new(PerformBegin)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeAttach:
+		t := new(PerformAttach)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeFlow:
+		t := new(PerformFlow)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeTransfer:
+		t := new(PerformTransfer)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeDisposition:
+		t := new(PerformDisposition)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeDetach:
+		t := new(PerformDetach)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeEnd:
+		t := new(PerformEnd)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeClose:
+		t := new(PerformClose)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeSASLMechanism:
+		t := new(SASLMechanisms)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeSASLChallenge:
+		t := new(SASLChallenge)
+		err := t.Unmarshal(r)
+		return t, err
+	case encoding.TypeCodeSASLOutcome:
+		t := new(SASLOutcome)
+		err := t.Unmarshal(r)
+		return t, err
+	default:
+		return nil, fmt.Errorf("unknown performative type %02x", pType)
+	}
+}

--- a/internal/mocks/connection.go
+++ b/internal/mocks/connection.go
@@ -241,7 +241,6 @@ type frameType uint8
 
 const (
 	frameAMQP frameType = 0x0
-	frameSASL frameType = 0x1
 )
 
 func encodeFrame(t frameType, f frames.FrameBody) ([]byte, error) {

--- a/internal/mocks/connection.go
+++ b/internal/mocks/connection.go
@@ -1,0 +1,288 @@
+package mocks
+
+import (
+	"errors"
+	"math"
+	"net"
+	"time"
+
+	"github.com/Azure/go-amqp/internal/buffer"
+	"github.com/Azure/go-amqp/internal/encoding"
+	"github.com/Azure/go-amqp/internal/frames"
+)
+
+// NewConnection creates a new instance of MockConnection.
+// Responder is invoked by Write when a frame is received.
+// Return a nil slice/nil error to swallow the frame.
+// Return a non-nil error to simulate a write error.
+func NewConnection(resp func(frames.FrameBody) ([]byte, error)) *MockConnection {
+	return &MockConnection{
+		resp: resp,
+		// during shutdown, connReader can close before connWriter as they both
+		// both return on c.Done being closed, so there is some non-determinism
+		// here.  this means that sometimes writes can still happen but there's
+		// no reader to consume them.  we used a buffered channel to prevent these
+		// writes from blocking shutdown. the size was arbitrarily picked.
+		readData:  make(chan []byte, 10),
+		readClose: make(chan struct{}),
+	}
+}
+
+// MockConnection is a mock connection that satisfies the net.Conn interface.
+type MockConnection struct {
+	resp      func(frames.FrameBody) ([]byte, error)
+	readDL    *time.Timer
+	readData  chan []byte
+	readClose chan struct{}
+	closed    bool
+}
+
+///////////////////////////////////////////////////////
+// following methods are for the net.Conn interface
+///////////////////////////////////////////////////////
+
+// NOTE: Read, Write, and Close are all called by separate goroutines!
+
+// Read is invoked by conn.connReader to recieve frame data.
+// It blocks until Write or Close are called, or the read
+// deadline expires which will return an error.
+func (m *MockConnection) Read(b []byte) (n int, err error) {
+	select {
+	case <-m.readClose:
+		return 0, errors.New("mock connection was closed")
+	default:
+		// not closed yet
+	}
+
+	select {
+	case <-m.readClose:
+		return 0, errors.New("mock connection was closed")
+	case <-m.readDL.C:
+		return 0, errors.New("mock connection read deadline exceeded")
+	case rd := <-m.readData:
+		return copy(b, rd), nil
+	}
+}
+
+// Write is invoked by conn.connWriter when we're being sent frame
+// data.  Every call to Write will invoke the responder callback that
+// must reply with one of three possibilities.
+//  1. an encoded frame and nil error
+//  2. a non-nil error to similate a write failure
+//  3. a nil slice and nil error indicating the frame should be ignored
+func (m *MockConnection) Write(b []byte) (n int, err error) {
+	select {
+	case <-m.readClose:
+		return 0, errors.New("mock connection was closed")
+	default:
+		// not closed yet
+	}
+
+	frame, err := decodeFrame(b)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := m.resp(frame)
+	if err != nil {
+		return 0, err
+	}
+	if resp != nil {
+		m.readData <- resp
+	}
+	return len(b), nil
+}
+
+// Close is called by conn.close when conn.mux unwinds.
+func (m *MockConnection) Close() error {
+	if m.closed {
+		return errors.New("double close")
+	}
+	m.closed = true
+	close(m.readClose)
+	return nil
+}
+
+func (m *MockConnection) LocalAddr() net.Addr {
+	return &net.IPAddr{
+		IP: net.IPv4(127, 0, 0, 2),
+	}
+}
+
+func (m *MockConnection) RemoteAddr() net.Addr {
+	return &net.IPAddr{
+		IP: net.IPv4(127, 0, 0, 2),
+	}
+}
+
+func (m *MockConnection) SetDeadline(t time.Time) error {
+	return errors.New("not used")
+}
+
+func (m *MockConnection) SetReadDeadline(t time.Time) error {
+	// called by conn.connReader before calling Read
+	// stop the last timer if available
+	if m.readDL != nil && !m.readDL.Stop() {
+		<-m.readDL.C
+	}
+	m.readDL = time.NewTimer(time.Until(t))
+	return nil
+}
+
+func (m *MockConnection) SetWriteDeadline(t time.Time) error {
+	// called by conn.connWriter before calling Write
+	return nil
+}
+
+///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////
+
+// ProtoID indicates the type of protocol (copied from conn.go)
+type ProtoID uint8
+
+const (
+	ProtoAMQP ProtoID = 0x0
+	ProtoTLS  ProtoID = 0x2
+	ProtoSASL ProtoID = 0x3
+)
+
+// ProtoHeader adds the initial handshake frame to the list of responses.
+// This frame, and PerformOpen, are needed when calling amqp.New() to create a client.
+func ProtoHeader(id ProtoID) ([]byte, error) {
+	return []byte{'A', 'M', 'Q', 'P', byte(id), 1, 0, 0}, nil
+}
+
+// PerformOpen appends a PerformOpen frame with the specified container ID.
+// This frame, and ProtoHeader, are needed when calling amqp.New() to create a client.
+func PerformOpen(containerID string) ([]byte, error) {
+	return encodeFrame(frameAMQP, &frames.PerformOpen{ContainerID: "test"})
+}
+
+// PerformBegin appends a PerformBegin frame with the specified remote channel ID.
+// This frame is needed when making a call to Client.NewSession().
+func PerformBegin(remoteChannel uint16) ([]byte, error) {
+	return encodeFrame(frameAMQP, &frames.PerformBegin{
+		RemoteChannel:  &remoteChannel,
+		NextOutgoingID: 1,
+		IncomingWindow: 5000,
+		OutgoingWindow: 1000,
+		HandleMax:      math.MaxInt16,
+	})
+}
+
+// ReceiverAttach appends a PerformAttach frame with the specified values.
+// This frame is needed when making a call to Session.NewReceiver().
+func ReceiverAttach(linkName string, linkHandle uint32, mode encoding.ReceiverSettleMode) ([]byte, error) {
+	return encodeFrame(frameAMQP, &frames.PerformAttach{
+		Name:   linkName,
+		Handle: linkHandle,
+		Role:   encoding.RoleSender,
+		Source: &frames.Source{
+			Address:      "test",
+			Durable:      encoding.DurabilityNone,
+			ExpiryPolicy: encoding.ExpirySessionEnd,
+		},
+		ReceiverSettleMode: &mode,
+		MaxMessageSize:     math.MaxUint32,
+	})
+}
+
+// PerformTransfer appends a PerformTransfer frame with the specified values.
+// The linkHandle MUST match the linkHandle value specified in ReceiverAttach.
+func PerformTransfer(linkHandle, deliveryID uint32, payload []byte) ([]byte, error) {
+	format := uint32(0)
+	payloadBuf := &buffer.Buffer{}
+	encoding.WriteDescriptor(payloadBuf, encoding.TypeCodeApplicationData)
+	err := encoding.WriteBinary(payloadBuf, payload)
+	if err != nil {
+		return nil, err
+	}
+	return encodeFrame(frameAMQP, &frames.PerformTransfer{
+		Handle:        linkHandle,
+		DeliveryID:    &deliveryID,
+		DeliveryTag:   []byte("tag"),
+		MessageFormat: &format,
+		Payload:       payloadBuf.Detach(),
+	})
+}
+
+// PerformDisposition appends a PerformDisposition frame with the specified values.
+// The deliveryID MUST match the deliveryID value specified in PerformTransfer.
+func PerformDisposition(deliveryID uint32, state encoding.DeliveryState) ([]byte, error) {
+	return encodeFrame(frameAMQP, &frames.PerformDisposition{
+		Role:    encoding.RoleSender,
+		First:   deliveryID,
+		Settled: true,
+		State:   state,
+	})
+}
+
+// AMQPProto is the frame type passed to FrameCallback() for the initial protocal handshake.
+type AMQPProto struct {
+	frames.FrameBody
+}
+
+// KeepAlive is the frame type passed to FrameCallback() for keep-alive frames.
+type KeepAlive struct {
+	frames.FrameBody
+}
+
+type frameHeader frames.Header
+
+func (f frameHeader) Marshal(wr *buffer.Buffer) error {
+	wr.AppendUint32(f.Size)
+	wr.AppendByte(f.DataOffset)
+	wr.AppendByte(f.FrameType)
+	wr.AppendUint16(f.Channel)
+	return nil
+}
+
+// FrameType indicates the type of frame (copied from sasl.go)
+type frameType uint8
+
+const (
+	frameAMQP frameType = 0x0
+	frameSASL frameType = 0x1
+)
+
+func encodeFrame(t frameType, f frames.FrameBody) ([]byte, error) {
+	bodyBuf := buffer.New([]byte{})
+	if err := encoding.Marshal(bodyBuf, f); err != nil {
+		return nil, err
+	}
+	// create the frame header, needs size of the body plus itself
+	header := frameHeader{
+		Size:       uint32(bodyBuf.Len()) + 8,
+		DataOffset: 2,
+		FrameType:  uint8(t),
+	}
+	headerBuf := buffer.New([]byte{})
+	if err := encoding.Marshal(headerBuf, header); err != nil {
+		return nil, err
+	}
+	// concatenate header + body
+	raw := headerBuf.Detach()
+	raw = append(raw, bodyBuf.Detach()...)
+	return raw, nil
+}
+
+func decodeFrame(b []byte) (frames.FrameBody, error) {
+	if len(b) > 3 && b[0] == 'A' && b[1] == 'M' && b[2] == 'Q' && b[3] == 'P' {
+		return &AMQPProto{}, nil
+	}
+	buf := buffer.New(b)
+	header, err := frames.ParseHeader(buf)
+	if err != nil {
+		return nil, err
+	}
+	bodySize := int64(header.Size - frames.HeaderSize)
+	if bodySize == 0 {
+		// keep alive frame
+		return &KeepAlive{}, nil
+	}
+	// parse the frame
+	b, ok := buf.Next(bodySize)
+	if !ok {
+		return nil, err
+	}
+	return frames.ParseBody(buffer.New(b))
+}

--- a/link.go
+++ b/link.go
@@ -227,7 +227,11 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 		l.Messages = make(chan Message, l.receiver.maxCredit)
 		l.unsettledMessages = map[string]struct{}{}
 		// copy the received filter values
-		l.Source.Filter = resp.Source.Filter
+		if l.Source == nil {
+			l.Source = resp.Source
+		} else {
+			l.Source.Filter = resp.Source.Filter
+		}
 	} else {
 		// if dynamic address requested, copy assigned name to address
 		if l.dynamicAddr && resp.Target != nil {

--- a/link.go
+++ b/link.go
@@ -34,12 +34,12 @@ type link struct {
 	// This will be initiated if the service sends back an error or requests the link detach.
 	Detached chan struct{}
 
-	detachErrorMu sync.Mutex // protects detachError
-	detachError   *Error     // error to send to remote on detach, set by closeWithError
-	Session       *Session   // parent session
-	receiver      *Receiver  // allows link options to modify Receiver
-	Source        *frames.Source
-	Target        *frames.Target
+	detachErrorMu sync.Mutex                      // protects detachError
+	detachError   *Error                          // error to send to remote on detach, set by closeWithError
+	Session       *Session                        // parent session
+	receiver      *Receiver                       // allows link options to modify Receiver
+	Source        *frames.Source                  // used for Receiver links
+	Target        *frames.Target                  // used for Sender links
 	properties    map[encoding.Symbol]interface{} // additional properties sent upon link attach
 	// Indicates whether we should allow detaches on disposition errors or not.
 	// Some AMQP servers (like Event Hubs) benefit from keeping the link open on disposition errors
@@ -217,6 +217,9 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 	}
 
 	if isReceiver {
+		if l.Source == nil {
+			l.Source = new(frames.Source)
+		}
 		// if dynamic address requested, copy assigned name to address
 		if l.dynamicAddr && resp.Source != nil {
 			l.Source.Address = resp.Source.Address
@@ -227,12 +230,11 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 		l.Messages = make(chan Message, l.receiver.maxCredit)
 		l.unsettledMessages = map[string]struct{}{}
 		// copy the received filter values
-		if l.Source == nil {
-			l.Source = resp.Source
-		} else {
-			l.Source.Filter = resp.Source.Filter
-		}
+		l.Source.Filter = resp.Source.Filter
 	} else {
+		if l.Target == nil {
+			l.Target = new(frames.Target)
+		}
 		// if dynamic address requested, copy assigned name to address
 		if l.dynamicAddr && resp.Target != nil {
 			l.Target.Address = resp.Target.Address

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -54,7 +54,7 @@ func TestFrameMarshalUnmarshal(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
-			header, err := parseFrameHeader(&buf)
+			header, err := frames.ParseHeader(&buf)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -67,7 +67,7 @@ func TestFrameMarshalUnmarshal(t *testing.T) {
 				t.Errorf("Expected channel to be %d, but it is %d", want.Type, header.FrameType)
 			}
 
-			payload, err := parseFrameBody(&buf)
+			payload, err := frames.ParseBody(&buf)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -112,12 +112,12 @@ func BenchmarkFrameUnmarshal(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				buf := buffer.New(data)
-				_, err := parseFrameHeader(buf)
+				_, err := frames.ParseHeader(buf)
 				if err != nil {
 					b.Errorf("%+v", err)
 				}
 
-				_, err = parseFrameBody(buf)
+				_, err = frames.ParseBody(buf)
 				if err != nil {
 					b.Errorf("%+v", err)
 				}

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -2,112 +2,161 @@ package amqp
 
 import (
 	"context"
+	"fmt"
+	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Azure/go-amqp/internal/encoding"
+	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/mocks"
+	"github.com/stretchr/testify/assert"
 )
 
-func makeLink(mode ReceiverSettleMode) *link {
-	return &link{
-		close:              make(chan struct{}),
-		Detached:           make(chan struct{}),
-		ReceiverReady:      make(chan struct{}, 1),
-		Messages:           make(chan Message, 1),
-		ReceiverSettleMode: &mode,
-		unsettledMessages:  map[string]struct{}{},
+// helper to wait for a link to pause/resume
+// returns an error if it times out waiting
+func waitForLink(l *link, paused bool) error {
+	state := uint32(0) // unpaused
+	if paused {
+		state = 1
 	}
-}
-
-func makeMessage(mode ReceiverSettleMode) Message {
-	var tag []byte
-	if mode == ModeSecond {
-		tag = []byte("one")
-	}
-	return Message{
-		deliveryID:  uint32(1),
-		DeliveryTag: tag,
-	}
-}
-
-func TestReceiver_HandleMessageModeFirst_AutoAccept(t *testing.T) {
-	r := &Receiver{
-		link:         makeLink(ModeFirst),
-		batching:     true, // allows to  avoid making the outgoing call on dispostion
-		dispositions: make(chan messageDisposition, 2),
-	}
-	msg := makeMessage(ModeFirst)
-	r.link.Messages <- msg
-	if r.link.countUnsettled() != 0 {
-		// mode first messages have no delivery tag, thus there should be no unsettled message
-		t.Fatal("expected zero unsettled count")
-	}
-	if _, err := r.Receive(context.TODO()); err != nil {
-		t.Errorf("Receive() error = %v", err)
-	}
-
-	if len(r.dispositions) != 1 {
-		t.Errorf("the message should have triggered a disposition")
-	}
-}
-
-func TestReceiver_HandleMessageModeSecond_DontDispose(t *testing.T) {
-	r := &Receiver{
-		link:         makeLink(ModeSecond),
-		batching:     true, // allows to  avoid making the outgoing call on dispostion
-		dispositions: make(chan messageDisposition, 2),
-	}
-	msg := makeMessage(ModeSecond)
-	r.link.Messages <- msg
-	r.link.addUnsettled(&msg)
-	if _, err := r.Receive(context.TODO()); err != nil {
-		t.Errorf("Receive() error = %v", err)
-	}
-	if len(r.dispositions) != 0 {
-		t.Errorf("it is up to the message handler to settle messages")
-	}
-	if r.link.countUnsettled() == 0 {
-		t.Errorf("the message should still be tracked until settled")
-	}
-}
-
-func TestReceiver_HandleMessageModeSecond_removeFromUnsettledMapOnDisposition(t *testing.T) {
-	r := &Receiver{
-		link:         makeLink(ModeSecond),
-		batching:     true, // allows to  avoid making the outgoing call on dispostion
-		dispositions: make(chan messageDisposition, 1),
-	}
-	msg := makeMessage(ModeSecond)
-	r.link.Messages <- msg
-	r.link.addUnsettled(&msg)
-	// unblock the accept waiting on inflight disposition for modeSecond
-	loop := true
-	// call handle with the accept handler in a goroutine because it will block on inflight disposition.
-	go func() {
-		msg, err := r.Receive(context.TODO())
-		if err != nil {
-			t.Errorf("Receive() error = %v", err)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	for {
+		if atomic.LoadUint32(&l.Paused) == state {
+			return nil
+		} else if err := ctx.Err(); err != nil {
+			return err
 		}
-		if err = r.AcceptMessage(context.TODO(), msg); err != nil {
-			t.Errorf("AcceptMessage() error = %v", err)
-		}
-	}()
+		runtime.Gosched()
+	}
+}
 
-	// simulate batch disposition.
-	// when the inflight has an entry, we know the Accept has been called
-	for loop {
-		r.inFlight.mu.Lock()
-		inflightCount := len(r.inFlight.m)
-		r.inFlight.mu.Unlock()
-		if inflightCount > 0 {
-			r.inFlight.remove(msg.deliveryID, nil, nil)
-			loop = false
+func TestReceive_ModeFirst(t *testing.T) {
+	const linkName = "test"
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(linkName, linkHandle, ModeFirst)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			return mocks.PerformDisposition(deliveryID, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
-		time.Sleep(1 * time.Millisecond)
 	}
+	conn := mocks.NewConnection(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkName(linkName), LinkReceiverSettle(ModeFirst))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	// subsequent dispositions should have no effect
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	assert.NoError(t, client.Close())
+}
 
-	if len(r.dispositions) == 0 {
-		t.Errorf("the message should have triggered a disposition")
+func TestReceive_ModeSecond(t *testing.T) {
+	const linkName = "test"
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(linkName, linkHandle, ModeSecond)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			return mocks.PerformDisposition(deliveryID, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
 	}
-	if r.link.countUnsettled() != 0 {
-		t.Errorf("the message should be removed from unsettled map")
+	conn := mocks.NewConnection(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkName(linkName), LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
 	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// perform a dummy receive with short timeout to trigger flow
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, _ = r.Receive(ctx)
+	cancel()
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be back to 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	// subsequent dispositions should have no effect
+	// TODO: https://github.com/Azure/go-amqp/issues/76
+	/*ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)*/
+	assert.NoError(t, client.Close())
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -60,7 +60,7 @@ func TestReceive_ModeFirst(t *testing.T) {
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := mocks.NewConnection(responder)
+	conn := mocks.NewNetConn(responder)
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -115,7 +115,7 @@ func TestReceive_ModeSecond(t *testing.T) {
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := mocks.NewConnection(responder)
+	conn := mocks.NewNetConn(responder)
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()


### PR DESCRIPTION
This includes a mock net.Conn and various helper funcs for creating mock
response frames.
Moved frame parsing out of conn.go and into frames package so that the
mock infrastructure can use it.
Fixed a bug in link uncovered by new unit tests.
Rewrote receiver tests using the new framework.