### PR TITLE
Remove ErrTimeout type

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -866,7 +866,7 @@ func (c *conn) readProtoHeader() (protoHeader, error) {
 	case fr := <-c.rxFrame:
 		return p, fmt.Errorf("readProtoHeader: unexpected frame %#v", fr)
 	case <-deadline:
-		return p, ErrTimeout
+		return p, errors.New("amqp: timeout waiting for response")
 	}
 }
 
@@ -1035,7 +1035,7 @@ func (c *conn) readFrame() (frames.Frame, error) {
 	case p := <-c.rxProto:
 		return fr, fmt.Errorf("unexpected protocol header %#v", p)
 	case <-deadline:
-		return fr, ErrTimeout
+		return fr, errors.New("amqp: timeout waiting for response")
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -61,8 +61,6 @@ func (e *DetachError) Error() string {
 
 // Errors
 var (
-	ErrTimeout = errors.New("amqp: timeout waiting for response")
-
 	// ErrConnClosed is propagated to Session and Senders/Receivers
 	// when Client.Close() is called or the server closes the connection
 	// without specifying an error.


### PR DESCRIPTION
It's only used in a few edge cases during protocol negotiation and you
can't respond to it programmatically.