### PR TITLE
Fixing a data race where the mux could unwind while we're simultaneously reading the last error

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -88,8 +88,6 @@ func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
 		debug(3, "Receive() blocking %d", msg.deliveryID)
 		msg.link = r.link
 		return acceptIfModeFirst(ctx, r, &msg)
-	case <-r.link.close:
-		return nil, r.link.err
 	case <-r.link.Detached:
 		return nil, r.link.err
 	case <-ctx.Done():


### PR DESCRIPTION
This PR changes our logic to not early-exit `Receive()` if l.close is closed. This fixes a data race we're seeing in Service Bus.

There are two channels that track the state of a link:

- `l.Detached`, which gets closed after muxDetach() ultimately completes. This basically functions as a "mux is ended" signal.
- `l.close`, which gets closed immediately when you call link.Close()

Receive is intended to wait for the mux to exit. If it doesn't then it can't return any contextual error that might have been set by mux() or it's multiple friends (muxFlow, muxDetach).