### PR TITLE
Fix hangs in manual credit management

### DIFF
--- a/link.go
+++ b/link.go
@@ -604,7 +604,7 @@ func (l *link) DrainCredit(ctx context.Context) error {
 	default:
 	}
 
-	return l.receiver.manualCreditor.Drain(ctx)
+	return l.receiver.manualCreditor.Drain(ctx, l)
 }
 
 // IssueCredit requests additional credits be issued for this link.
@@ -812,6 +812,11 @@ func (l *link) muxDetach() {
 		// unblock any in flight message dispositions
 		if l.receiver != nil {
 			l.receiver.inFlight.clear(l.err)
+		}
+
+		// unblock any pending drain requests
+		if l.receiver != nil && l.receiver.manualCreditor != nil {
+			l.receiver.manualCreditor.EndDrain()
 		}
 
 		// signal that the link mux has exited

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -61,7 +61,7 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 }
 
 // Drain initiates a drain and blocks until EndDrain is called.
-func (mc *manualCreditor) Drain(ctx context.Context) error {
+func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	mc.mu.Lock()
 
 	if mc.drained != nil {
@@ -79,6 +79,8 @@ func (mc *manualCreditor) Drain(ctx context.Context) error {
 	select {
 	case <-drained:
 		return nil
+	case <-l.Detached:
+		return l.detachError
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -35,16 +35,17 @@ func TestManualCreditorDrain(t *testing.T) {
 	drainRoutines := sync.WaitGroup{}
 	drainRoutines.Add(2)
 
+	l := newTestLink(t)
 	var err1, err2 error
 
 	go func() {
 		defer drainRoutines.Done()
-		err1 = mc.Drain(ctx)
+		err1 = mc.Drain(ctx, l)
 	}()
 
 	go func() {
 		defer drainRoutines.Done()
-		err2 = mc.Drain(ctx)
+		err2 = mc.Drain(ctx, l)
 	}()
 
 	// one of the drain calls will have succeeded, the other one should still be blocking.
@@ -88,7 +89,7 @@ func TestManualCreditorIssueCreditsWhileDrainingFails(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		err := mc.Drain(ctx)
+		err := mc.Drain(ctx, newTestLink(t))
 		require.NoError(t, err)
 	}()
 
@@ -109,5 +110,5 @@ func TestManualCreditorDrainRespectsContext(t *testing.T) {
 
 	cancel()
 
-	require.Error(t, mc.Drain(ctx), context.Canceled.Error())
+	require.Error(t, mc.Drain(ctx, newTestLink(t)), context.Canceled.Error())
 }


### PR DESCRIPTION
Unblock pending drain during link.muxDetach.
Exit manualCreditor.Drain if the link has been detached.