### PR TITLE
Fix link panic when l.receiver == nil

### DIFF
--- a/link.go
+++ b/link.go
@@ -679,7 +679,7 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		if !fr.Echo {
 			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
 			// we signal whomever is waiting (the service has seen and acknowledged our drain)
-			if fr.Drain && l.receiver.manualCreditor != nil {
+			if fr.Drain && l.receiver != nil && l.receiver.manualCreditor != nil {
 				l.linkCredit = 0 // we have no active credits at this point.
 				l.receiver.manualCreditor.EndDrain()
 			}


### PR DESCRIPTION
It fixes `nil` panic for the `l.receiver`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x6adca1]

goroutine 11352 [running]:
github.com/Azure/go-amqp.(*link).muxHandleFrame(0xc0001761e0, {0x7dbbe0, 0xc000402c80})
        /home/tymon/go/pkg/mod/github.com/!azure/go-amqp@v0.17.4/link.go:682 +0x501
github.com/Azure/go-amqp.(*link).mux(0xc0001761e0)
        /home/tymon/go/pkg/mod/github.com/!azure/go-amqp@v0.17.4/link.go:375 +0x1d3
created by github.com/Azure/go-amqp.attachLink
        /home/tymon/go/pkg/mod/github.com/!azure/go-amqp@v0.17.4/link.go:256 +0x809
exit status 2
```