### PR TITLE
Add retries when writing to net.Conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
 * Disambiguate error message for distinct cases where a session wasn't found for the specified remote channel.
 * Removed `link.Paused` as it didn't add much value and was broken in some cases.
+* Added retries when writes to the underlying `net.Conn` fail.

--- a/conn.go
+++ b/conn.go
@@ -795,8 +795,8 @@ func (c *conn) netWriteWithRetry(b []byte) (int, error) {
 			// slice off the portion that was written
 			b = b[written:]
 		}
-		// exponential back-off starting at 100ms
-		delay := (100 * time.Millisecond) * time.Duration(math.Pow(2, float64(i)))
+		// exponential back-off starting at 10ms
+		delay := (10 * time.Millisecond) * time.Duration(math.Pow(2, float64(i)))
 		debug(3, "netWriteWithRetry: %v; sleep for %s", err, delay)
 		time.Sleep(delay)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -377,6 +377,8 @@ func TestKeepAlives(t *testing.T) {
 		case *frames.PerformOpen:
 			// specify small idle timeout so we receive a lot of keep-alives
 			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{ContainerID: "container", IdleTimeout: 100 * time.Millisecond})
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *mocks.KeepAlive:
 			keepAlives <- struct{}{}
 			return nil, nil

--- a/internal/mocks/net_conn.go
+++ b/internal/mocks/net_conn.go
@@ -17,8 +17,9 @@ import (
 // Return a non-nil error to simulate a write error.
 func NewNetConn(resp func(frames.FrameBody) ([]byte, error)) *NetConn {
 	return &NetConn{
-		ReadErr: make(chan error),
-		resp:    resp,
+		ReadErr:  make(chan error),
+		WriteErr: func() error { return nil },
+		resp:     resp,
 		// during shutdown, connReader can close before connWriter as they both
 		// both return on c.Done being closed, so there is some non-determinism
 		// here.  this means that sometimes writes can still happen but there's
@@ -41,9 +42,9 @@ type NetConn struct {
 	ReadErr chan error
 
 	// WriteErr is used to simulate a connWriter error.
-	// The error set here is returned from the call to NetConn.Write.
-	// After the error is sent, its value is set to nil.
-	WriteErr error
+	// The func here is invoked in the call to NetConn.Write.
+	// If return value is non-nil, it's returned instead.
+	WriteErr func() error
 
 	resp      func(frames.FrameBody) ([]byte, error)
 	readDL    *time.Timer
@@ -120,9 +121,8 @@ func (n *NetConn) Write(b []byte) (int, error) {
 		// not closed yet
 	}
 
-	if n.WriteErr != nil {
-		defer func() { n.WriteErr = nil }()
-		return 0, n.WriteErr
+	if err := n.WriteErr(); err != nil {
+		return 0, err
 	}
 
 	frame, err := decodeFrame(b)

--- a/sender_test.go
+++ b/sender_test.go
@@ -50,6 +50,8 @@ func TestSenderMethodsNoSend(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -222,6 +224,8 @@ func TestSenderAttachError(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -455,6 +459,8 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -585,6 +591,8 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -688,6 +696,8 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 				IdleTimeout:  time.Minute,
 				MaxFrameSize: maxReceiverFrameSize, // really small max frame size
 			})
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -798,8 +808,10 @@ func TestSenderConnWriterError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snd)
 
+	sendInitialFlowFrame(t, netConn, 0, 100)
+
 	// simulate some connWriter error
-	netConn.WriteErr = errors.New("failed")
+	netConn.WriteErr = func() error { return errors.New("failed") }
 
 	err = snd.Send(context.Background(), NewMessage([]byte("failed")))
 	var connErr *ConnectionError

--- a/session_test.go
+++ b/session_test.go
@@ -20,6 +20,8 @@ func TestSessionClose(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			b, err := mocks.PerformBegin(uint16(channelNum))
 			if err != nil {
@@ -67,6 +69,8 @@ func TestSessionServerClose(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -105,6 +109,8 @@ func TestSessionCloseTimeout(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -181,6 +187,8 @@ func TestSessionNewReceiverBatchingOneCredit(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -222,6 +230,8 @@ func TestSessionNewReceiverBatchingEnabled(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -263,6 +273,8 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -323,6 +335,8 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:
@@ -466,6 +480,8 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformFlow:
@@ -525,6 +541,8 @@ func TestSessionInvalidAttachDeadlock(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return mocks.PerformOpen("container")
+		case *frames.PerformClose:
+			return mocks.PerformClose(nil)
 		case *frames.PerformBegin:
 			return mocks.PerformBegin(0)
 		case *frames.PerformEnd:


### PR DESCRIPTION
Retry with exponential back-off when writing to the network fails.  The
initial delay time is 100ms.
Capture write errors when sending the close performative.
Fixed up some misbehaving tests that were uncovered due to the above
changes.
Updated Go version to 1.13 as there are some features used that first
appeared in that version.