### PR TITLE
Receiver.ModifyMessage takes an options struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The following type names had the prefix `AMQP` removed to prevent stuttering.
   * `AMQPAddress`, `AMQPMessageID`, `AMQPSymbol`, `AMQPSequenceNumber`, `AMQPBinary`
 * Various `Default*` constants are no longer exported.
+* The args to `Receiver.ModifyMessage()` have changed.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.

--- a/receiver.go
+++ b/receiver.go
@@ -120,26 +120,35 @@ func (r *Receiver) ReleaseMessage(ctx context.Context, msg *Message) error {
 
 // Modify notifies the server that the message was not acted upon
 // and should be modifed.
-//
-// deliveryFailed indicates that the server must consider this and
-// unsuccessful delivery attempt and increment the delivery count.
-//
-// undeliverableHere indicates that the server must not redeliver
-// the message to this link.
-//
-// messageAnnotations is an optional annotation map to be merged
-// with the existing message annotations, overwriting existing keys
-// if necessary.
-func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, deliveryFailed, undeliverableHere bool, messageAnnotations Annotations) error {
+func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, options *ModifyMessageOptions) error {
 	if !msg.shouldSendDisposition() {
 		return nil
 	}
+	if options == nil {
+		options = &ModifyMessageOptions{}
+	}
 	return r.messageDisposition(ctx,
 		msg, &encoding.StateModified{
-			DeliveryFailed:     deliveryFailed,
-			UndeliverableHere:  undeliverableHere,
-			MessageAnnotations: messageAnnotations,
+			DeliveryFailed:     options.DeliveryFailed,
+			UndeliverableHere:  options.UndeliverableHere,
+			MessageAnnotations: options.Annotations,
 		})
+}
+
+// ModifyMessageOptions contains the optional parameters to ModifyMessage.
+type ModifyMessageOptions struct {
+	// DeliveryFailed indicates that the server must consider this and
+	// unsuccessful delivery attempt and increment the delivery count.
+	DeliveryFailed bool
+
+	// UndeliverableHere indicates that the server must not redeliver
+	// the message to this link.
+	UndeliverableHere bool
+
+	// Annotations is an optional annotation map to be merged
+	// with the existing message annotations, overwriting existing keys
+	// if necessary.
+	Annotations Annotations
 }
 
 // Address returns the link's address.

--- a/receiver.go
+++ b/receiver.go
@@ -118,8 +118,7 @@ func (r *Receiver) ReleaseMessage(ctx context.Context, msg *Message) error {
 	return r.messageDisposition(ctx, msg, &encoding.StateReleased{})
 }
 
-// Modify notifies the server that the message was not acted upon
-// and should be modifed.
+// Modify notifies the server that the message was not acted upon and should be modifed.
 func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, options *ModifyMessageOptions) error {
 	if !msg.shouldSendDisposition() {
 		return nil
@@ -137,7 +136,7 @@ func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, options *Mod
 
 // ModifyMessageOptions contains the optional parameters to ModifyMessage.
 type ModifyMessageOptions struct {
-	// DeliveryFailed indicates that the server must consider this and
+	// DeliveryFailed indicates that the server must consider this an
 	// unsuccessful delivery attempt and increment the delivery count.
 	DeliveryFailed bool
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -693,8 +693,11 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-	err = r.ModifyMessage(ctx, msg, false, true, Annotations{
-		"some": "value",
+	err = r.ModifyMessage(ctx, msg, &ModifyMessageOptions{
+		UndeliverableHere: true,
+		Annotations: Annotations{
+			"some": "value",
+		},
 	})
 	cancel()
 	require.NoError(t, err)


### PR DESCRIPTION
Moved all optional parameters to ModifyMessageOptions type.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
