### PR TITLE
SASL External Fix

### DIFF
--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -1351,7 +1351,7 @@ func (si *SASLInit) frameBody() {}
 func (si *SASLInit) Marshal(wr *buffer.Buffer) error {
 	return encoding.MarshalComposite(wr, encoding.TypeCodeSASLInit, []encoding.MarshalField{
 		{Value: &si.Mechanism, Omit: false},
-		{Value: &si.InitialResponse, Omit: len(si.InitialResponse) == 0},
+		{Value: &si.InitialResponse, Omit: false},
 		{Value: &si.Hostname, Omit: len(si.Hostname) == 0},
 	})
 }


### PR DESCRIPTION
This is a change related to PR [#41](https://github.com/Azure/go-amqp/pull/41). 

Back when the change in PR #41 was made (July 15, 2021), there was a types.go in the root directory that needed a change in order to support SASL External.

On Sept 8, 2021, the types.go file was removed and it's SASL-related functionality was moved to internal/frames/frames.go.

On Sept 16, 2021, PR #41 was merged but the changes to types.go were lost.

This pull request is for the missed change that now needs to be in internal/frames/frames.go.