### PR TITLE
Eat keep-alive frames in receiver unit tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         Linux_Go116:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.16.7'
+          go.version: '1.16.11'
         Linux_Go117:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.17'
+          go.version: '1.17.4'
 
     pool:
       vmImage: '$(vm.image)'

--- a/conn.go
+++ b/conn.go
@@ -715,6 +715,7 @@ func (c *conn) connWriter() {
 
 		// keepalive timer
 		case <-keepalive:
+			debug(3, "sending keep-alive frame")
 			_, err = c.net.Write(keepaliveFrame)
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -49,7 +49,7 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 			assert.Equal(t, ExpiryNever, ff.Target.ExpiryPolicy)
 			assert.Equal(t, uint32(300), ff.Target.Timeout)
 			return mocks.ReceiverAttach(0, linkName, 0, ModeFirst, nil)
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
@@ -219,7 +219,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 			return b, err
 		}
 		switch req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformDisposition:
 			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
@@ -693,7 +693,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 			return b, err
 		}
 		switch ff := req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformDisposition:
 			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
@@ -771,7 +771,7 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 			return b, err
 		}
 		switch req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
@@ -868,7 +868,7 @@ func TestReceiveMultiFrameMessageAborted(t *testing.T) {
 			return b, err
 		}
 		switch ff := req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformDisposition:
 			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
@@ -1069,7 +1069,7 @@ func TestReceiverDispositionBatcherFull(t *testing.T) {
 			return b, err
 		}
 		switch ff := req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformDisposition:
 			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
@@ -1137,7 +1137,7 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 			return b, err
 		}
 		switch ff := req.(type) {
-		case *frames.PerformFlow:
+		case *frames.PerformFlow, *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformDisposition:
 			if ff.Last == nil || *ff.Last == ff.First {


### PR DESCRIPTION
The unhandled frame was causing some tests to fail due to the link
detaching.
Updated waitForLink() to handle a detached link which makes it clear why
the test would fail.