### PR TITLE
Fix context deadline exceeded not wrapped correctly

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -60,7 +60,7 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	case <-s.link.Detached:
 		return s.link.err
 	case <-ctx.Done():
-		return fmt.Errorf("awaiting send: %w", ctx.Err())
+		return ctx.Err()
 	}
 }
 
@@ -130,7 +130,7 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 		case <-s.link.Detached:
 			return nil, s.link.err
 		case <-ctx.Done():
-			return nil, fmt.Errorf("awaiting send: %w", ctx.Err())
+			return nil, ctx.Err()
 		}
 
 		// clear values that are only required on first message


### PR DESCRIPTION
Hello,

First of all thanks for maintaining this fork.

I'm not sure if it's an intended behavior, but go-amqp does not wrap the underlying context error on awaiting send error.

It would be easier to not depends of plaintext matching to filter any canceled/deadline exceeded error :)