### PR TITLE
Clean up public surface area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * The following methods now require a `context.Context` as their first parameter.
   * `Client.NewSession()`, `Session.NewReceiver()`, `Session.NewSender()`
 * Removed `context.Context` parameter from method `Receiver.Prefetched()`.
+* The following type names had the prefix `AMQP` removed to prevent stuttering.
+  * `AMQPAddress`, `AMQPMessageID`, `AMQPSymbol`, `AMQPSequenceNumber`, `AMQPBinary`
+* Various `Default*` constants are no longer exported.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.

--- a/client.go
+++ b/client.go
@@ -128,12 +128,6 @@ func (c *Client) NewSession(ctx context.Context, opts ...SessionOption) (*Sessio
 	return s, nil
 }
 
-// Default session options
-const (
-	DefaultMaxLinks = 4294967296
-	DefaultWindow   = 1000
-)
-
 // SessionOption is an function for configuring an AMQP session.
 type SessionOption func(*Session) error
 

--- a/conn.go
+++ b/conn.go
@@ -20,9 +20,9 @@ import (
 
 // Default connection options
 const (
-	DefaultIdleTimeout  = 1 * time.Minute
-	DefaultMaxFrameSize = 65536
-	DefaultMaxSessions  = 65536
+	defaultIdleTimeout  = 1 * time.Minute
+	defaultMaxFrameSize = 65536
+	defaultMaxSessions  = 65536
 )
 
 // ConnOption is a function for configuring an AMQP connection.
@@ -291,10 +291,10 @@ func dialConn(addr string, opts ...ConnOption) (*conn, error) {
 func newConn(netConn net.Conn, opts ...ConnOption) (*conn, error) {
 	c := &conn{
 		net:              netConn,
-		maxFrameSize:     DefaultMaxFrameSize,
-		PeerMaxFrameSize: DefaultMaxFrameSize,
-		channelMax:       DefaultMaxSessions - 1, // -1 because channel-max starts at zero
-		idleTimeout:      DefaultIdleTimeout,
+		maxFrameSize:     defaultMaxFrameSize,
+		PeerMaxFrameSize: defaultMaxFrameSize,
+		channelMax:       defaultMaxSessions - 1, // -1 because channel-max starts at zero
+		idleTimeout:      defaultIdleTimeout,
 		containerID:      randString(40),
 		Done:             make(chan struct{}),
 		connErr:          make(chan error, 2), // buffered to ensure connReader/Writer won't leak

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/Azure/go-amqp/internal/encoding"
 )
@@ -82,10 +81,3 @@ func (c *ConnectionError) Error() string {
 	}
 	return c.inner.Error()
 }
-
-// Default link options
-const (
-	DefaultLinkCredit      = 1
-	DefaultLinkBatching    = false
-	DefaultLinkBatchMaxAge = 5 * time.Second
-)

--- a/link_options.go
+++ b/link_options.go
@@ -310,15 +310,15 @@ func LinkTargetExpiryPolicy(p ExpiryPolicy) LinkOption {
 	}
 }
 
-// LinkTargetTimeout sets the duration that an expiring target will be retained.
+// LinkTargetTimeout sets the number of seconds that an expiring target will be retained.
 //
 // Default: 0.
-func LinkTargetTimeout(timeout uint32) LinkOption {
+func LinkTargetTimeout(seconds uint32) LinkOption {
 	return func(l *link) error {
 		if l.Target == nil {
 			l.Target = new(frames.Target)
 		}
-		l.Target.Timeout = timeout
+		l.Target.Timeout = seconds
 
 		return nil
 	}

--- a/message.go
+++ b/message.go
@@ -357,7 +357,7 @@ func (h *MessageHeader) Unmarshal(r *buffer.Buffer) error {
 type (
 	// AMQPAddress corresponds to the 'address' type in the AMQP spec.
 	// <type name="address-string" class="restricted" source="string" provides="address"/>
-	AMQPAddress = string
+	Address = string
 
 	// AMQPMessageID corresponds to the 'message-id' type in the AMQP spec. Internally it can
 	// be one of the following:
@@ -365,21 +365,21 @@ type (
 	// - amqp.UUID: <type name="message-id-uuid" class="restricted" source="uuid" provides="message-id"/>
 	// - []byte:    <type name="message-id-binary" class="restricted" source="binary" provides="message-id"/>
 	// - string:    <type name="message-id-string" class="restricted" source="string" provides="message-id"/>
-	AMQPMessageID = interface{}
+	MessageID = interface{}
 
 	// AMQPSymbol corresponds to the 'symbol' type in the AMQP spec.
 	// <type name="symbol" class="primitive"/>
 	// And either:
 	// - variable-width, 1 byte size	up to 2^8 - 1 seven bit ASCII characters representing a symbolic value
 	// - variable-width, 4 byte size	up to 2^32 - 1 seven bit ASCII characters representing a symbolic value
-	AMQPSymbol = string
+	Symbol = string
 
 	// AMQPSequenceNumber corresponds to the `sequence-no` type in the AMQP spec.
 	// <type name="sequence-no" class="restricted" source="uint"/>
-	AMQPSequenceNumber = uint32
+	SequenceNumber = uint32
 
 	// AMQPBinary corresponds to the `binary` type in the AMQP spec.
-	AMQPBinary = []byte
+	Binary = []byte
 )
 
 /*
@@ -408,25 +408,25 @@ type MessageProperties struct {
 	// such a way that it is assured to be globally unique. A broker MAY discard a
 	// message as a duplicate if the value of the message-id matches that of a
 	// previously received message sent to the same node.
-	MessageID AMQPMessageID // uint64, UUID, []byte, or string
+	MessageID MessageID // uint64, UUID, []byte, or string
 
 	// The identity of the user responsible for producing the message.
 	// The client sets this value, and it MAY be authenticated by intermediaries.
-	UserID AMQPBinary
+	UserID Binary
 
 	// The to field identifies the node that is the intended destination of the message.
 	// On any given transfer this might not be the node at the receiving end of the link.
-	To *AMQPAddress
+	To *Address
 
 	// A common field for summary information about the message content and purpose.
 	Subject *string
 
 	// The address of the node to send replies to.
-	ReplyTo *AMQPAddress
+	ReplyTo *Address
 
 	// This is a client-specific id that can be used to mark or identify messages
 	// between clients.
-	CorrelationID AMQPMessageID // uint64, UUID, []byte, or string
+	CorrelationID MessageID // uint64, UUID, []byte, or string
 
 	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
 	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
@@ -439,7 +439,7 @@ type MessageProperties struct {
 	//
 	// When using an application-data section with a section code other than data,
 	// content-type SHOULD NOT be set.
-	ContentType *AMQPSymbol
+	ContentType *Symbol
 
 	// The content-encoding property is used as a modifier to the content-type.
 	// When present, its value indicates what additional content encodings have been
@@ -464,7 +464,7 @@ type MessageProperties struct {
 	//
 	// Implementations SHOULD NOT specify multiple content-encoding values except as to
 	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
-	ContentEncoding *AMQPSymbol
+	ContentEncoding *Symbol
 
 	// An absolute time when this message is considered to be expired.
 	AbsoluteExpiryTime *time.Time
@@ -476,7 +476,7 @@ type MessageProperties struct {
 	GroupID *string
 
 	// The relative position of this message within its group.
-	GroupSequence *AMQPSequenceNumber // RFC-1982 sequence number
+	GroupSequence *SequenceNumber // RFC-1982 sequence number
 
 	// This is a client-specific id that is used so that client can send replies to this
 	// message to a specific group.

--- a/session.go
+++ b/session.go
@@ -5,10 +5,24 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Azure/go-amqp/internal/bitmap"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
+)
+
+// Default session options
+const (
+	defaultMaxLinks = 4294967296
+	defaultWindow   = 1000
+)
+
+// Default link options
+const (
+	defaultLinkCredit      = 1
+	defaultLinkBatching    = false
+	defaultLinkBatchMaxAge = 5 * time.Second
 )
 
 // Session is an AMQP session.
@@ -46,9 +60,9 @@ func newSession(c *conn, channel uint16) *Session {
 		rx:               make(chan frames.Frame),
 		tx:               make(chan frames.FrameBody),
 		txTransfer:       make(chan *frames.PerformTransfer),
-		incomingWindow:   DefaultWindow,
-		outgoingWindow:   DefaultWindow,
-		handleMax:        DefaultMaxLinks - 1,
+		incomingWindow:   defaultWindow,
+		outgoingWindow:   defaultWindow,
+		handleMax:        defaultMaxLinks - 1,
 		allocateHandle:   make(chan *link),
 		deallocateHandle: make(chan *link),
 		close:            make(chan struct{}),
@@ -87,9 +101,9 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 // NewReceiver opens a new receiver link on the session.
 func (s *Session) NewReceiver(ctx context.Context, opts ...LinkOption) (*Receiver, error) {
 	r := &Receiver{
-		batching:    DefaultLinkBatching,
-		batchMaxAge: DefaultLinkBatchMaxAge,
-		maxCredit:   DefaultLinkCredit,
+		batching:    defaultLinkBatching,
+		batchMaxAge: defaultLinkBatchMaxAge,
+		maxCredit:   defaultLinkCredit,
 	}
 
 	l, err := attachLink(ctx, s, r, opts)

--- a/session_test.go
+++ b/session_test.go
@@ -477,10 +477,10 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 			if id := tt.NextOutgoingID; id != 0 {
 				return nil, fmt.Errorf("unexpected NextOutgoingID %d", id)
 			}
-			if w := tt.IncomingWindow; w != DefaultWindow {
+			if w := tt.IncomingWindow; w != defaultWindow {
 				return nil, fmt.Errorf("unexpected IncomingWindow %d", w)
 			}
-			if w := tt.OutgoingWindow; w != DefaultWindow {
+			if w := tt.OutgoingWindow; w != defaultWindow {
 				return nil, fmt.Errorf("unexpected OutgoingWindow %d", w)
 			}
 			return nil, nil


### PR DESCRIPTION
Fixed some stuttering type names.
Default constants are no longer exported.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
