### PR TITLE
Fix hangs exposed by manual credit management

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -211,6 +211,9 @@ func newTestLink(t *testing.T) *link {
 		},
 		RX:            make(chan frames.FrameBody, 100),
 		ReceiverReady: make(chan struct{}, 1),
+		Messages:      make(chan Message, 1),
+		Detached:      make(chan struct{}),
+		close:         make(chan struct{}),
 	}
 
 	return l


### PR DESCRIPTION
Manual credit management is power-user mode and, if not used properly,
can cause callers to get into a bad state.
Exit link.muxReceive if the link has been closed or detached.
Unblock pending drain during link.muxDetach.
Exit manualCreditor.Drain if the link has been closed or detached.
Don't issue additional credit if the link's message channel is full;
this indicates that too many messages have been left unsettled.