### PR TITLE
Add unit tests for Receiver

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -367,7 +367,7 @@ func TestClientNewSessionInvalidSecondResponseDifferentChannel(t *testing.T) {
 			}
 			// respond with the wrong frame type
 			// note that it has to be for the next channel
-			return mocks.PerformDisposition(encoding.RoleSender, 1, 0, nil)
+			return mocks.PerformDisposition(encoding.RoleSender, 1, 0, nil, nil)
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
 		default:

--- a/client_test.go
+++ b/client_test.go
@@ -253,7 +253,7 @@ func TestClientTooManySessions(t *testing.T) {
 }
 
 func TestClientNewSessionInvalidOption(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -319,13 +319,13 @@ func TestStart(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err := newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())
 	require.NoError(t, conn.Close())
 	// with Close error
-	netConn = mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn = mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err = newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())
@@ -338,7 +338,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestServerSideClose(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err := newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())
@@ -348,7 +348,7 @@ func TestServerSideClose(t *testing.T) {
 	err = conn.Close()
 	require.NoError(t, err)
 	// with error
-	netConn = mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn = mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err = newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())
@@ -400,7 +400,7 @@ func TestKeepAlives(t *testing.T) {
 }
 
 func TestConnReaderError(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err := newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())
@@ -412,7 +412,7 @@ func TestConnReaderError(t *testing.T) {
 }
 
 func TestConnWriterError(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 	conn, err := newConn(netConn)
 	require.NoError(t, err)
 	require.NoError(t, conn.Start())

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -139,6 +138,6 @@ func waitForLink(l *link, paused bool) error {
 		} else if err := ctx.Err(); err != nil {
 			return err
 		}
-		runtime.Gosched()
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -176,7 +176,7 @@ func waitForLink(l *link, paused bool) error {
 	if paused {
 		state = 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	for {
 		if atomic.LoadUint32(&l.Paused) == state {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -93,34 +93,38 @@ func sendInitialFlowFrame(t *testing.T, netConn *mocks.NetConn, handle uint32, c
 
 // standard frame handler for connecting/disconnecting etc.
 // returns nil, nil for unhandled frames.
-func standardFrameHandler(req frames.FrameBody) ([]byte, error) {
-	switch tt := req.(type) {
-	case *mocks.AMQPProto:
-		return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
-	case *frames.PerformOpen:
-		return mocks.PerformOpen("container")
-	case *frames.PerformClose:
-		return mocks.PerformClose(nil)
-	case *frames.PerformBegin:
-		return mocks.PerformBegin(0)
-	case *frames.PerformEnd:
-		return mocks.PerformEnd(0, nil)
-	case *frames.PerformAttach:
-		return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeUnsettled)
-	case *frames.PerformDetach:
-		return mocks.PerformDetach(0, 0, nil)
-	default:
-		return nil, nil
+func senderFrameHandler(ssm encoding.SenderSettleMode) func(frames.FrameBody) ([]byte, error) {
+	return func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return mocks.SenderAttach(0, tt.Name, 0, ssm)
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		default:
+			return nil, nil
+		}
 	}
 }
 
-// similar to standardFrameHandler but returns an error on unhandled frames
-func standardFrameHandlerNoUnhandled(req frames.FrameBody) ([]byte, error) {
-	b, err := standardFrameHandler(req)
-	if b == nil && err == nil {
-		return nil, fmt.Errorf("unhandled frame %T", req)
+// similar to senderFrameHandler but returns an error on unhandled frames
+func senderFrameHandlerNoUnhandled(ssm encoding.SenderSettleMode) func(frames.FrameBody) ([]byte, error) {
+	return func(req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(ssm)(req)
+		if b == nil && err == nil {
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+		return b, err
 	}
-	return b, err
 }
 
 // helper to wait for a link to pause/resume

--- a/link_test.go
+++ b/link_test.go
@@ -339,7 +339,7 @@ func TestSourceName(t *testing.T) {
 func TestSessionFlowDisablesTransfer(t *testing.T) {
 	t.Skip("TODO: finish for link testing")
 	nextIncomingID := uint32(0)
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestSessionFlowDisablesTransfer(t *testing.T) {
 }
 
 func TestExactlyOnceDoesntWork(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)

--- a/link_test.go
+++ b/link_test.go
@@ -380,3 +380,5 @@ func TestExactlyOnceDoesntWork(t *testing.T) {
 	require.Nil(t, snd)
 	require.NoError(t, client.Close())
 }
+
+// TODO: echo flow frame

--- a/receiver.go
+++ b/receiver.go
@@ -316,6 +316,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	case err := <-wait:
 		// we've received confirmation of disposition
 		r.link.DeleteUnsettled(msg)
+		msg.settled = true
 		return err
 	case <-ctx.Done():
 		return ctx.Err()

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -16,23 +16,7 @@ import (
 )
 
 func TestReceiverInvalidOptions(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, "test", 0, ModeFirst, nil)
-		case *frames.PerformFlow:
-			return nil, nil
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -93,24 +77,7 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 }
 
 func TestReceiverLinkSourceFilter(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			// propagate filter specified by caller
-			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
-		case *frames.PerformFlow:
-			return nil, nil
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -128,23 +95,7 @@ func TestReceiverLinkSourceFilter(t *testing.T) {
 }
 
 func TestReceiverOnClosed(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
-		case *frames.PerformFlow:
-			return nil, nil
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -171,25 +122,7 @@ func TestReceiverOnClosed(t *testing.T) {
 }
 
 func TestReceiverOnSessionClosed(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
-		case *frames.PerformFlow:
-			return nil, nil
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -216,25 +149,7 @@ func TestReceiverOnSessionClosed(t *testing.T) {
 }
 
 func TestReceiverOnConnClosed(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
-		case *frames.PerformFlow:
-			return nil, nil
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -259,27 +174,7 @@ func TestReceiverOnConnClosed(t *testing.T) {
 }
 
 func TestReceiverOnDetached(t *testing.T) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
-		case *frames.PerformFlow:
-			return nil, nil
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
-		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
-		}
-	}
-	conn := mocks.NewNetConn(responder)
+	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ModeFirst))
 	client, err := New(conn)
 	assert.NoError(t, err)
 	session, err := client.NewSession()
@@ -319,23 +214,15 @@ func TestReceiveInvalidMessage(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeFirst, nil)
+		b, err := receiverFrameHandler(ModeFirst)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
 		case *frames.PerformFlow:
 			return nil, nil
 		case *frames.PerformDisposition:
 			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -436,15 +323,11 @@ func TestReceiveSuccessModeFirst(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeFirst)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeFirst, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -490,15 +373,11 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -565,15 +444,11 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -634,15 +509,11 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -703,15 +574,11 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -809,15 +676,11 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		case *frames.PerformDisposition:
@@ -887,21 +750,13 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
 		case *frames.PerformFlow:
 			return nil, nil
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -992,15 +847,11 @@ func TestReceiveMultiFrameMessageAborted(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		case *frames.PerformDisposition:
@@ -1050,15 +901,11 @@ func TestReceiveMessageTooBig(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -1067,10 +914,6 @@ func TestReceiveMessageTooBig(t *testing.T) {
 			}
 			// ignore future flow frames as we have no response
 			return nil, nil
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -1098,15 +941,11 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -1155,15 +994,11 @@ func TestReceiverDispositionBatcherTimer(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -1213,15 +1048,11 @@ func TestReceiverDispositionBatcherFull(t *testing.T) {
 	acceptCount := 0
 	allAccepted := make(chan struct{})
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		case *frames.PerformDisposition:
@@ -1285,15 +1116,11 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 	acceptCount := 0
 	allAccepted := make(chan struct{})
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
 		switch ff := req.(type) {
-		case *mocks.AMQPProto:
-			return mocks.ProtoHeader(mocks.ProtoAMQP)
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("test")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		case *frames.PerformDisposition:

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -424,7 +424,10 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	require.Equal(t, true, msg.settled)
 	// perform a dummy receive with short timeout to trigger flow
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	_, _ = r.Receive(ctx)
+	_, err = r.Receive(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
 	assert.NoError(t, waitForLink(r.link, false))
@@ -494,7 +497,10 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	}
 	// perform a dummy receive with short timeout to trigger flow
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	_, _ = r.Receive(ctx)
+	_, err = r.Receive(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
 	assert.NoError(t, waitForLink(r.link, false))
@@ -559,7 +565,10 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	}
 	// perform a dummy receive with short timeout to trigger flow
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	_, _ = r.Receive(ctx)
+	_, err = r.Receive(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
 	assert.NoError(t, waitForLink(r.link, false))
@@ -631,7 +640,10 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	}
 	// perform a dummy receive with short timeout to trigger flow
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	_, _ = r.Receive(ctx)
+	_, err = r.Receive(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
 	assert.NoError(t, waitForLink(r.link, false))
@@ -736,7 +748,10 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	require.Equal(t, true, msg.settled)
 	// perform a dummy receive with short timeout to trigger flow
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	_, _ = r.Receive(ctx)
+	_, err = r.Receive(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
 	assert.NoError(t, waitForLink(r.link, false))

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -2,9 +2,8 @@ package amqp
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"runtime"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,27 +14,264 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// helper to wait for a link to pause/resume
-// returns an error if it times out waiting
-func waitForLink(l *link, paused bool) error {
-	state := uint32(0) // unpaused
-	if paused {
-		state = 1
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	for {
-		if atomic.LoadUint32(&l.Paused) == state {
-			return nil
-		} else if err := ctx.Err(); err != nil {
-			return err
+func TestReceiverMethodsNoReceive(t *testing.T) {
+	const linkName = "test"
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, linkName, 0, ModeFirst, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
-		runtime.Gosched()
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	const sourceAddr = "thesource"
+	r, err := session.NewReceiver(LinkName(linkName), LinkSourceAddress(sourceAddr))
+	assert.NoError(t, err)
+	require.Equal(t, sourceAddr, r.Address())
+	require.Equal(t, linkName, r.LinkName())
+	require.Nil(t, r.LinkSourceFilterValue("nofilter"))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(t, r.Close(ctx))
+	cancel()
+}
+
+func TestReceiverLinkSourceFilter(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			// propagate filter specified by caller
+			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
+		case *frames.PerformFlow:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	const filterName = "myfilter"
+	const filterExp = "filter_exp"
+	r, err := session.NewReceiver(LinkAddressDynamic(), LinkSourceFilter(filterName, 0, filterExp))
+	assert.NoError(t, err)
+	require.Equal(t, "test", r.Address())
+	require.NotEmpty(t, r.LinkName())
+	require.Equal(t, filterExp, r.LinkSourceFilterValue(filterName))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(t, r.Close(ctx))
+	cancel()
+}
+
+func TestReceiverOnClosed(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
+		case *frames.PerformFlow:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver()
+	assert.NoError(t, err)
+
+	errChan := make(chan error)
+	go func() {
+		_, err := r.Receive(context.Background())
+		errChan <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(t, r.Close(ctx))
+	cancel()
+	if err = <-errChan; !errors.Is(err, ErrLinkClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, err = r.Receive(context.Background())
+	if !errors.Is(err, ErrLinkClosed) {
+		t.Fatalf("unexpected error %v", err)
 	}
 }
 
-func TestReceive_ModeFirst(t *testing.T) {
-	const linkName = "test"
+func TestReceiverOnSessionClosed(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver()
+	assert.NoError(t, err)
+
+	errChan := make(chan error)
+	go func() {
+		_, err := r.Receive(context.Background())
+		errChan <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(t, session.Close(ctx))
+	cancel()
+	if err = <-errChan; !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, err = r.Receive(context.Background())
+	if !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestReceiverOnConnClosed(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver()
+	assert.NoError(t, err)
+
+	errChan := make(chan error)
+	go func() {
+		_, err := r.Receive(context.Background())
+		errChan <- err
+	}()
+
+	require.NoError(t, client.Close())
+	if err = <-errChan; !errors.Is(err, ErrConnClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, err = r.Receive(context.Background())
+	if !errors.Is(err, ErrConnClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestReceiverOnDetached(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, 0, ModeFirst, ff.Source.Filter)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver()
+	assert.NoError(t, err)
+
+	errChan := make(chan error)
+	go func() {
+		_, err := r.Receive(context.Background())
+		errChan <- err
+	}()
+
+	// initiate a server-side detach
+	const (
+		errcon  = "detaching"
+		errdesc = "server side detach"
+	)
+	b, err := mocks.PerformDetach(0, 0, &Error{Condition: errcon, Description: errdesc})
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	var de *DetachError
+	if !errors.As(<-errChan, &de) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, encoding.ErrorCondition(errcon), de.RemoteError.Condition)
+	require.Equal(t, errdesc, de.RemoteError.Description)
+	require.NoError(t, client.Close())
+	_, err = r.Receive(context.Background())
+	if !errors.As(err, &de) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+}
+
+func TestReceiveInvalidMessage(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
@@ -47,16 +283,15 @@ func TestReceive_ModeFirst(t *testing.T) {
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, linkName, linkHandle, ModeFirst)
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeFirst, nil)
 		case *frames.PerformFlow:
-			if *ff.NextIncomingID == deliveryID {
-				// this is the first flow frame, send our payload
-				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
-			}
-			// ignore future flow frames as we have no response
 			return nil, nil
 		case *frames.PerformDisposition:
-			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -66,9 +301,127 @@ func TestReceive_ModeFirst(t *testing.T) {
 	assert.NoError(t, err)
 	session, err := client.NewSession()
 	assert.NoError(t, err)
-	r, err := session.NewReceiver(LinkName(linkName), LinkReceiverSettle(ModeFirst))
+	r, err := session.NewReceiver()
 	assert.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+
+	msgChan := make(chan *Message)
+	errChan := make(chan error)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+
+	// missing DeliveryID
+	fr, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+		Handle: linkHandle,
+	})
+	assert.NoError(t, err)
+	conn.SendFrame(fr)
+
+	assert.Nil(t, <-msgChan)
+	var amqpErr *Error
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	_, err = r.Receive(context.Background())
+	if !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// missing MessageFormat
+	r, err = session.NewReceiver()
+	assert.NoError(t, err)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	fr, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+		DeliveryID: &deliveryID,
+		Handle:     linkHandle,
+	})
+	assert.NoError(t, err)
+	conn.SendFrame(fr)
+
+	assert.Nil(t, <-msgChan)
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	_, err = r.Receive(context.Background())
+	if !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// missing delivery tag
+	format := uint32(0)
+	r, err = session.NewReceiver()
+	assert.NoError(t, err)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	fr, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+		DeliveryID:    &deliveryID,
+		Handle:        linkHandle,
+		MessageFormat: &format,
+	})
+	assert.NoError(t, err)
+	conn.SendFrame(fr)
+
+	assert.Nil(t, <-msgChan)
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	_, err = r.Receive(context.Background())
+	if !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveSuccessModeFirst(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeFirst, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeFirst))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	msg, err := r.Receive(ctx)
 	cancel()
 	assert.NoError(t, err)
@@ -82,15 +435,14 @@ func TestReceive_ModeFirst(t *testing.T) {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
 	assert.NoError(t, err)
 	assert.NoError(t, client.Close())
 }
 
-func TestReceive_ModeSecond(t *testing.T) {
-	const linkName = "test"
+func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {
@@ -102,7 +454,7 @@ func TestReceive_ModeSecond(t *testing.T) {
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, linkName, linkHandle, ModeSecond)
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
 		case *frames.PerformFlow:
 			if *ff.NextIncomingID == deliveryID {
 				// this is the first flow frame, send our payload
@@ -111,7 +463,10 @@ func TestReceive_ModeSecond(t *testing.T) {
 			// ignore future flow frames as we have no response
 			return nil, nil
 		case *frames.PerformDisposition:
-			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, &encoding.StateAccepted{})
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -121,9 +476,9 @@ func TestReceive_ModeSecond(t *testing.T) {
 	assert.NoError(t, err)
 	session, err := client.NewSession()
 	assert.NoError(t, err)
-	r, err := session.NewReceiver(LinkName(linkName), LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
 	assert.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	msg, err := r.Receive(ctx)
 	cancel()
 	assert.NoError(t, err)
@@ -136,8 +491,83 @@ func TestReceive_ModeSecond(t *testing.T) {
 	if c := r.link.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	require.Equal(t, true, msg.settled)
+	// perform a dummy receive with short timeout to trigger flow
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, _ = r.Receive(ctx)
+	cancel()
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be back to 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	// subsequent dispositions should have no effect
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveSuccessModeSecondReject(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateRejected); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateRejected{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.RejectMessage(ctx, msg, nil)
 	cancel()
 	assert.NoError(t, err)
 	if c := r.link.countUnsettled(); c != 0 {
@@ -153,16 +583,155 @@ func TestReceive_ModeSecond(t *testing.T) {
 	if c := r.link.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	// subsequent dispositions should have no effect
-	// TODO: https://github.com/Azure/go-amqp/issues/76
-	/*ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	err = r.AcceptMessage(ctx, msg)
-	cancel()
-	assert.NoError(t, err)*/
 	assert.NoError(t, client.Close())
 }
 
-func Test_ReceiveNonBlocking(t *testing.T) {
+func TestReceiveSuccessModeSecondRelease(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateReleased); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateReleased{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.ReleaseMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// perform a dummy receive with short timeout to trigger flow
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, _ = r.Receive(ctx)
+	cancel()
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be back to 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveSuccessModeSecondModify(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			var mod *encoding.StateModified
+			var ok bool
+			if mod, ok = ff.State.(*encoding.StateModified); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			if v := mod.MessageAnnotations["some"]; v != "value" {
+				return nil, fmt.Errorf("unexpected annotation value %v", v)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateModified{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.ModifyMessage(ctx, msg, false, true, Annotations{
+		"some": "value",
+	})
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// perform a dummy receive with short timeout to trigger flow
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, _ = r.Receive(ctx)
+	cancel()
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be back to 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiverPrefetch(t *testing.T) {
 	messagesCh := make(chan Message, 1)
 
 	receiver := &Receiver{
@@ -190,4 +759,542 @@ func Test_ReceiveNonBlocking(t *testing.T) {
 	require.EqualValues(t, "hello", msg.ApplicationProperties["prop"].(string))
 	require.Nil(t, err)
 	require.Empty(t, messagesCh)
+}
+
+func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	msgChan := make(chan *Message)
+	errChan := make(chan error)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	// send multi-frame message
+	payload := []byte("this should be split into three frames for a multi-frame transfer message")
+	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, nil))
+	msg := <-msgChan
+	assert.NoError(t, <-errChan)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	result := []byte{}
+	for i := range msg.Data {
+		result = append(result, msg.Data[i]...)
+	}
+	assert.Equal(t, payload, result)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	require.Equal(t, true, msg.settled)
+	// perform a dummy receive with short timeout to trigger flow
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, _ = r.Receive(ctx)
+	cancel()
+	// wait for the link to unpause as credit should now be available
+	assert.NoError(t, waitForLink(r.link, false))
+	// link credit should be back to 1
+	if c := r.link.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	msgChan := make(chan *Message)
+	errChan := make(chan error)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	// send multi-frame message
+	payload := []byte("this should be split into two frames for a multi-frame transfer")
+
+	// mismatched DeliveryID
+	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, func(i int, fr *frames.PerformTransfer) {
+		if i == 0 {
+			return
+		}
+		// modify the second frame with mismatched data
+		badID := uint32(123)
+		fr.DeliveryID = &badID
+	}))
+	msg := <-msgChan
+	assert.Nil(t, msg)
+	var amqpErr *Error
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	// mismatched MessageFormat
+	r, err = session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, func(i int, fr *frames.PerformTransfer) {
+		if i == 0 {
+			return
+		}
+		// modify the second frame with mismatched data
+		badFormat := uint32(123)
+		fr.MessageFormat = &badFormat
+	}))
+	msg = <-msgChan
+	assert.Nil(t, msg)
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	// mismatched DeliveryTag
+	r, err = session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		msgChan <- msg
+		errChan <- err
+	}()
+	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, func(i int, fr *frames.PerformTransfer) {
+		if i == 0 {
+			return
+		}
+		// modify the second frame with mismatched data
+		fr.DeliveryTag = []byte("bad_tag")
+	}))
+	msg = <-msgChan
+	assert.Nil(t, msg)
+	if err = <-errChan; !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorNotAllowed, amqpErr.Condition)
+
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveMultiFrameMessageAborted(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	msgChan := make(chan *Message)
+	errChan := make(chan error)
+	go func() {
+		msg, err := r.Receive(context.Background())
+		errChan <- err
+		msgChan <- msg
+	}()
+	// send multi-frame message
+	payload := []byte("this should be split into three frames for a multi-frame transfer message")
+	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, func(i int, fr *frames.PerformTransfer) {
+		if i < 2 {
+			return
+		}
+		// set abort flag on the last frame
+		fr.Aborted = true
+	}))
+	// we shouldn't have received any message at this point, now send a single-frame message
+	payload = []byte("single message")
+	b, err := mocks.PerformTransfer(0, linkHandle, deliveryID+1, payload)
+	assert.NoError(t, err)
+	conn.SendFrame(b)
+	assert.NoError(t, <-errChan)
+	msg := <-msgChan
+	assert.Equal(t, payload, msg.GetData())
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveMessageTooBig(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				bigPayload := make([]byte, 256)
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, bigPayload)
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
+		case *frames.PerformEnd:
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond), LinkMaxMessageSize(128))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.Nil(t, msg)
+	var amqpErr *Error
+	if !errors.As(err, &amqpErr) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	assert.Equal(t, ErrorMessageSizeExceeded, amqpErr.Condition)
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiveSuccessAcceptFails(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	assert.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	// close client before accepting the message
+	assert.NoError(t, client.Close())
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	if !errors.Is(err, ErrConnClosed) {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+}
+
+func TestReceiverDispositionBatcherTimer(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond), LinkCredit(2), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	assert.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	assert.Equal(t, 0, r.inFlight.len())
+	assert.Equal(t, true, msg.settled)
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiverDispositionBatcherFull(t *testing.T) {
+	const credit = 3
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	acceptCount := 0
+	allAccepted := make(chan struct{})
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			if ff.Last == nil {
+				acceptCount++
+			} else {
+				acceptCount += int(*ff.Last)
+			}
+			if acceptCount == credit {
+				close(allAccepted)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, ff.First, ff.Last, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond), LinkCredit(credit), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	assert.NoError(t, err)
+	for i := 0; i < credit; i++ {
+		b, err := mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+		assert.NoError(t, err)
+		conn.SendFrame(b)
+		deliveryID++
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		msg, err := r.Receive(ctx)
+		cancel()
+		assert.NoError(t, err)
+		go func() {
+			assert.NoError(t, r.AcceptMessage(context.Background(), msg))
+			assert.Equal(t, true, msg.settled)
+		}()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	select {
+	case <-allAccepted:
+		// all messages were settled
+	case <-ctx.Done():
+		t.Fatalf("not all messages were settled within the allotted time: %d", acceptCount)
+	}
+	assert.Equal(t, 0, r.inFlight.len())
+	assert.NoError(t, client.Close())
+}
+
+func TestReceiverDispositionBatcherRelease(t *testing.T) {
+	const credit = 3
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	acceptCount := 0
+	allAccepted := make(chan struct{})
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch ff := req.(type) {
+		case *mocks.AMQPProto:
+			return mocks.ProtoHeader(mocks.ProtoAMQP)
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("test")
+		case *frames.PerformBegin:
+			return mocks.PerformBegin(0)
+		case *frames.PerformAttach:
+			return mocks.ReceiverAttach(0, ff.Name, linkHandle, ModeSecond, nil)
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			if ff.Last == nil || *ff.Last == ff.First {
+				acceptCount++
+			} else {
+				acceptCount += int(*ff.Last)
+			}
+			if acceptCount == credit {
+				close(allAccepted)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, ff.First, ff.Last, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn)
+	assert.NoError(t, err)
+	session, err := client.NewSession()
+	assert.NoError(t, err)
+	r, err := session.NewReceiver(LinkReceiverSettle(ModeSecond), LinkCredit(credit), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	assert.NoError(t, err)
+	for i := 0; i < credit; i++ {
+		b, err := mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+		assert.NoError(t, err)
+		conn.SendFrame(b)
+		deliveryID++
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+		msg, err := r.Receive(ctx)
+		cancel()
+		assert.NoError(t, err)
+		go func(count int) {
+			if count == credit-1 {
+				assert.NoError(t, r.AcceptMessage(context.Background(), msg))
+			} else {
+				assert.NoError(t, r.ReleaseMessage(context.Background(), msg))
+			}
+			assert.Equal(t, true, msg.settled)
+		}(i)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	select {
+	case <-allAccepted:
+		// all messages were settled
+	case <-ctx.Done():
+		t.Fatalf("not all messages were settled within the allotted time: %d", acceptCount)
+	}
+	assert.Equal(t, 0, r.inFlight.len())
+	assert.NoError(t, client.Close())
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -711,6 +711,12 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	assert.NoError(t, conn.SendMultiFrameTransfer(0, linkHandle, deliveryID, payload, nil))
 	msg := <-msgChan
 	assert.NoError(t, <-errChan)
+	// validate message content
+	result := []byte{}
+	for i := range msg.Data {
+		result = append(result, msg.Data[i]...)
+	}
+	assert.Equal(t, payload, result)
 	if c := r.link.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
@@ -720,11 +726,6 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	if c := r.link.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	result := []byte{}
-	for i := range msg.Data {
-		result = append(result, msg.Data[i]...)
-	}
-	assert.Equal(t, payload, result)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()

--- a/sender_test.go
+++ b/sender_test.go
@@ -283,8 +283,6 @@ func TestSenderSendSuccess(t *testing.T) {
 				return nil, fmt.Errorf("unexpected payload %v", tt.Payload)
 			}
 			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -577,8 +575,6 @@ func TestSenderSendTagTooBig(t *testing.T) {
 		switch tt := req.(type) {
 		case *frames.PerformTransfer:
 			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}

--- a/sender_test.go
+++ b/sender_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestSenderInvalidOptions(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandler)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestSenderMethodsNoSend(t *testing.T) {
 }
 
 func TestSenderSendOnClosed(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestSenderSendOnClosed(t *testing.T) {
 }
 
 func TestSenderSendOnSessionClosed(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestSenderSendOnSessionClosed(t *testing.T) {
 }
 
 func TestSenderSendOnConnClosed(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestSenderSendOnConnClosed(t *testing.T) {
 }
 
 func TestSenderSendOnDetached(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestSenderAttachError(t *testing.T) {
 }
 
 func TestSenderSendMismatchedModes(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestSenderSendMismatchedModes(t *testing.T) {
 
 func TestSenderSendSuccess(t *testing.T) {
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := standardFrameHandler(req)
+		b, err := senderFrameHandler(ModeUnsettled)(req)
 		if err != nil || b != nil {
 			return b, err
 		}
@@ -310,17 +310,11 @@ func TestSenderSendSuccess(t *testing.T) {
 
 func TestSenderSendSettled(t *testing.T) {
 	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(ModeSettled)(req)
+		if err != nil || b != nil {
+			return b, err
+		}
 		switch tt := req.(type) {
-		case *mocks.AMQPProto:
-			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
-		case *frames.PerformOpen:
-			return mocks.PerformOpen("container")
-		case *frames.PerformBegin:
-			return mocks.PerformBegin(0)
-		case *frames.PerformEnd:
-			return mocks.PerformEnd(0, nil)
-		case *frames.PerformAttach:
-			return mocks.SenderAttach(0, tt.Name, 0, encoding.ModeSettled)
 		case *frames.PerformTransfer:
 			if tt.More {
 				return nil, errors.New("didn't expect more to be true")
@@ -332,8 +326,6 @@ func TestSenderSendSettled(t *testing.T) {
 				return nil, fmt.Errorf("unexpected payload %v", tt.Payload)
 			}
 			return nil, nil
-		case *frames.PerformDetach:
-			return mocks.PerformDetach(0, 0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -359,7 +351,7 @@ func TestSenderSendSettled(t *testing.T) {
 
 func TestSenderSendRejected(t *testing.T) {
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := standardFrameHandler(req)
+		b, err := senderFrameHandler(ModeUnsettled)(req)
 		if err != nil || b != nil {
 			return b, err
 		}
@@ -422,14 +414,14 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 		case *frames.PerformTransfer:
 			// reject first delivery
 			if *tt.DeliveryID == 1 {
-				return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateRejected{
+				return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateRejected{
 					Error: &Error{
 						Condition:   "rejected",
 						Description: "didn't like it",
 					},
 				})
 			}
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
 		case *frames.PerformDetach:
 			return mocks.PerformDetach(0, 0, nil)
 		default:
@@ -467,7 +459,7 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 
 func TestSenderSendDetached(t *testing.T) {
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := standardFrameHandler(req)
+		b, err := senderFrameHandler(ModeUnsettled)(req)
 		if err != nil || b != nil {
 			return b, err
 		}
@@ -506,7 +498,7 @@ func TestSenderSendDetached(t *testing.T) {
 }
 
 func TestSenderSendTimeout(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -578,7 +570,7 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 
 func TestSenderSendTagTooBig(t *testing.T) {
 	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := standardFrameHandler(req)
+		b, err := senderFrameHandler(ModeUnsettled)(req)
 		if err != nil || b != nil {
 			return b, err
 		}

--- a/sender_test.go
+++ b/sender_test.go
@@ -282,7 +282,9 @@ func TestSenderSendSuccess(t *testing.T) {
 			if !reflect.DeepEqual([]byte{0, 83, 117, 160, 4, 116, 101, 115, 116}, tt.Payload) {
 				return nil, fmt.Errorf("unexpected payload %v", tt.Payload)
 			}
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -363,7 +365,7 @@ func TestSenderSendRejected(t *testing.T) {
 		}
 		switch tt := req.(type) {
 		case *frames.PerformTransfer:
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateRejected{
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateRejected{
 				Error: &Error{
 					Condition:   "rejected",
 					Description: "didn't like it",
@@ -548,7 +550,7 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 				MaxMessageSize:   16, // really small messages only
 			})
 		case *frames.PerformTransfer:
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
 		case *frames.PerformDetach:
 			return mocks.PerformDetach(0, 0, nil)
 		default:
@@ -582,7 +584,9 @@ func TestSenderSendTagTooBig(t *testing.T) {
 		}
 		switch tt := req.(type) {
 		case *frames.PerformTransfer:
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
+		case *frames.PerformDetach:
+			return mocks.PerformDetach(0, 0, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -648,7 +652,7 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 				transferCount++
 				return nil, nil
 			}
-			return mocks.PerformDisposition(encoding.RoleReceiver, 0, deliveryID, &encoding.StateAccepted{})
+			return mocks.PerformDisposition(encoding.RoleReceiver, 0, deliveryID, nil, &encoding.StateAccepted{})
 		case *frames.PerformDetach:
 			return mocks.PerformDetach(0, 0, nil)
 		default:

--- a/session.go
+++ b/session.go
@@ -248,6 +248,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 					handle, ok := handles[deliveryID]
 					if !ok {
+						debug(2, "role %s: didn't find deliveryID %d in handles map", body.Role, deliveryID)
 						continue
 					}
 					delete(handles, deliveryID)

--- a/session_test.go
+++ b/session_test.go
@@ -126,7 +126,7 @@ func TestSessionCloseTimeout(t *testing.T) {
 }
 
 func TestConnCloseSessionClose(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestConnCloseSessionClose(t *testing.T) {
 }
 
 func TestSessionNewReceiverBadOptionFails(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 }
 
 func TestSessionNewSenderBadOptionFails(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -323,7 +323,7 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 }
 
 func TestSessionNewSenderDuplicateLinks(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestSessionNewSenderDuplicateLinks(t *testing.T) {
 }
 
 func TestSessionNewSenderMaxHandles(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestSessionNewSenderMaxHandles(t *testing.T) {
 }
 
 func TestSessionUnexpectedFrame(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestSessionUnexpectedFrame(t *testing.T) {
 }
 
 func TestSessionInvalidFlowFrame(t *testing.T) {
-	netConn := mocks.NewNetConn(standardFrameHandlerNoUnhandled)
+	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(ModeUnsettled))
 
 	client, err := New(netConn)
 	require.NoError(t, err)

--- a/session_test.go
+++ b/session_test.go
@@ -174,7 +174,7 @@ func TestSessionNewReceiverBatchingOneCredit(t *testing.T) {
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
 		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, tt.Name, 0, encoding.ModeFirst)
+			return mocks.ReceiverAttach(0, tt.Name, 0, encoding.ModeFirst, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		default:
@@ -211,7 +211,7 @@ func TestSessionNewReceiverBatchingEnabled(t *testing.T) {
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
 		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, tt.Name, 0, encoding.ModeFirst)
+			return mocks.ReceiverAttach(0, tt.Name, 0, encoding.ModeFirst, nil)
 		case *frames.PerformFlow:
 			return nil, nil
 		default:
@@ -248,7 +248,7 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
 		case *frames.PerformAttach:
-			return mocks.ReceiverAttach(0, "wrong_name", 0, encoding.ModeFirst)
+			return mocks.ReceiverAttach(0, "wrong_name", 0, encoding.ModeFirst, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}


### PR DESCRIPTION
Fixed an issue where malformed deliveries returned a different error
type from that which was used to close the link.
Fixed a potential deadlock during link.muxDetach.
Set Message.settled to true when confirmation of settlement is received.
Added support to mocks.NetConn for sending multi-frame transfers.
Made filter configurable in mocks.ReceiverAttach.
Added support for multi-message dispositions.