### PR TITLE
Add unit tests for Sender

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,16 +13,6 @@ import (
 	"github.com/Azure/go-amqp/internal/frames"
 )
 
-var (
-	// ErrSessionClosed is propagated to Sender/Receivers
-	// when Session.Close() is called.
-	ErrSessionClosed = errors.New("amqp: session closed")
-
-	// ErrLinkClosed is returned by send and receive operations when
-	// Sender.Close() or Receiver.Close() are called.
-	ErrLinkClosed = errors.New("amqp: link closed")
-)
-
 // Client is an AMQP client connection.
 type Client struct {
 	conn *conn

--- a/client.go
+++ b/client.go
@@ -21,10 +21,6 @@ var (
 	// ErrLinkClosed is returned by send and receive operations when
 	// Sender.Close() or Receiver.Close() are called.
 	ErrLinkClosed = errors.New("amqp: link closed")
-
-	// ErrLinkDetached is returned by operations when the
-	// link is in a detached state.
-	ErrLinkDetached = errors.New("amqp: link detached")
 )
 
 // Client is an AMQP client connection.

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
 	"github.com/Azure/go-amqp/internal/mocks"
 	"github.com/stretchr/testify/require"
@@ -385,7 +386,7 @@ func TestClientNewSessionInvalidSecondResponseDifferentChannel(t *testing.T) {
 			}
 			// respond with the wrong frame type
 			// note that it has to be for the next channel
-			return mocks.PerformDisposition(1, 0, nil)
+			return mocks.PerformDisposition(encoding.RoleSender, 1, 0, nil)
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
 		default:

--- a/conn.go
+++ b/conn.go
@@ -26,16 +26,6 @@ const (
 	DefaultMaxSessions  = 65536
 )
 
-// Errors
-var (
-	ErrTimeout = errors.New("amqp: timeout waiting for response")
-
-	// ErrConnClosed is propagated to Session and Senders/Receivers
-	// when Client.Close() is called or the server closes the connection
-	// without specifying an error.
-	ErrConnClosed = errors.New("amqp: connection closed")
-)
-
 // ConnOption is a function for configuring an AMQP connection.
 type ConnOption func(*conn) error
 

--- a/conn.go
+++ b/conn.go
@@ -509,6 +509,8 @@ func (c *conn) mux() {
 				continue
 			}
 
+			// TODO: this can deadlock with session mux unwind
+			// https://github.com/Azure/go-amqp/issues/87
 			select {
 			case session.rx <- fr:
 			case <-c.closeMux:

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package amqp
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -57,6 +58,24 @@ type DetachError struct {
 func (e *DetachError) Error() string {
 	return fmt.Sprintf("link detached, reason: %+v", e.RemoteError)
 }
+
+// Errors
+var (
+	ErrTimeout = errors.New("amqp: timeout waiting for response")
+
+	// ErrConnClosed is propagated to Session and Senders/Receivers
+	// when Client.Close() is called or the server closes the connection
+	// without specifying an error.
+	ErrConnClosed = errors.New("amqp: connection closed")
+
+	// ErrSessionClosed is propagated to Sender/Receivers
+	// when Session.Close() is called.
+	ErrSessionClosed = errors.New("amqp: session closed")
+
+	// ErrLinkClosed is returned by send and receive operations when
+	// Sender.Close() or Receiver.Close() are called.
+	ErrLinkClosed = errors.New("amqp: link closed")
+)
 
 // Default link options
 const (

--- a/internal/mocks/net_conn.go
+++ b/internal/mocks/net_conn.go
@@ -257,13 +257,18 @@ func PerformTransfer(remoteChannel uint16, linkHandle, deliveryID uint32, payloa
 
 // PerformDisposition appends a PerformDisposition frame with the specified values.
 // The deliveryID MUST match the deliveryID value specified in PerformTransfer.
-func PerformDisposition(remoteChannel uint16, deliveryID uint32, state encoding.DeliveryState) ([]byte, error) {
+func PerformDisposition(role encoding.Role, remoteChannel uint16, deliveryID uint32, state encoding.DeliveryState) ([]byte, error) {
 	return EncodeFrame(FrameAMQP, remoteChannel, &frames.PerformDisposition{
-		Role:    encoding.RoleSender,
+		Role:    role,
 		First:   deliveryID,
 		Settled: true,
 		State:   state,
 	})
+}
+
+// PerformDetach encodes a PerformDetach frame with an optional error.
+func PerformDetach(remoteChannel uint16, linkHandle uint32, e *encoding.Error) ([]byte, error) {
+	return EncodeFrame(FrameAMQP, remoteChannel, &frames.PerformDetach{Handle: linkHandle, Closed: true, Error: e})
 }
 
 // PerformEnd encodes a PerformEnd frame with an optional error.

--- a/link.go
+++ b/link.go
@@ -25,11 +25,10 @@ type link struct {
 	Transfers    chan frames.PerformTransfer // sender uses to send transfer frames
 	closeOnce    sync.Once                   // closeOnce protects close from being closed multiple times
 
-	// NOTE: `close` and `detached` BOTH need to be checked to determine if the link
-	// is not in a "closed" state
-
 	// close signals the mux to shutdown. This indicates that `Close()` was called on this link.
+	// NOTE: observers outside of link.go *must* use the Detached channel to check if the link is unavailable.
 	close chan struct{}
+
 	// detached is closed by mux/muxDetach when the link is fully detached.
 	// This will be initiated if the service sends back an error or requests the link detach.
 	Detached chan struct{}
@@ -710,7 +709,7 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		// set detach received and close link
 		l.detachReceived = true
 
-		return fmt.Errorf("received detach frame %v", &DetachError{fr.Error})
+		return &DetachError{fr.Error}
 
 	case *frames.PerformDisposition:
 		debug(3, "RX (muxHandleFrame): %s", fr)
@@ -758,19 +757,6 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 	return nil
 }
 
-// Check checks the link state, returning an error if the link is closed (ErrLinkClosed) or if
-// it is in a detached state (ErrLinkDetached)
-func (l *link) Check() error {
-	select {
-	case <-l.Detached:
-		return ErrLinkDetached
-	case <-l.close:
-		return ErrLinkClosed
-	default:
-		return nil
-	}
-}
-
 // close closes and requests deletion of the link.
 //
 // No operations on link are valid after close.
@@ -782,6 +768,7 @@ func (l *link) Close(ctx context.Context) error {
 	l.closeOnce.Do(func() { close(l.close) })
 	select {
 	case <-l.Detached:
+		// mux exited
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -813,13 +800,13 @@ func (l *link) muxDetach() {
 			}
 		}
 
-		// signal other goroutines that link is detached
-		close(l.Detached)
-
 		// unblock any in flight message dispositions
 		if l.receiver != nil {
 			l.receiver.inFlight.clear(l.err)
 		}
+
+		// signal that the link mux has exited
+		close(l.Detached)
 	}()
 
 	// "A peer closes a link by sending the detach frame with the

--- a/link.go
+++ b/link.go
@@ -26,7 +26,8 @@ type link struct {
 	closeOnce    sync.Once                   // closeOnce protects close from being closed multiple times
 
 	// close signals the mux to shutdown. This indicates that `Close()` was called on this link.
-	// NOTE: observers outside of link.go *must* use the Detached channel to check if the link is unavailable.
+	// NOTE: observers outside of link.go *must only* use the Detached channel to check if the link is unavailable.
+	// including the close channel will lead to a race condition.
 	close chan struct{}
 
 	// detached is closed by mux/muxDetach when the link is fully detached.

--- a/link_options.go
+++ b/link_options.go
@@ -14,21 +14,6 @@ import (
 // A link may be a Sender or a Receiver.
 type LinkOption func(*link) error
 
-// LinkAddress sets the link address.
-//
-// For a Receiver this configures the source address.
-// For a Sender this configures the target address.
-//
-// Deprecated: use LinkSourceAddress or LinkTargetAddress instead.
-func LinkAddress(source string) LinkOption {
-	return func(l *link) error {
-		if l.receiver != nil {
-			return LinkSourceAddress(source)(l)
-		}
-		return LinkTargetAddress(source)(l)
-	}
-}
-
 // LinkProperty sets an entry in the link properties map sent to the server.
 //
 // This option can be used multiple times.

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -56,7 +56,7 @@ func TestReceive_ModeFirst(t *testing.T) {
 			// ignore future flow frames as we have no response
 			return nil, nil
 		case *frames.PerformDisposition:
-			return mocks.PerformDisposition(0, deliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, &encoding.StateAccepted{})
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -111,7 +111,7 @@ func TestReceive_ModeSecond(t *testing.T) {
 			// ignore future flow frames as we have no response
 			return nil, nil
 		case *frames.PerformDisposition:
-			return mocks.PerformDisposition(0, deliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, &encoding.StateAccepted{})
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}

--- a/sender.go
+++ b/sender.go
@@ -41,6 +41,14 @@ func (s *Sender) MaxMessageSize() uint64 {
 // additional messages can be sent while the current goroutine is waiting
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
+	// check if the link is dead.  while it's safe to call s.send
+	// in this case, this will avoid some allocations etc.
+	select {
+	case <-s.link.Detached:
+		return s.link.err
+	default:
+		// link is still active
+	}
 	done, err := s.send(ctx, msg)
 	if err != nil {
 		return err

--- a/sender.go
+++ b/sender.go
@@ -41,10 +41,6 @@ func (s *Sender) MaxMessageSize() uint64 {
 // additional messages can be sent while the current goroutine is waiting
 // for the confirmation.
 func (s *Sender) Send(ctx context.Context, msg *Message) error {
-	if err := s.link.Check(); err != nil {
-		return err
-	}
-
 	done, err := s.send(ctx, msg)
 	if err != nil {
 		return err

--- a/sender_test.go
+++ b/sender_test.go
@@ -46,7 +46,7 @@ func TestSenderMethodsNoSend(t *testing.T) {
 		linkName   = "test1"
 		maxMsgSize = uint64(4096)
 	)
-	snd, err := session.NewSender(LinkAddress(linkAddr), LinkName(linkName), LinkMaxMessageSize(maxMsgSize))
+	snd, err := session.NewSender(LinkTargetAddress(linkAddr), LinkName(linkName), LinkMaxMessageSize(maxMsgSize))
 	require.NoError(t, err)
 	require.NotNil(t, snd)
 	time.Sleep(100 * time.Millisecond)

--- a/sender_test.go
+++ b/sender_test.go
@@ -317,6 +317,7 @@ func TestSenderSendMismatchedModes(t *testing.T) {
 	require.NoError(t, err)
 	snd, err := session.NewSender(LinkSenderSettle(encoding.ModeSettled))
 	require.Error(t, err)
+	require.Equal(t, "amqp: sender settlement mode \"settled\" requested, received \"unsettled\" from server", err.Error())
 	require.Nil(t, snd)
 	require.NoError(t, client.Close())
 }

--- a/sender_test.go
+++ b/sender_test.go
@@ -2,32 +2,671 @@ package amqp
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/Azure/go-amqp/internal/encoding"
+	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/mocks"
 	"github.com/stretchr/testify/require"
 )
 
-func TestClosedSenderReturnsErrClosed(t *testing.T) {
-	// this feels a bit _too_ fake, should revisit.
-	link, err := newLink(newSession(nil, 0), &Receiver{}, nil)
+func TestSenderMethodsNoSend(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
 	require.NoError(t, err)
 
-	sender := &Sender{link: link}
-
-	// simulate the detach happening before the send. This happens in cases
-	// where we get an error back from the AMQP service (for instance, throttling)
-	// which calls link.muxDetach() (artifical detach)
-	close(link.Detached)
+	session, err := client.NewSession()
 	require.NoError(t, err)
-
-	err = sender.Send(context.TODO(), &Message{})
-	require.EqualError(t, ErrLinkDetached, err.Error())
+	time.Sleep(100 * time.Millisecond)
+	const (
+		linkAddr   = "addr1"
+		linkName   = "test1"
+		maxMsgSize = uint64(4096)
+	)
+	snd, err := session.NewSender(LinkAddress(linkAddr), LinkName(linkName), LinkMaxMessageSize(maxMsgSize))
+	require.NoError(t, err)
+	require.NotNil(t, snd)
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, linkAddr, snd.Address())
+	require.Equal(t, linkName, snd.LinkName())
+	require.Equal(t, maxMsgSize, snd.MaxMessageSize())
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	require.NoError(t, snd.Close(ctx))
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
 }
 
-func TestSenderId(t *testing.T) {
-	link, err := newLink(newSession(nil, 0), &Receiver{}, nil)
+func TestSenderSendOnClosed(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
 	require.NoError(t, err)
 
-	sender := &Sender{link: link}
-	require.NotEmpty(t, sender.LinkName())
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+	require.NotNil(t, snd)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	require.NoError(t, snd.Close(ctx))
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+	// sending on a closed sender returns ErrLinkClosed
+	if err = snd.Send(context.Background(), NewMessage([]byte("failed"))); !errors.Is(err, ErrLinkClosed) {
+		t.Fatalf("unexpected error %T", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendOnDetached(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+	require.NotNil(t, snd)
+	time.Sleep(100 * time.Millisecond)
+	// initiate a server-side detach
+	const (
+		errcon  = "detaching"
+		errdesc = "server side detach"
+	)
+	b, err := mocks.PerformDetach(0, 0, &Error{Condition: errcon, Description: errdesc})
+	require.NoError(t, err)
+	netConn.SendFrame(b)
+	time.Sleep(100 * time.Millisecond)
+	// sending on a detached link returns a DetachError
+	err = snd.Send(context.Background(), NewMessage([]byte("failed")))
+	var de *DetachError
+	if !errors.As(err, &de) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, encoding.ErrorCondition(errcon), de.RemoteError.Condition)
+	require.Equal(t, errdesc, de.RemoteError.Description)
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderAttachError(t *testing.T) {
+	var detachAck bool
+	var enqueueFrames func(string)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			enqueueFrames(tt.Name)
+			return nil, nil
+		case *frames.PerformDetach:
+			// we don't need to respond to the ack
+			detachAck = true
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+
+	const (
+		errcon  = "cantattach"
+		errdesc = "server side error"
+	)
+
+	enqueueFrames = func(n string) {
+		// send an invalid attach response
+		b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformAttach{
+			Name: n,
+			Role: encoding.RoleReceiver,
+		})
+		require.NoError(t, err)
+		netConn.SendFrame(b)
+		// now follow up with a detach frame
+		b, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformDetach{
+			Error: &encoding.Error{
+				Condition:   errcon,
+				Description: errdesc,
+			},
+		})
+		require.NoError(t, err)
+		netConn.SendFrame(b)
+	}
+	snd, err := session.NewSender()
+	time.Sleep(100 * time.Millisecond)
+	var de *Error
+	if !errors.As(err, &de) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, encoding.ErrorCondition(errcon), de.Condition)
+	require.Equal(t, errdesc, de.Description)
+	require.Nil(t, snd)
+	require.Equal(t, true, detachAck)
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendMismatchedModes(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender(LinkSenderSettle(encoding.ModeSettled))
+	require.Error(t, err)
+	require.Nil(t, snd)
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendSuccess(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformTransfer:
+			if tt.More {
+				return nil, errors.New("didn't expect more to be true")
+			}
+			if tt.Settled {
+				return nil, errors.New("didn't expect message to be settled")
+			}
+			if !reflect.DeepEqual([]byte{0, 83, 117, 160, 4, 116, 101, 115, 116}, tt.Payload) {
+				return nil, fmt.Errorf("unexpected payload %v", tt.Payload)
+			}
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	require.NoError(t, snd.Send(ctx, NewMessage([]byte("test"))))
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendSettled(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeSettled)
+		case *frames.PerformTransfer:
+			if tt.More {
+				return nil, errors.New("didn't expect more to be true")
+			}
+			if !tt.Settled {
+				return nil, errors.New("didn't expect message to be settled")
+			}
+			if !reflect.DeepEqual([]byte{0, 83, 117, 160, 4, 116, 101, 115, 116}, tt.Payload) {
+				return nil, fmt.Errorf("unexpected payload %v", tt.Payload)
+			}
+			return nil, nil
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender(LinkSenderSettle(ModeSettled))
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	require.NoError(t, snd.Send(ctx, NewMessage([]byte("test"))))
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendRejected(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformTransfer:
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateRejected{
+				Error: &Error{
+					Condition:   "rejected",
+					Description: "didn't like it",
+				},
+			})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = snd.Send(ctx, NewMessage([]byte("test")))
+	cancel()
+	var asErr *Error
+	if !errors.As(err, &asErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, encoding.ErrorCondition("rejected"), asErr.Condition)
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendDetached(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformTransfer:
+			return mocks.PerformDetach(0, 0, &Error{
+				Condition:   "detached",
+				Description: "server exploded",
+			})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = snd.Send(ctx, NewMessage([]byte("test")))
+	cancel()
+	var asErr *DetachError
+	if !errors.As(err, &asErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, encoding.ErrorCondition("detached"), asErr.RemoteError.Condition)
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendTimeout(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	// no credits have been issued so the send will time out
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	require.Error(t, snd.Send(ctx, NewMessage([]byte("test"))))
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendMsgTooBig(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			mode := encoding.ModeUnsettled
+			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformAttach{
+				Name:   tt.Name,
+				Handle: 0,
+				Role:   encoding.RoleReceiver,
+				Target: &frames.Target{
+					Address:      "test",
+					Durable:      encoding.DurabilityNone,
+					ExpiryPolicy: encoding.ExpirySessionEnd,
+				},
+				SenderSettleMode: &mode,
+				MaxMessageSize:   16, // really small messages only
+			})
+		case *frames.PerformTransfer:
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	require.Error(t, snd.Send(ctx, NewMessage([]byte("test message that's too big"))))
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendTagTooBig(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformTransfer:
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	msg := NewMessage([]byte("test"))
+	msg.DeliveryTag = make([]byte, 33)
+	require.Error(t, snd.Send(ctx, msg))
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendMultiTransfer(t *testing.T) {
+	var deliveryID uint32
+	transferCount := 0
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{
+				ChannelMax:   65535,
+				ContainerID:  "container",
+				IdleTimeout:  time.Minute,
+				MaxFrameSize: 128, // really small max frame size
+			})
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
+		case *frames.PerformTransfer:
+			if tt.DeliveryID != nil {
+				// deliveryID is only sent on the first transfer frame for multi-frame transfers
+				deliveryID = *tt.DeliveryID
+			}
+			if tt.More {
+				transferCount++
+				return nil, nil
+			}
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, deliveryID, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn)
+	require.NoError(t, err)
+
+	session, err := client.NewSession()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	snd, err := session.NewSender()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, netConn, 0, 100)
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100000*time.Millisecond)
+	payload := make([]byte, 512)
+	for i := 0; i < 512; i++ {
+		payload[i] = byte(i % 256)
+	}
+	require.NoError(t, snd.Send(ctx, NewMessage(payload)))
+	cancel()
+
+	// split up into 8 transfers due to transfer frame header size
+	require.Equal(t, 8, transferCount)
+
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, client.Close())
 }

--- a/session.go
+++ b/session.go
@@ -472,6 +472,7 @@ func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 		// frame successfully sent to link
 	case <-l.Detached:
 		// link is closed
+		// this should be impossible to hit as the link has been removed from the session once Detached is closed
 	case <-s.conn.Done:
 		// conn is closed
 	}

--- a/session.go
+++ b/session.go
@@ -35,7 +35,7 @@ type Session struct {
 	// used for gracefully closing link
 	close     chan struct{}
 	closeOnce sync.Once
-	done      chan struct{}
+	done      chan struct{} // part of internal public surface area
 	err       error
 }
 
@@ -127,6 +127,8 @@ func (s *Session) NewSender(opts ...LinkOption) (*Sender, error) {
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
 		// clean up session record in conn.mux()
+		// TODO: this can deadlock with conn.mux sending a frame to the session
+		// https://github.com/Azure/go-amqp/issues/87
 		select {
 		case s.conn.DelSession <- s:
 		case <-s.conn.Done:
@@ -467,7 +469,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	select {
 	case l.RX <- fr:
+		// frame successfully sent to link
 	case <-l.Detached:
+		// link is closed
 	case <-s.conn.Done:
+		// conn is closed
 	}
 }


### PR DESCRIPTION
Fixed a bug where DetachError was lost on receipt.  This made
ErrLinkDetached unnecessary so it's been removed.
Removed link.Check as it's no longer required.
Clear in-fligt messages before declaring the mux as detached.
Documented a deadlock between conn and session with pending test.
Require role when calling mocks.PerformDisposition.
Added mocks.PerformDetach.
Added various code comments.