### PR TITLE
Remove link.Paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
 * Disambiguate error message for distinct cases where a session wasn't found for the specified remote channel.
+* Removed `link.Paused` as it didn't add much value and was broken in some cases.

--- a/link_test.go
+++ b/link_test.go
@@ -29,7 +29,6 @@ func TestLinkFlowForSender(t *testing.T) {
 
 	// and flow goes through the non-manual credit path
 	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
-	require.EqualValues(t, 0, l.Paused, "Link not paused")
 
 	// if we have link credit we can enable outgoing transfers
 	l.linkCredit = 1
@@ -37,7 +36,6 @@ func TestLinkFlowForSender(t *testing.T) {
 
 	require.True(t, ok, "no errors, should continue to process")
 	require.True(t, enableOutgoingTransfers, "outgoing transfers needed for senders")
-	require.EqualValues(t, 0, l.Paused, "Link not paused")
 }
 
 func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
@@ -51,7 +49,6 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 
 	// and flow goes through the non-manual credit path
 	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
-	require.EqualValues(t, 0, l.Paused, "Link not paused")
 
 	// we've consumed half of the maximum credit we're allowed to have - reflow!
 	l.receiver.maxCredit = 2
@@ -62,7 +59,6 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 
 	require.True(t, ok, "no errors, should continue to process")
 	require.False(t, enableOutgoingTransfers, "outgoing transfers only needed for senders")
-	require.EqualValues(t, 0, l.Paused, "Link not paused")
 
 	// flow happens immmediately in 'mux'
 	txFrame := <-l.Session.tx
@@ -88,7 +84,6 @@ func TestLinkFlowWithZeroCredits(t *testing.T) {
 
 	// and flow goes through the non-manual credit path
 	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
-	require.EqualValues(t, 0, l.Paused, "Link not paused...yet")
 
 	l.receiver.maxCredit = 2
 	l.linkCredit = 0
@@ -101,7 +96,6 @@ func TestLinkFlowWithZeroCredits(t *testing.T) {
 
 	require.True(t, ok)
 	require.False(t, enableOutgoingTransfers)
-	require.EqualValues(t, uint32(1), l.Paused, "Link is paused because credits are zero")
 }
 
 func TestLinkFlowDrain(t *testing.T) {

--- a/receiver.go
+++ b/receiver.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Azure/go-amqp/internal/encoding"
@@ -47,11 +46,9 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 // one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
 // When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Prefetched(ctx context.Context) (*Message, error) {
-	if atomic.LoadUint32(&r.link.Paused) == 1 {
-		select {
-		case r.link.ReceiverReady <- struct{}{}:
-		default:
-		}
+	select {
+	case r.link.ReceiverReady <- struct{}{}:
+	default:
 	}
 
 	// non-blocking receive to ensure buffered messages are


### PR DESCRIPTION
Asking the link mux to evaluate its state is fine in any case.
There was a corner case where this would incorrectly be set.  If a
transfer frame is receiving from link.muxFlow() the link wouldn't be
marked as paused even though the credit was consumed.  Fixing this is
complex and doesn't make sense for an unnecessary feature.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
