### PR TITLE
Return *ConnectionError when connection has faulted

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -175,7 +175,11 @@ func TestClientNewSession(t *testing.T) {
 	require.NoError(t, client.Close())
 	// creating a session after the connection has been closed returns nothing
 	session, err = client.NewSession()
-	require.Equal(t, ErrConnClosed, err)
+	var connErr *ConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
+	require.Equal(t, "amqp: connection closed", connErr.Error())
 	require.Nil(t, session)
 }
 

--- a/conn.go
+++ b/conn.go
@@ -391,6 +391,7 @@ func (c *conn) close() {
 	err := c.net.Close()
 	switch {
 	// conn.err already set
+	// TODO: err info is lost, log it?
 	case c.err != nil:
 
 	// conn.err not set and c.net.Close() returned a non-nil error

--- a/conn.go
+++ b/conn.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"net"
 	"net/url"
@@ -360,7 +359,13 @@ func (c *conn) Start() error {
 func (c *conn) Close() error {
 	c.closeMuxOnce.Do(func() { close(c.closeMux) })
 	err := c.Err()
-	if err == ErrConnClosed {
+	var connErr *ConnectionError
+	if errors.As(err, &connErr) && connErr.inner == nil {
+		// an empty ConnectionError means the connection was closed by the caller
+		// or as requested by the peer and no error was provided in the close frame.
+		// TODO: unclear if returning an error here is valuable.  it's not really
+		// actionable and we have to use this funky heuristic to skip returning an
+		// error if closing was clean.
 		return nil
 	}
 	return err
@@ -394,7 +399,6 @@ func (c *conn) close() {
 
 	// no errors
 	default:
-		c.err = ErrConnClosed
 	}
 
 	// check rxDone after closing net, otherwise may block
@@ -407,7 +411,7 @@ func (c *conn) close() {
 func (c *conn) Err() error {
 	c.errMu.Lock()
 	defer c.errMu.Unlock()
-	return c.err
+	return &ConnectionError{inner: c.err}
 }
 
 // mux is started in it's own goroutine after initial connection establishment.
@@ -454,8 +458,6 @@ func (c *conn) mux() {
 			case *frames.PerformClose:
 				if body.Error != nil {
 					c.err = body.Error
-				} else {
-					c.err = ErrConnClosed
 				}
 				return
 
@@ -655,7 +657,7 @@ func (c *conn) connReader() {
 		// parse the frame
 		b, ok := buf.Next(bodySize)
 		if !ok {
-			c.connErr <- io.EOF
+			c.connErr <- fmt.Errorf("buffer EOF; requested bytes: %d, actual size: %d", bodySize, buf.Len())
 			return
 		}
 

--- a/conn.go
+++ b/conn.go
@@ -363,9 +363,6 @@ func (c *conn) Close() error {
 	if errors.As(err, &connErr) && connErr.inner == nil {
 		// an empty ConnectionError means the connection was closed by the caller
 		// or as requested by the peer and no error was provided in the close frame.
-		// TODO: unclear if returning an error here is valuable.  it's not really
-		// actionable and we have to use this funky heuristic to skip returning an
-		// error if closing was clean.
 		return nil
 	}
 	return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -358,11 +358,11 @@ func TestServerSideClose(t *testing.T) {
 	// wait a bit for connReader to read from the mock
 	time.Sleep(100 * time.Millisecond)
 	err = conn.Close()
-	var ee *Error
-	if !errors.As(err, &ee) {
+	var connErr *ConnectionError
+	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	require.Equal(t, encoding.ErrorCondition("Close"), ee.Condition)
+	require.Equal(t, "*Error{Condition: Close, Description: mock server error, Info: map[]}", connErr.Error())
 }
 
 func TestKeepAlives(t *testing.T) {
@@ -408,7 +408,11 @@ func TestConnReaderError(t *testing.T) {
 	netConn.ReadErr <- errors.New("failed")
 	// wait a bit for the connReader goroutine to read from the mock
 	time.Sleep(100 * time.Millisecond)
-	require.Error(t, conn.Close())
+	err = conn.Close()
+	var connErr *ConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
 }
 
 func TestConnWriterError(t *testing.T) {
@@ -423,5 +427,9 @@ func TestConnWriterError(t *testing.T) {
 	}))
 	// wait a bit for connReader to read from the mock
 	time.Sleep(100 * time.Millisecond)
-	require.Error(t, conn.Close())
+	err = conn.Close()
+	var connErr *ConnectionError
+	if !errors.As(err, &connErr) {
+		t.Fatalf("unexpected error type %T", err)
+	}
 }

--- a/errors.go
+++ b/errors.go
@@ -61,11 +61,6 @@ func (e *DetachError) Error() string {
 
 // Errors
 var (
-	// ErrConnClosed is propagated to Session and Senders/Receivers
-	// when Client.Close() is called or the server closes the connection
-	// without specifying an error.
-	ErrConnClosed = errors.New("amqp: connection closed")
-
 	// ErrSessionClosed is propagated to Sender/Receivers
 	// when Session.Close() is called.
 	ErrSessionClosed = errors.New("amqp: session closed")
@@ -74,6 +69,19 @@ var (
 	// Sender.Close() or Receiver.Close() are called.
 	ErrLinkClosed = errors.New("amqp: link closed")
 )
+
+// ConnectionError is propagated to Session and Senders/Receivers
+// when the connection has been closed or is no longer functional.
+type ConnectionError struct {
+	inner error
+}
+
+func (c *ConnectionError) Error() string {
+	if c.inner == nil {
+		return "amqp: connection closed"
+	}
+	return c.inner.Error()
+}
 
 // Default link options
 const (

--- a/integration_test.go
+++ b/integration_test.go
@@ -708,8 +708,9 @@ func TestIntegrationClose(t *testing.T) {
 		}
 
 		msg, err := receiver.Receive(context.Background())
-		if err != amqp.ErrConnClosed {
-			t.Fatalf("Expected ErrConnClosed from receiver.Receiver, got: %+v", err)
+		var connErr *amqp.ConnectionError
+		if !errors.As(err, &connErr) {
+			t.Fatalf("unexpected error type %T", err)
 			return
 		}
 		if msg != nil {


### PR DESCRIPTION
Errors reading from/writing to the underlying net.Conn were being
propagated to the sender/receiver APIs, making them hard to identify.
Now, when the connection is no longer functional, a ConnectionError
instance is returned.  If the connection died due to a read/write error,
the ConnectionError will contain this information.
Removed ErrConnClosed as it's too simplistic and can't capture the
reason why the connection was closed.