### PR TITLE
fix reading application properties with ULong type

### DIFF
--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -178,7 +178,7 @@ func Unmarshal(r *buffer.Buffer, i interface{}) error {
 	case *map[Symbol]interface{}:
 		return (*mapSymbolAny)(t).Unmarshal(r)
 	case *DeliveryState:
-		type_, err := PeekMessageType(r.Bytes())
+		type_, _, err := PeekMessageType(r.Bytes())
 		if err != nil {
 			return err
 		}

--- a/internal/encoding/types.go
+++ b/internal/encoding/types.go
@@ -410,38 +410,38 @@ func (f *Filter) Unmarshal(r *buffer.Buffer) error {
 
 // peekMessageType reads the message type without
 // modifying any data.
-func PeekMessageType(buf []byte) (uint8, error) {
+func PeekMessageType(buf []byte) (uint8, uint8, error) {
 	if len(buf) < 3 {
-		return 0, errors.New("invalid message")
+		return 0, 0, errors.New("invalid message")
 	}
 
 	if buf[0] != 0 {
-		return 0, fmt.Errorf("invalid composite header %02x", buf[0])
+		return 0, 0, fmt.Errorf("invalid composite header %02x", buf[0])
 	}
 
 	// copied from readUlong to avoid allocations
 	t := AMQPType(buf[1])
 	if t == TypeCodeUlong0 {
-		return 0, nil
+		return 0, 2, nil
 	}
 
 	if t == TypeCodeSmallUlong {
 		if len(buf[2:]) == 0 {
-			return 0, errors.New("invalid ulong")
+			return 0, 0, errors.New("invalid ulong")
 		}
-		return buf[2], nil
+		return buf[2], 3, nil
 	}
 
 	if t != TypeCodeUlong {
-		return 0, fmt.Errorf("invalid type for uint32 %02x", t)
+		return 0, 0, fmt.Errorf("invalid type for uint32 %02x", t)
 	}
 
 	if len(buf[2:]) < 8 {
-		return 0, errors.New("invalid ulong")
+		return 0, 0, errors.New("invalid ulong")
 	}
 	v := binary.BigEndian.Uint64(buf[2:10])
 
-	return uint8(v), nil
+	return uint8(v), 10, nil
 }
 
 func tryReadNull(r *buffer.Buffer) bool {

--- a/message.go
+++ b/message.go
@@ -223,7 +223,7 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 	// loop, decoding sections until bytes have been consumed
 	for r.Len() > 0 {
 		// determine type
-		type_, err := encoding.PeekMessageType(r.Bytes())
+		type_, headerLength, err := encoding.PeekMessageType(r.Bytes())
 		if err != nil {
 			return err
 		}
@@ -254,7 +254,7 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 			section = &m.ApplicationProperties
 
 		case encoding.TypeCodeApplicationData:
-			r.Skip(3)
+			r.Skip(int(headerLength))
 
 			var data []byte
 			err = encoding.Unmarshal(r, &data)
@@ -276,7 +276,7 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 		}
 
 		if discardHeader {
-			r.Skip(3)
+			r.Skip(int(headerLength))
 		}
 
 		err = encoding.Unmarshal(r, section)

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,61 @@
+package amqp
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var helperTo = "ActiveMQ.DLQ"
+
+var exampleEncodedMessages = []struct {
+	label    string
+	expected Message
+	encoded  []byte
+}{
+	{
+		label: "SwiftMQ message",
+		expected: Message{
+			Format: 0,
+			Header: &MessageHeader{
+				Durable: true, Priority: 4,
+				TTL: 0, FirstAcquirer: false,
+				DeliveryCount: 0,
+			},
+			Properties: &MessageProperties{
+				MessageID: "7735812932138480283/1/12",
+				To:        &helperTo,
+			},
+			ApplicationProperties: map[string]interface{}{
+				"prop002":       "v2",
+				"prop000000003": int64(100000),
+				"prop4":         "val000004",
+				"prop01":        "val001",
+			},
+			Value: `{"id":"000000000","prop4":"val000004","prop002Code":"v2","___prop000000003":10.0,"_______prop000000003":"10.0","prop0005":100,"_________prop01":"val001"}`,
+		},
+		encoded: []byte{
+			0, 128, 0, 0, 0, 0, 0, 0, 0, 112, 192, 7, 5, 65, 80, 4, 64, 66, 67,
+			0, 128, 0, 0, 0, 0, 0, 0, 0, 115, 192, 42, 3, 161, 24, 55, 55, 51, 53, 56, 49, 50, 57, 51, 50, 49, 51, 56, 52, 56, 48, 50, 56, 51, 47, 49, 47, 49, 50, 64, 161, 12, 65, 99, 116, 105, 118, 101, 77, 81, 46, 68, 76, 81,
+			0, 128, 0, 0, 0, 0, 0, 0, 0, 116, 193, 72, 8, 161, 6, 112, 114, 111, 112, 48, 49, 161, 6, 118, 97, 108, 48, 48, 49, 161, 7, 112, 114, 111, 112, 48, 48, 50, 161, 2, 118, 50, 161, 13, 112, 114, 111, 112, 48, 48, 48, 48, 48, 48, 48, 48, 51, 129, 0, 0, 0, 0, 0, 1, 134, 160, 161, 5, 112, 114, 111, 112, 52, 161, 9, 118, 97, 108, 48, 48, 48, 48, 48, 52,
+			0, 128, 0, 0, 0, 0, 0, 0, 0, 119, 161, 153, 123, 34, 105, 100, 34, 58, 34, 48, 48, 48, 48, 48, 48, 48, 48, 48, 34, 44, 34, 112, 114, 111, 112, 52, 34, 58, 34, 118, 97, 108, 48, 48, 48, 48, 48, 52, 34, 44, 34, 112, 114, 111, 112, 48, 48, 50, 67, 111, 100, 101, 34, 58, 34, 118, 50, 34, 44, 34, 95, 95, 95, 112, 114, 111, 112, 48, 48, 48, 48, 48, 48, 48, 48, 51, 34, 58, 49, 48, 46, 48, 44, 34, 95, 95, 95, 95, 95, 95, 95, 112, 114, 111, 112, 48, 48, 48, 48, 48, 48, 48, 48, 51, 34, 58, 34, 49, 48, 46, 48, 34, 44, 34, 112, 114, 111, 112, 48, 48, 48, 53, 34, 58, 49, 48, 48, 44, 34, 95, 95, 95, 95, 95, 95, 95, 95, 95, 112, 114, 111, 112, 48, 49, 34, 58, 34, 118, 97, 108, 48, 48, 49, 34, 125,
+		},
+	},
+}
+
+func TestMessageUnmarshaling(t *testing.T) {
+	for _, tt := range exampleEncodedMessages {
+		t.Run(tt.label, func(t *testing.T) {
+			var msg Message
+
+			if err := msg.UnmarshalBinary(tt.encoded); err != nil {
+				t.Fatal("failed to decode message: ", err)
+			}
+
+			if diff := cmp.Diff(tt.expected, msg, cmpopts.IgnoreUnexported(Message{})); diff != "" {
+				t.Fatalf("decoded message differs from expected (-expected +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #119

It seems that there is a bug when decoding maps with the type encoded as ULong instead of SmallULong.
I added a test to reproduce the issue and a fix in the affected code.

I didn't have a 0 length map to test it with, so I'm not sure about the returned size for the `TypeCodeUlong0` type, please check.
Thank you again for this library!