### PR TITLE
Make it possible to only read cached messages only

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -38,13 +38,13 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 	return r.link.DrainCredit(ctx)
 }
 
-// GetCached returns the next message that is stored in the Receiver's
+// Prefetched returns the next message that is stored in the Receiver's
 // prefetch cache. It does NOT wait for the remote sender to send messages
 // and returns immediately if the prefetch cache is empty.
 //
 // NOTE: Most callers will want to use `Receive`, which checks both the prefetch
 // cache and also waits for messages to arrive from the remote Sender.
-func (r *Receiver) GetCached(ctx context.Context) (*Message, error) {
+func (r *Receiver) Prefetched(ctx context.Context) (*Message, error) {
 	if atomic.LoadUint32(&r.link.Paused) == 1 {
 		select {
 		case r.link.ReceiverReady <- struct{}{}:
@@ -74,7 +74,7 @@ func (r *Receiver) GetCached(ctx context.Context) (*Message, error) {
 // one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
 // When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
-	msg, err := r.GetCached(ctx)
+	msg, err := r.Prefetched(ctx)
 
 	if err != nil || msg != nil {
 		return msg, err

--- a/receiver.go
+++ b/receiver.go
@@ -38,13 +38,13 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 	return r.link.DrainCredit(ctx)
 }
 
-// ReceiveCached returns the next message that is stored in the Receiver's
-// internal message channel. It does NOT wait for the remote sender to send messages
-// and returns immediately if the internal cache is empty.
+// GetCached returns the next message that is stored in the Receiver's
+// prefetch cache. It does NOT wait for the remote sender to send messages
+// and returns immediately if the prefetch cache is empty.
 //
-// NOTE: Most callers will use `Receive`, which checks both the internal channel and also
-// waits for messages to arrive from the remote Sender.
-func (r *Receiver) ReceiveCached(ctx context.Context) (*Message, error) {
+// NOTE: Most callers will want to use `Receive`, which checks both the prefetch
+// cache and also waits for messages to arrive from the remote Sender.
+func (r *Receiver) GetCached(ctx context.Context) (*Message, error) {
 	if atomic.LoadUint32(&r.link.Paused) == 1 {
 		select {
 		case r.link.ReceiverReady <- struct{}{}:
@@ -74,7 +74,7 @@ func (r *Receiver) ReceiveCached(ctx context.Context) (*Message, error) {
 // one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
 // When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
-	msg, err := r.ReceiveCached(ctx)
+	msg, err := r.GetCached(ctx)
 
 	if err != nil || msg != nil {
 		return msg, err

--- a/receiver.go
+++ b/receiver.go
@@ -40,10 +40,12 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 
 // Prefetched returns the next message that is stored in the Receiver's
 // prefetch cache. It does NOT wait for the remote sender to send messages
-// and returns immediately if the prefetch cache is empty.
+// and returns immediately if the prefetch cache is empty. To receive from the
+// prefetch and wait for messages from the remote Sender use `Receive`.
 //
-// NOTE: Most callers will want to use `Receive`, which checks both the prefetch
-// cache and also waits for messages to arrive from the remote Sender.
+// When using ModeSecond, you *must* take an action on the message by calling
+// one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
+// When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Prefetched(ctx context.Context) (*Message, error) {
 	if atomic.LoadUint32(&r.link.Paused) == 1 {
 		select {

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-amqp/internal/frames"
 	"github.com/Azure/go-amqp/internal/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // helper to wait for a link to pause/resume
@@ -159,4 +160,34 @@ func TestReceive_ModeSecond(t *testing.T) {
 	cancel()
 	assert.NoError(t, err)*/
 	assert.NoError(t, client.Close())
+}
+
+func Test_ReceiveNonBlocking(t *testing.T) {
+	messagesCh := make(chan Message, 1)
+
+	receiver := &Receiver{
+		link: &link{
+			Messages:      messagesCh,
+			ReceiverReady: make(chan struct{}),
+		},
+	}
+
+	// if there are no cached messages we just return immediately - no error, no message.
+	msg, err := receiver.ReceiveCached(context.Background())
+	require.Nil(t, msg)
+	require.Nil(t, err)
+
+	messagesCh <- Message{
+		ApplicationProperties: map[string]interface{}{
+			"prop": "hello",
+		},
+		settled: true,
+	}
+
+	require.NotEmpty(t, messagesCh)
+	msg, err = receiver.ReceiveCached(context.Background())
+
+	require.EqualValues(t, "hello", msg.ApplicationProperties["prop"].(string))
+	require.Nil(t, err)
+	require.Empty(t, messagesCh)
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -173,7 +173,7 @@ func Test_ReceiveNonBlocking(t *testing.T) {
 	}
 
 	// if there are no cached messages we just return immediately - no error, no message.
-	msg, err := receiver.ReceiveCached(context.Background())
+	msg, err := receiver.GetCached(context.Background())
 	require.Nil(t, msg)
 	require.Nil(t, err)
 
@@ -185,7 +185,7 @@ func Test_ReceiveNonBlocking(t *testing.T) {
 	}
 
 	require.NotEmpty(t, messagesCh)
-	msg, err = receiver.ReceiveCached(context.Background())
+	msg, err = receiver.GetCached(context.Background())
 
 	require.EqualValues(t, "hello", msg.ApplicationProperties["prop"].(string))
 	require.Nil(t, err)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -173,7 +173,7 @@ func Test_ReceiveNonBlocking(t *testing.T) {
 	}
 
 	// if there are no cached messages we just return immediately - no error, no message.
-	msg, err := receiver.GetCached(context.Background())
+	msg, err := receiver.Prefetched(context.Background())
 	require.Nil(t, msg)
 	require.Nil(t, err)
 
@@ -185,7 +185,7 @@ func Test_ReceiveNonBlocking(t *testing.T) {
 	}
 
 	require.NotEmpty(t, messagesCh)
-	msg, err = receiver.GetCached(context.Background())
+	msg, err = receiver.Prefetched(context.Background())
 
 	require.EqualValues(t, "hello", msg.ApplicationProperties["prop"].(string))
 	require.Nil(t, err)


### PR DESCRIPTION
This is useful for scenarios outlined in #71, where we have stopped adding in new credit (after a drain) and just want to make sure we're only reading in messages that have been cached internally and not waiting for additional messages that will never come, since we've drained all credit.

Fixes #71