### PR TITLE
Fixing an issue where a drain would return a nil *amqp.Error, rather than error(nil)

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -223,6 +223,7 @@ func newTestLink(t *testing.T) *link {
 			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
 			inFlight: inFlight{},
 		},
+		Detached: make(chan struct{}),
 		Session: &Session{
 			tx:   make(chan frames.FrameBody, 100),
 			done: make(chan struct{}),

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -80,12 +80,7 @@ func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	case <-drained:
 		return nil
 	case <-l.Detached:
-		// NOTE: need to be careful to not pass back a nil *Error when you're
-		// returning an `error` interface!
-		if l.detachError == nil {
-			return nil
-		}
-		return l.detachError
+		return &DetachError{RemoteError: l.detachError}
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -80,6 +80,11 @@ func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	case <-drained:
 		return nil
 	case <-l.Detached:
+		// NOTE: need to be careful to not pass back a nil *Error when you're
+		// returning an `error` interface!
+		if l.detachError == nil {
+			return nil
+		}
 		return l.detachError
 	case <-ctx.Done():
 		return ctx.Err()

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -112,3 +112,16 @@ func TestManualCreditorDrainRespectsContext(t *testing.T) {
 
 	require.Error(t, mc.Drain(ctx, newTestLink(t)), context.Canceled.Error())
 }
+
+func TestManualCreditorDrainReturnsProperNilError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+
+	mc := manualCreditor{}
+	link := newTestLink(t)
+
+	link.detachError = (*Error)(nil)
+	close(link.Detached)
+
+	require.NoError(t, mc.Drain(ctx, link))
+}


### PR DESCRIPTION
Drain() was forwarding the error from the Detach frame. When that error is nil it's of type (*encoding/amqpError), which doesn't compare against error(nil) properly.

This just makes sure we translate it before returning it.