### PR TITLE
Fix deadlock between conn and session

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -499,8 +499,6 @@ func (c *conn) mux() {
 				continue
 			}
 
-			// TODO: this can deadlock with session mux unwind
-			// https://github.com/Azure/go-amqp/issues/87
 			select {
 			case session.rx <- fr:
 			case <-c.closeMux:

--- a/session.go
+++ b/session.go
@@ -127,10 +127,11 @@ func (s *Session) NewSender(opts ...LinkOption) (*Sender, error) {
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
 		// clean up session record in conn.mux()
-		// TODO: this can deadlock with conn.mux sending a frame to the session
-		// https://github.com/Azure/go-amqp/issues/87
 		select {
+		case <-s.rx:
+			// discard any incoming frames to keep conn mux unblocked
 		case s.conn.DelSession <- s:
+			// successfully deleted session
 		case <-s.conn.Done:
 			s.err = s.conn.Err()
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -615,8 +615,6 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 }
 
 func TestSessionInvalidAttachDeadlock(t *testing.T) {
-	// https://github.com/Azure/go-amqp/issues/87
-	t.Skip("TODO: deadlock fix for conn and session")
 	var enqueueFrames func(string)
 	responder := func(req frames.FrameBody) ([]byte, error) {
 		switch tt := req.(type) {


### PR DESCRIPTION
Read and discard any errant frames send to the session when the mux is
unwinding.  This prevents the conn mux from being blocked which can lead
to a deadlock.