### PR TITLE
Replace varadic config for Sender and Receiver with struct config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `ConnectionError` type that's returned when a connection is no longer functional.
 * Added `LinkTargetCapabilities()` option to specify desired target capabilities.
 * Added `SASLType` used when configuring the SASL authentication mechanism.
+* Added `Ptr()` method to `SenderSettleMode` and `ReceiverSettleMode` types.
 
 ### Breaking Changes
 * Removed `ErrConnClosed` and `ErrTimeout` sentinel error types.
@@ -16,11 +17,14 @@
   * `AMQPAddress`, `AMQPMessageID`, `AMQPSymbol`, `AMQPSequenceNumber`, `AMQPBinary`
 * Various `Default*` constants are no longer exported.
 * The args to `Receiver.ModifyMessage()` have changed.
-* The "variadic config" pattern for `Client` and `Session` constructors has been replaced with a struct-based config.
-  * This removes the `ConnOption` and `SessionOption` types and all of the associated configuration funcs.
+* The "variadic config" pattern for `Client`, `Session`, `Sender`, and `Receiver` constructors has been replaced with a struct-based config.
+  * This removes the `ConnOption`, `SessionOption`, and `LinkOption` types and all of the associated configuration funcs.
+  * The sender and receiver specific link options have been moved into their respective options types.
   * The `ConnTLS()` option was removed as part of this change.
 * The `Dial()` and `New()` constructors now require an `*ConnOptions` parameter.
 * `Client.NewSession()` now requires a `*SessionOptions` parameter.
+* `Session.NewSender()` now requires `target` address and `*SenderOptions` parameters.
+* `Session.NewReceiver()` now requires `source` address and `*ReceiverOptions` parameters.
 * The various SASL configuration funcs have been slightly renamed.
 
 ### Bugs Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Removed `ErrConnClosed` and `ErrTimeout` sentinel error types.
 * The following methods now require a `context.Context` as their first parameter.
   * `Client.NewSession()`, `Session.NewReceiver()`, `Session.NewSender()`
-* Removed `context.Context` parameter from method `Receiver.Prefetched()`.
+* Removed `context.Context` parameter and `error` return from method `Receiver.Prefetched()`.
 * The following type names had the prefix `AMQP` removed to prevent stuttering.
   * `AMQPAddress`, `AMQPMessageID`, `AMQPSymbol`, `AMQPSequenceNumber`, `AMQPBinary`
 * Various `Default*` constants are no longer exported.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,14 +31,14 @@ func BenchmarkSimple(b *testing.B) {
 	targetName := fmt.Sprintf("BenchmarkSimple %d", rand.Uint64())
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	sender, err := session.NewSender(ctx, amqp.LinkTargetAddress(targetName))
+	sender, err := session.NewSender(ctx, targetName, nil)
 	cancel()
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	receiver, err := session.NewReceiver(ctx, amqp.LinkSourceAddress(targetName))
+	receiver, err := session.NewReceiver(ctx, targetName, nil)
 	cancel()
 	if err != nil {
 		b.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 	// Send a message
 	{
 		// Create a sender
-		sender, err := session.NewSender(ctx, amqp.LinkTargetAddress("/queue-name"))
+		sender, err := session.NewSender(ctx, "/queue-name", nil)
 		if err != nil {
 			log.Fatal("Creating sender link:", err)
 		}
@@ -50,11 +50,9 @@ func Example() {
 	// Continuously read messages
 	{
 		// Create a receiver
-		receiver, err := session.NewReceiver(
-			ctx,
-			amqp.LinkSourceAddress("/queue-name"),
-			amqp.LinkCredit(10),
-		)
+		receiver, err := session.NewReceiver(ctx, "/queue-name", &amqp.ReceiverOptions{
+			Credit: 10,
+		})
 		if err != nil {
 			log.Fatal("Creating receiver link:", err)
 		}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -32,7 +32,9 @@ func fuzzConn(data []byte) int {
 		return 0
 	}
 
-	r, err := s.NewReceiver(context.Background(), LinkSourceAddress("source"), LinkCredit(2))
+	r, err := s.NewReceiver(context.Background(), "source", &ReceiverOptions{
+		Credit: 2,
+	})
 	if err != nil {
 		return 0
 	}
@@ -68,7 +70,7 @@ func fuzzConn(data []byte) int {
 		return 0
 	}
 
-	sender, err := s.NewSender(context.Background(), LinkTargetAddress("source"), LinkCredit(2))
+	sender, err := s.NewSender(context.Background(), "source", nil)
 	if err != nil {
 		return 0
 	}

--- a/internal/encoding/types.go
+++ b/internal/encoding/types.go
@@ -229,6 +229,10 @@ const (
 // SenderSettleMode specifies how the sender will settle messages.
 type SenderSettleMode uint8
 
+func (m SenderSettleMode) Ptr() *SenderSettleMode {
+	return &m
+}
+
 func (m *SenderSettleMode) String() string {
 	if m == nil {
 		return "<nil>"
@@ -272,6 +276,10 @@ const (
 
 // ReceiverSettleMode specifies how the receiver will settle messages.
 type ReceiverSettleMode uint8
+
+func (m ReceiverSettleMode) Ptr() *ReceiverSettleMode {
+	return &m
+}
 
 func (m *ReceiverSettleMode) String() string {
 	if m == nil {

--- a/link.go
+++ b/link.go
@@ -71,41 +71,163 @@ type link struct {
 	msg                   Message             // current message being decoded
 }
 
-func newLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
+// newSendingLinkd creates a new sending link and attaches it to the session
+func newSendingLink(target string, s *Session, opts *SenderOptions) (*link, error) {
 	l := &link{
-		Key:                      linkKey{randString(40), encoding.Role(r != nil)},
+		Key:                      linkKey{randString(40), encoding.RoleSender},
+		Session:                  s,
+		close:                    make(chan struct{}),
+		Detached:                 make(chan struct{}),
+		ReceiverReady:            make(chan struct{}, 1),
+		detachOnDispositionError: true,
+		Target:                   &frames.Target{Address: target},
+		Source:                   new(frames.Source),
+	}
+
+	if opts == nil {
+		return l, nil
+	}
+
+	for _, v := range opts.Capabilities {
+		l.Source.Capabilities = append(l.Source.Capabilities, encoding.Symbol(v))
+	}
+	if opts.Durability > DurabilityUnsettledState {
+		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
+	}
+	l.Source.Durable = opts.Durability
+	if opts.DynamicAddress {
+		l.Target.Address = ""
+		l.dynamicAddr = opts.DynamicAddress
+	}
+	if opts.ExpiryPolicy != "" {
+		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
+			return nil, err
+		}
+		l.Source.ExpiryPolicy = opts.ExpiryPolicy
+	}
+	l.Source.Timeout = opts.ExpiryTimeout
+	l.detachOnDispositionError = !opts.IgnoreDispositionErrors
+	if opts.Name != "" {
+		l.Key.name = opts.Name
+	}
+	if opts.Properties != nil {
+		l.properties = make(map[encoding.Symbol]interface{})
+		for k, v := range opts.Properties {
+			if k == "" {
+				return nil, errors.New("link property key must not be empty")
+			}
+			l.properties[encoding.Symbol(k)] = v
+		}
+	}
+	if opts.RequestedReceiverSettleMode != nil {
+		if rsm := *opts.RequestedReceiverSettleMode; rsm > ModeSecond {
+			return nil, fmt.Errorf("invalid RequestedReceiverSettleMode %d", rsm)
+		}
+		l.ReceiverSettleMode = opts.RequestedReceiverSettleMode
+	}
+	if opts.SettlementMode != nil {
+		if ssm := *opts.SettlementMode; ssm > ModeMixed {
+			return nil, fmt.Errorf("invalid SettlementMode %d", ssm)
+		}
+		l.SenderSettleMode = opts.SettlementMode
+	}
+	l.Source.Address = opts.SourceAddress
+	return l, nil
+}
+
+func newReceivingLink(source string, s *Session, r *Receiver, opts *ReceiverOptions) (*link, error) {
+	l := &link{
+		Key:                      linkKey{randString(40), encoding.RoleReceiver},
 		Session:                  s,
 		receiver:                 r,
 		close:                    make(chan struct{}),
 		Detached:                 make(chan struct{}),
 		ReceiverReady:            make(chan struct{}, 1),
 		detachOnDispositionError: true,
+		Source:                   &frames.Source{Address: source},
+		Target:                   new(frames.Target),
 	}
 
-	// configure options
-	for _, o := range opts {
-		err := o(l)
-		if err != nil {
+	if opts == nil {
+		return l, nil
+	}
+
+	l.receiver.batching = opts.Batching
+	if opts.BatchMaxAge > 0 {
+		l.receiver.batchMaxAge = opts.BatchMaxAge
+	}
+	for _, v := range opts.Capabilities {
+		l.Target.Capabilities = append(l.Target.Capabilities, encoding.Symbol(v))
+	}
+	if opts.Credit > 0 {
+		l.receiver.maxCredit = opts.Credit
+	}
+	if opts.Durability > DurabilityUnsettledState {
+		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
+	}
+	l.Target.Durable = opts.Durability
+	if opts.DynamicAddress {
+		l.Source.Address = ""
+		l.dynamicAddr = opts.DynamicAddress
+	}
+	if opts.ExpiryPolicy != "" {
+		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
 			return nil, err
 		}
+		l.Target.ExpiryPolicy = opts.ExpiryPolicy
 	}
-
-	// sending unsettled messages when the receiver is in mode-second is currently
-	// broken and causes a hang after sending, so just disallow it for now.
-	if r == nil && senderSettleModeValue(l.SenderSettleMode) != ModeSettled && receiverSettleModeValue(l.ReceiverSettleMode) == ModeSecond {
-		return nil, errors.New("sender does not support exactly-once guarantee")
+	l.Target.Timeout = opts.ExpiryTimeout
+	if opts.Filters != nil {
+		l.Source.Filter = make(encoding.Filter)
+		for _, f := range opts.Filters {
+			f(l.Source.Filter)
+		}
 	}
+	l.detachOnDispositionError = !opts.IgnoreDispositionErrors
+	if opts.ManualCredits {
+		l.receiver.manualCreditor = &manualCreditor{}
+	}
+	if opts.MaxMessageSize > 0 {
+		l.MaxMessageSize = opts.MaxMessageSize
+	}
+	if opts.Name != "" {
+		l.Key.name = opts.Name
+	}
+	if opts.Properties != nil {
+		l.properties = make(map[encoding.Symbol]interface{})
+		for k, v := range opts.Properties {
+			if k == "" {
+				return nil, errors.New("link property key must not be empty")
+			}
+			l.properties[encoding.Symbol(k)] = v
+		}
+	}
+	if opts.RequestedSenderSettleMode != nil {
+		if rsm := *opts.RequestedSenderSettleMode; rsm > ModeMixed {
+			return nil, fmt.Errorf("invalid RequestedSenderSettleMode %d", rsm)
+		}
+		l.SenderSettleMode = opts.RequestedSenderSettleMode
+	}
+	if opts.SettlementMode != nil {
+		if rsm := *opts.SettlementMode; rsm > ModeSecond {
+			return nil, fmt.Errorf("invalid SettlementMode %d", rsm)
+		}
+		l.ReceiverSettleMode = opts.SettlementMode
+	}
+	l.Target.Address = opts.TargetAddress
 	return l, nil
 }
 
-// attachLink is used by Receiver and Sender to create new links
-func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption) (*link, error) {
-	l, err := newLink(s, r, opts)
-	if err != nil {
-		return nil, err
+// attach sends the Attach performative to establish the link with its parent session.
+// this is automatically called by the new*Link constructors.
+func (l *link) attach(ctx context.Context, s *Session) error {
+	// sending unsettled messages when the receiver is in mode-second is currently
+	// broken and causes a hang after sending, so just disallow it for now.
+	if l.receiver == nil && senderSettleModeValue(l.SenderSettleMode) != ModeSettled && receiverSettleModeValue(l.ReceiverSettleMode) == ModeSecond {
+		return errors.New("sender does not support exactly-once guarantee")
 	}
 
-	isReceiver := r != nil
+	isReceiver := l.receiver != nil
 
 	// buffer rx to linkCredit so that conn.mux won't block
 	// attempting to send to a slow reader
@@ -122,24 +244,25 @@ func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption)
 	// request handle from Session.mux
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return ctx.Err()
 	case <-s.done:
-		return nil, s.err
+		return s.err
 	case s.allocateHandle <- l:
 	}
 
 	// wait for handle allocation
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		// TODO: this _might_ leak l's handle
+		return ctx.Err()
 	case <-s.done:
-		return nil, s.err
+		return s.err
 	case <-l.RX:
 	}
 
 	// check for link request error
 	if l.err != nil {
-		return nil, l.err
+		return l.err
 	}
 
 	attach := &frames.PerformAttach{
@@ -175,15 +298,16 @@ func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption)
 	var fr frames.FrameBody
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		// TODO: this leaks l's handle
+		return ctx.Err()
 	case <-s.done:
-		return nil, s.err
+		return s.err
 	case fr = <-l.RX:
 	}
 	log.Debug(3, "RX (attachLink): %s", fr)
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
-		return nil, fmt.Errorf("unexpected attach response: %#v", fr)
+		return fmt.Errorf("unexpected attach response: %#v", fr)
 	}
 
 	// If the remote encounters an error during the attach it returns an Attach
@@ -199,15 +323,16 @@ func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption)
 		// wait for detach
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			// TODO: this leaks l's handle
+			return ctx.Err()
 		case <-s.done:
-			return nil, s.err
+			return s.err
 		case fr = <-l.RX:
 		}
 
 		detach, ok := fr.(*frames.PerformDetach)
 		if !ok {
-			return nil, fmt.Errorf("unexpected frame while waiting for detach: %#v", fr)
+			return fmt.Errorf("unexpected frame while waiting for detach: %#v", fr)
 		}
 
 		// send return detach
@@ -219,9 +344,9 @@ func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption)
 		_ = s.txFrame(fr, nil)
 
 		if detach.Error == nil {
-			return nil, fmt.Errorf("received detach with no error specified")
+			return fmt.Errorf("received detach with no error specified")
 		}
-		return nil, detach.Error
+		return detach.Error
 	}
 
 	if l.MaxMessageSize == 0 || resp.MaxMessageSize < l.MaxMessageSize {
@@ -256,15 +381,14 @@ func attachLink(ctx context.Context, s *Session, r *Receiver, opts []LinkOption)
 		l.Transfers = make(chan frames.PerformTransfer)
 	}
 
-	err = l.setSettleModes(resp)
-	if err != nil {
+	if err := l.setSettleModes(resp); err != nil {
 		l.muxDetach()
-		return nil, err
+		return err
 	}
 
 	go l.mux()
 
-	return l, nil
+	return nil
 }
 
 func (l *link) addUnsettled(msg *Message) {

--- a/link.go
+++ b/link.go
@@ -71,7 +71,7 @@ type link struct {
 	msg                   Message             // current message being decoded
 }
 
-// newSendingLinkd creates a new sending link and attaches it to the session
+// newSendingLink creates a new sending link and attaches it to the session
 func newSendingLink(target string, s *Session, opts *SenderOptions) (*link, error) {
 	l := &link{
 		Key:                      linkKey{randString(40), encoding.RoleSender},
@@ -137,15 +137,14 @@ func newSendingLink(target string, s *Session, opts *SenderOptions) (*link, erro
 
 func newReceivingLink(source string, s *Session, r *Receiver, opts *ReceiverOptions) (*link, error) {
 	l := &link{
-		Key:                      linkKey{randString(40), encoding.RoleReceiver},
-		Session:                  s,
-		receiver:                 r,
-		close:                    make(chan struct{}),
-		Detached:                 make(chan struct{}),
-		ReceiverReady:            make(chan struct{}, 1),
-		detachOnDispositionError: true,
-		Source:                   &frames.Source{Address: source},
-		Target:                   new(frames.Target),
+		Key:           linkKey{randString(40), encoding.RoleReceiver},
+		Session:       s,
+		receiver:      r,
+		close:         make(chan struct{}),
+		Detached:      make(chan struct{}),
+		ReceiverReady: make(chan struct{}, 1),
+		Source:        &frames.Source{Address: source},
+		Target:        new(frames.Target),
 	}
 
 	if opts == nil {
@@ -183,7 +182,6 @@ func newReceivingLink(source string, s *Session, r *Receiver, opts *ReceiverOpti
 			f(l.Source.Filter)
 		}
 	}
-	l.detachOnDispositionError = !opts.IgnoreDispositionErrors
 	if opts.ManualCredits {
 		l.receiver.manualCreditor = &manualCreditor{}
 	}

--- a/link_options.go
+++ b/link_options.go
@@ -119,11 +119,6 @@ type ReceiverOptions struct {
 	// If the peer cannot fulfill the filters the link will be detached.
 	Filters []LinkFilter
 
-	// IgnoreDispositionErrors controls automatic detach on disposition errors.
-	//
-	// Default: false.
-	IgnoreDispositionErrors bool
-
 	// ManualCredits enables manual credit management for this link.
 	// Credits can be added with IssueCredit(), and links can also be
 	// drained with DrainCredit().

--- a/link_options.go
+++ b/link_options.go
@@ -1,218 +1,170 @@
 package amqp
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/Azure/go-amqp/internal/encoding"
-	"github.com/Azure/go-amqp/internal/frames"
 )
 
-// LinkOption is a function for configuring an AMQP link.
-//
-// A link may be a Sender or a Receiver.
-type LinkOption func(*link) error
+type SenderOptions struct {
+	// Capabilities is the list of extension capabilities the sender supports/desires.
+	Capabilities []string
 
-// LinkProperty sets an entry in the link properties map sent to the server.
-//
-// This option can be used multiple times.
-func LinkProperty(key, value string) LinkOption {
-	return linkProperty(key, value)
+	// Durability indicates what state of the sender will be retained durably.
+	//
+	// Default: DurabilityNone.
+	Durability Durability
+
+	// DynamicAddress indicates a dynamic address is to be used.
+	// Any specified address will be ignored.
+	//
+	// Default: false.
+	DynamicAddress bool
+
+	// ExpiryPolicy determines when the expiry timer of the sender starts counting
+	// down from the timeout value.  If the link is subsequently re-attached before
+	// the timeout is reached, the count down is aborted.
+	//
+	// Default: ExpirySessionEnd.
+	ExpiryPolicy ExpiryPolicy
+
+	// ExpiryTimeout is the duration in seconds that the sender will be retained.
+	//
+	// Default: 0.
+	ExpiryTimeout uint32
+
+	// IgnoreDispositionErrors controls automatic detach on disposition errors.
+	//
+	// Default: false.
+	IgnoreDispositionErrors bool
+
+	// Name sets the name of the link.
+	//
+	// Link names must be unique per-connection and direction.
+	//
+	// Default: randomly generated.
+	Name string
+
+	// Properties sets an entry in the link properties map sent to the server.
+	Properties map[string]interface{}
+
+	// RequestedReceiverSettleMode sets the requested receiver settlement mode.
+	//
+	// If a settlement mode is explicitly set and the server does not
+	// honor it an error will be returned during link attachment.
+	//
+	// Default: Accept the settlement mode set by the server, commonly ModeFirst.
+	RequestedReceiverSettleMode *ReceiverSettleMode
+
+	// SettlementMode sets the settlement mode in use by this sender.
+	//
+	// Default: ModeMixed.
+	SettlementMode *SenderSettleMode
+
+	// SourceAddress specifies the source address for this sender.
+	SourceAddress string
 }
 
-// LinkPropertyInt64 sets an entry in the link properties map sent to the server.
-//
-// This option can be used multiple times.
-func LinkPropertyInt64(key string, value int64) LinkOption {
-	return linkProperty(key, value)
+type ReceiverOptions struct {
+	// LinkBatching toggles batching of message disposition.
+	//
+	// When enabled, accepting a message does not send the disposition
+	// to the server until the batch is equal to link credit or the
+	// batch max age expires.
+	//
+	// Default: false.
+	Batching bool
+
+	// BatchMaxAge sets the maximum time between the start
+	// of a disposition batch and sending the batch to the server.
+	//
+	// Has no effect when Batching is false.
+	//
+	// Default: 5 seconds.
+	BatchMaxAge time.Duration
+
+	// Capabilities is the list of extension capabilities the receiver supports/desires.
+	Capabilities []string
+
+	// Credit specifies the maximum number of unacknowledged messages
+	// the sender can transmit.
+	//
+	// Default: 1.
+	Credit uint32
+
+	// Durability indicates what state of the receiver will be retained durably.
+	//
+	// Default: DurabilityNone.
+	Durability Durability
+
+	// DynamicAddress indicates a dynamic address is to be used.
+	// Any specified address will be ignored.
+	//
+	// Default: false.
+	DynamicAddress bool
+
+	// ExpiryPolicy determines when the expiry timer of the sender starts counting
+	// down from the timeout value.  If the link is subsequently re-attached before
+	// the timeout is reached, the count down is aborted.
+	//
+	// Default: ExpirySessionEnd.
+	ExpiryPolicy ExpiryPolicy
+
+	// ExpiryTimeout is the duration in seconds that the sender will be retained.
+	//
+	// Default: 0.
+	ExpiryTimeout uint32
+
+	// Filters contains the desired filters for this receiver.
+	// If the peer cannot fulfill the filters the link will be detached.
+	Filters []LinkFilter
+
+	// IgnoreDispositionErrors controls automatic detach on disposition errors.
+	//
+	// Default: false.
+	IgnoreDispositionErrors bool
+
+	// ManualCredits enables manual credit management for this link.
+	// Credits can be added with IssueCredit(), and links can also be
+	// drained with DrainCredit().
+	ManualCredits bool
+
+	// MaxMessageSize sets the maximum message size that can
+	// be received on the link.
+	//
+	// A size of zero indicates no limit.
+	//
+	// Default: 0.
+	MaxMessageSize uint64
+
+	// Name sets the name of the link.
+	//
+	// Link names must be unique per-connection and direction.
+	//
+	// Default: randomly generated.
+	Name string
+
+	// Properties sets an entry in the link properties map sent to the server.
+	Properties map[string]interface{}
+
+	// RequestedSenderSettleMode sets the requested sender settlement mode.
+	//
+	// If a settlement mode is explicitly set and the server does not
+	// honor it an error will be returned during link attachment.
+	//
+	// Default: Accept the settlement mode set by the server, commonly ModeMixed.
+	RequestedSenderSettleMode *SenderSettleMode
+
+	// SettlementMode sets the settlement mode in use by this receiver.
+	//
+	// Default: ModeFirst.
+	SettlementMode *ReceiverSettleMode
+
+	// TargetAddress specifies the target address for this receiver.
+	TargetAddress string
 }
 
-// LinkPropertyInt32 sets an entry in the link properties map sent to the server.
-//
-// This option can be set multiple times.
-func LinkPropertyInt32(key string, value int32) LinkOption {
-	return linkProperty(key, value)
-}
-
-func linkProperty(key string, value interface{}) LinkOption {
-	return func(l *link) error {
-		if key == "" {
-			return errors.New("link property key must not be empty")
-		}
-		if l.properties == nil {
-			l.properties = make(map[encoding.Symbol]interface{})
-		}
-		l.properties[encoding.Symbol(key)] = value
-		return nil
-	}
-}
-
-// LinkName sets the name of the link.
-//
-// The link names must be unique per-connection and direction.
-//
-// Default: randomly generated.
-func LinkName(name string) LinkOption {
-	return func(l *link) error {
-		l.Key.name = name
-		return nil
-	}
-}
-
-// LinkSourceCapabilities sets the source capabilities.
-func LinkSourceCapabilities(capabilities ...string) LinkOption {
-	return func(l *link) error {
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-
-		// Convert string to symbol
-		symbolCapabilities := make([]encoding.Symbol, len(capabilities))
-		for i, v := range capabilities {
-			symbolCapabilities[i] = encoding.Symbol(v)
-		}
-
-		l.Source.Capabilities = append(l.Source.Capabilities, symbolCapabilities...)
-		return nil
-	}
-}
-
-// LinkSourceAddress sets the source address.
-func LinkSourceAddress(addr string) LinkOption {
-	return func(l *link) error {
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		l.Source.Address = addr
-		return nil
-	}
-}
-
-// LinkTargetAddress sets the target address.
-func LinkTargetAddress(addr string) LinkOption {
-	return func(l *link) error {
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-		l.Target.Address = addr
-		return nil
-	}
-}
-
-// LinkTargetCapabilities sets the target capabilities.
-func LinkTargetCapabilities(capabilities ...string) LinkOption {
-	return func(l *link) error {
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-
-		// Convert string to symbol
-		symbolCapabilities := make([]encoding.Symbol, len(capabilities))
-		for i, v := range capabilities {
-			symbolCapabilities[i] = encoding.Symbol(v)
-		}
-
-		l.Target.Capabilities = append(l.Target.Capabilities, symbolCapabilities...)
-		return nil
-	}
-}
-
-// LinkAddressDynamic requests a dynamically created address from the server.
-func LinkAddressDynamic() LinkOption {
-	return func(l *link) error {
-		l.dynamicAddr = true
-		return nil
-	}
-}
-
-// LinkCredit specifies the maximum number of unacknowledged messages
-// the sender can transmit.
-func LinkCredit(credit uint32) LinkOption {
-	return func(l *link) error {
-		if l.receiver == nil {
-			return errors.New("LinkCredit is not valid for Sender")
-		}
-
-		l.receiver.maxCredit = credit
-		return nil
-	}
-}
-
-// LinkWithManualCredits enables manual credit management for this link.
-// Credits can be added with IssueCredit(), and links can also be drained
-// with DrainCredit().
-func LinkWithManualCredits() LinkOption {
-	return func(l *link) error {
-		if l.receiver == nil {
-			return errors.New("LinkWithManualCredits is not valid for Sender")
-		}
-
-		l.receiver.manualCreditor = &manualCreditor{}
-		return nil
-	}
-}
-
-// LinkBatching toggles batching of message disposition.
-//
-// When enabled, accepting a message does not send the disposition
-// to the server until the batch is equal to link credit or the
-// batch max age expires.
-func LinkBatching(enable bool) LinkOption {
-	return func(l *link) error {
-		l.receiver.batching = enable
-		return nil
-	}
-}
-
-// LinkBatchMaxAge sets the maximum time between the start
-// of a disposition batch and sending the batch to the server.
-func LinkBatchMaxAge(d time.Duration) LinkOption {
-	return func(l *link) error {
-		l.receiver.batchMaxAge = d
-		return nil
-	}
-}
-
-// LinkSenderSettle sets the requested sender settlement mode.
-//
-// If a settlement mode is explicitly set and the server does not
-// honor it an error will be returned during link attachment.
-//
-// Default: Accept the settlement mode set by the server, commonly ModeMixed.
-func LinkSenderSettle(mode SenderSettleMode) LinkOption {
-	return func(l *link) error {
-		if mode > ModeMixed {
-			return fmt.Errorf("invalid SenderSettlementMode %d", mode)
-		}
-		l.SenderSettleMode = &mode
-		return nil
-	}
-}
-
-// LinkReceiverSettle sets the requested receiver settlement mode.
-//
-// If a settlement mode is explicitly set and the server does not
-// honor it an error will be returned during link attachment.
-//
-// Default: Accept the settlement mode set by the server, commonly ModeFirst.
-func LinkReceiverSettle(mode ReceiverSettleMode) LinkOption {
-	return func(l *link) error {
-		if mode > ModeSecond {
-			return fmt.Errorf("invalid ReceiverSettlementMode %d", mode)
-		}
-		l.ReceiverSettleMode = &mode
-		return nil
-	}
-}
-
-// LinkSelectorFilter sets a selector filter (apache.org:selector-filter:string) on the link source.
-func LinkSelectorFilter(filter string) LinkOption {
-	// <descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
-	return LinkSourceFilter("apache.org:selector-filter:string", 0x0000468C00000004, filter)
-}
-
-// LinkSourceFilter is an advanced API for setting non-standard source filters.
+// LinkFilter is an advanced API for setting non-standard source filters.
 // Please file an issue or open a PR if a standard filter is missing from this
 // library.
 //
@@ -236,152 +188,30 @@ func LinkSelectorFilter(filter string) LinkOption {
 // References:
 //  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
 //  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
-func LinkSourceFilter(name string, code uint64, value interface{}) LinkOption {
-	return func(l *link) error {
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		if l.Source.Filter == nil {
-			l.Source.Filter = make(map[encoding.Symbol]*encoding.DescribedType)
-		}
+type LinkFilter func(encoding.Filter)
 
+// LinkFilterSource creates or updates the named filter for this LinkFilter.
+func LinkFilterSource(name string, code uint64, value interface{}) LinkFilter {
+	return func(f encoding.Filter) {
 		var descriptor interface{}
 		if code != 0 {
 			descriptor = code
 		} else {
 			descriptor = encoding.Symbol(name)
 		}
-
-		l.Source.Filter[encoding.Symbol(name)] = &encoding.DescribedType{
+		f[encoding.Symbol(name)] = &encoding.DescribedType{
 			Descriptor: descriptor,
 			Value:      value,
 		}
-		return nil
 	}
 }
 
-// LinkMaxMessageSize sets the maximum message size that can
-// be sent or received on the link.
-//
-// A size of zero indicates no limit.
-//
-// Default: 0.
-func LinkMaxMessageSize(size uint64) LinkOption {
-	return func(l *link) error {
-		l.MaxMessageSize = size
-		return nil
-	}
+// LinkFilterSelector creates or updates the selector filter (apache.org:selector-filter:string) for this LinkFilter.
+func LinkFilterSelector(filter string) LinkFilter {
+	return LinkFilterSource(selectorFilter, selectorFilterCode, filter)
 }
 
-// LinkTargetDurability sets the target durability policy.
-//
-// Default: DurabilityNone.
-func LinkTargetDurability(d Durability) LinkOption {
-	return func(l *link) error {
-		if d > DurabilityUnsettledState {
-			return fmt.Errorf("invalid Durability %d", d)
-		}
-
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-		l.Target.Durable = d
-
-		return nil
-	}
-}
-
-// LinkTargetExpiryPolicy sets the link expiration policy.
-//
-// Default: ExpirySessionEnd.
-func LinkTargetExpiryPolicy(p ExpiryPolicy) LinkOption {
-	return func(l *link) error {
-		err := encoding.ValidateExpiryPolicy(p)
-		if err != nil {
-			return err
-		}
-
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-		l.Target.ExpiryPolicy = p
-
-		return nil
-	}
-}
-
-// LinkTargetTimeout sets the number of seconds that an expiring target will be retained.
-//
-// Default: 0.
-func LinkTargetTimeout(seconds uint32) LinkOption {
-	return func(l *link) error {
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-		l.Target.Timeout = seconds
-
-		return nil
-	}
-}
-
-// LinkSourceDurability sets the source durability policy.
-//
-// Default: DurabilityNone.
-func LinkSourceDurability(d Durability) LinkOption {
-	return func(l *link) error {
-		if d > DurabilityUnsettledState {
-			return fmt.Errorf("invalid Durability %d", d)
-		}
-
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		l.Source.Durable = d
-
-		return nil
-	}
-}
-
-// LinkSourceExpiryPolicy sets the link expiration policy.
-//
-// Default: ExpirySessionEnd.
-func LinkSourceExpiryPolicy(p ExpiryPolicy) LinkOption {
-	return func(l *link) error {
-		err := encoding.ValidateExpiryPolicy(p)
-		if err != nil {
-			return err
-		}
-
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		l.Source.ExpiryPolicy = p
-
-		return nil
-	}
-}
-
-// LinkSourceTimeout sets the duration that an expiring source will be retained.
-//
-// Default: 0.
-func LinkSourceTimeout(timeout uint32) LinkOption {
-	return func(l *link) error {
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		l.Source.Timeout = timeout
-
-		return nil
-	}
-}
-
-// LinkDetachOnDispositionError controls whether you detach on disposition
-// errors (subject to some simple logic) or do NOT detach at all on disposition
-// errors.
-// Defaults to true.
-func LinkDetachOnDispositionError(detachOnDispositionError bool) LinkOption {
-	return func(l *link) error {
-		l.detachOnDispositionError = detachOnDispositionError
-		return nil
-	}
-}
+const (
+	selectorFilter     = "apache.org:selector-filter:string"
+	selectorFilterCode = uint64(0x0000468C00000004)
+)

--- a/link_test.go
+++ b/link_test.go
@@ -2,7 +2,6 @@ package amqp
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"sync"
 	"testing"
@@ -102,7 +101,7 @@ func TestLinkFlowDrain(t *testing.T) {
 	l := newTestLink(t)
 
 	// now initialize it as a manual credit link
-	require.NoError(t, LinkWithManualCredits()(l))
+	l.receiver.manualCreditor = &manualCreditor{}
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -117,7 +116,7 @@ func TestLinkFlowDrain(t *testing.T) {
 
 func TestLinkFlowWithManualCreditor(t *testing.T) {
 	l := newTestLink(t)
-	require.NoError(t, LinkWithManualCredits()(l))
+	l.receiver.manualCreditor = &manualCreditor{}
 
 	l.linkCredit = 1
 	require.NoError(t, l.IssueCredit(100))
@@ -140,7 +139,7 @@ func TestLinkFlowWithManualCreditor(t *testing.T) {
 
 func TestLinkFlowWithDrain(t *testing.T) {
 	l := newTestLink(t)
-	require.NoError(t, LinkWithManualCredits()(l))
+	l.receiver.manualCreditor = &manualCreditor{}
 
 	go func() {
 		<-l.ReceiverReady
@@ -176,7 +175,7 @@ func TestLinkFlowWithDrain(t *testing.T) {
 
 func TestLinkFlowWithManualCreditorAndNoFlowNeeded(t *testing.T) {
 	l := newTestLink(t)
-	require.NoError(t, LinkWithManualCredits()(l))
+	l.receiver.manualCreditor = &manualCreditor{}
 
 	l.linkCredit = 1
 
@@ -195,7 +194,7 @@ func TestLinkFlowWithManualCreditorAndNoFlowNeeded(t *testing.T) {
 
 func TestMuxFlowHandlesDrainProperly(t *testing.T) {
 	l := newTestLink(t)
-	require.NoError(t, LinkWithManualCredits()(l))
+	l.receiver.manualCreditor = &manualCreditor{}
 
 	l.linkCredit = 101
 
@@ -229,115 +228,184 @@ func newTestLink(t *testing.T) *link {
 	return l
 }
 
-func TestLinkOptions(t *testing.T) {
+func TestNewSendingLink(t *testing.T) {
+	const (
+		name       = "mysender"
+		targetAddr = "target"
+	)
 	tests := []struct {
-		label string
-		opts  []LinkOption
-
-		wantSource     *frames.Source
-		wantTarget     *frames.Target
-		wantProperties map[encoding.Symbol]interface{}
+		label    string
+		opts     SenderOptions
+		validate func(t *testing.T, l *link)
 	}{
 		{
-			label: "no options",
+			label: "default options",
+			validate: func(t *testing.T, l *link) {
+				require.Empty(t, l.Target.Capabilities)
+				require.Equal(t, DurabilityNone, l.Source.Durable)
+				require.False(t, l.dynamicAddr)
+				require.Empty(t, l.Source.ExpiryPolicy)
+				require.Zero(t, l.Source.Timeout)
+				require.True(t, l.detachOnDispositionError)
+				require.NotEmpty(t, l.Key.name)
+				require.Empty(t, l.properties)
+				require.Nil(t, l.SenderSettleMode)
+				require.Nil(t, l.ReceiverSettleMode)
+				require.Equal(t, targetAddr, l.Target.Address)
+			},
 		},
 		{
-			label: "link-filters",
-			opts: []LinkOption{
-				LinkSelectorFilter("amqp.annotation.x-opt-offset > '100'"),
-				LinkProperty("x-opt-test1", "test1"),
-				LinkProperty("x-opt-test2", "test2"),
-				LinkProperty("x-opt-test1", "test3"),
-				LinkPropertyInt64("x-opt-test4", 1),
-				LinkPropertyInt32("x-opt-test5", 2),
-				LinkSourceFilter("com.microsoft:session-filter", 0x00000137000000C, "123"),
-			},
-
-			wantSource: &frames.Source{
-				Filter: map[encoding.Symbol]*encoding.DescribedType{
-					"apache.org:selector-filter:string": {
-						Descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x46, 0x8C, 0x00, 0x00, 0x00, 0x04}),
-						Value:      "amqp.annotation.x-opt-offset > '100'",
-					},
-					"com.microsoft:session-filter": {
-						Descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x00, 0x13, 0x70, 0x00, 0x00, 0x0C}),
-						Value:      "123",
-					},
+			label: "with options",
+			opts: SenderOptions{
+				Capabilities:            []string{"foo", "bar"},
+				Durability:              DurabilityUnsettledState,
+				DynamicAddress:          true,
+				ExpiryPolicy:            ExpiryLinkDetach,
+				ExpiryTimeout:           5,
+				IgnoreDispositionErrors: true,
+				Name:                    name,
+				Properties: map[string]interface{}{
+					"property": 123,
 				},
+				RequestedReceiverSettleMode: ModeFirst.Ptr(),
+				SettlementMode:              ModeSettled.Ptr(),
 			},
-			wantProperties: map[encoding.Symbol]interface{}{
-				"x-opt-test1": "test3",
-				"x-opt-test2": "test2",
-				"x-opt-test4": int64(1),
-				"x-opt-test5": int32(2),
-			},
-		},
-		{
-			label: "more-link-filters",
-			opts: []LinkOption{
-				LinkSourceFilter("com.microsoft:session-filter", 0x00000137000000C, nil),
-			},
-
-			wantSource: &frames.Source{
-				Filter: map[encoding.Symbol]*encoding.DescribedType{
-					"com.microsoft:session-filter": {
-						Descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x00, 0x13, 0x70, 0x00, 0x00, 0x0C}),
-						Value:      nil,
-					},
-				},
-			},
-		},
-		{
-			label: "link-source-capabilities",
-			opts: []LinkOption{
-				LinkSourceCapabilities("cap1", "cap2", "cap3"),
-			},
-			wantSource: &frames.Source{
-				Capabilities: []encoding.Symbol{"cap1", "cap2", "cap3"},
-			},
-		},
-		{
-			label: "link-target-capabilities",
-			opts: []LinkOption{
-				LinkTargetCapabilities("cap1", "cap2", "cap3"),
-			},
-			wantTarget: &frames.Target{
-				Capabilities: []encoding.Symbol{"cap1", "cap2", "cap3"},
+			validate: func(t *testing.T, l *link) {
+				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.Source.Capabilities)
+				require.Equal(t, DurabilityUnsettledState, l.Source.Durable)
+				require.True(t, l.dynamicAddr)
+				require.Equal(t, ExpiryLinkDetach, l.Source.ExpiryPolicy)
+				require.Equal(t, uint32(5), l.Source.Timeout)
+				require.False(t, l.detachOnDispositionError)
+				require.Equal(t, name, l.Key.name)
+				require.Equal(t, map[encoding.Symbol]interface{}{
+					"property": 123,
+				}, l.properties)
+				require.NotNil(t, l.SenderSettleMode)
+				require.Equal(t, ModeSettled, *l.SenderSettleMode)
+				require.NotNil(t, l.ReceiverSettleMode)
+				require.Equal(t, ModeFirst, *l.ReceiverSettleMode)
+				require.Empty(t, l.Target.Address)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			got, err := newLink(nil, nil, tt.opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !testEqual(got.Source, tt.wantSource) {
-				t.Errorf("Source properties don't match expected:\n %s", testDiff(got.Source, tt.wantSource))
-			}
-
-			if !testEqual(got.properties, tt.wantProperties) {
-				t.Errorf("Link properties don't match expected:\n %s", testDiff(got.properties, tt.wantProperties))
-			}
+			got, err := newSendingLink(targetAddr, nil, &tt.opts)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			tt.validate(t, got)
 		})
 	}
 }
 
-func TestSourceName(t *testing.T) {
-	expectedSourceName := "source-name"
-	opts := []LinkOption{
-		LinkName(expectedSourceName),
+func TestNewReceivingLink(t *testing.T) {
+	const (
+		name       = "myreceiver"
+		sourceAddr = "source"
+	)
+	// skip validating any fields on l.receiver as they are
+	// populated in Session.NewReceiver()
+
+	tests := []struct {
+		label    string
+		opts     ReceiverOptions
+		validate func(t *testing.T, l *link)
+
+		wantSource     *frames.Source
+		wantTarget     *frames.Target
+		wantProperties map[encoding.Symbol]interface{}
+	}{
+		{
+			label: "default options",
+			validate: func(t *testing.T, l *link) {
+				//require.False(t, l.receiver.batching)
+				//require.Equal(t, defaultLinkBatchMaxAge, l.receiver.batchMaxAge)
+				require.Empty(t, l.Target.Capabilities)
+				//require.Equal(t, defaultLinkCredit, l.receiver.maxCredit)
+				require.Equal(t, DurabilityNone, l.Target.Durable)
+				require.False(t, l.dynamicAddr)
+				require.Empty(t, l.Target.ExpiryPolicy)
+				require.Zero(t, l.Target.Timeout)
+				require.Empty(t, l.Source.Filter)
+				require.True(t, l.detachOnDispositionError)
+				//require.Nil(t, l.receiver.manualCreditor)
+				require.Zero(t, l.MaxMessageSize)
+				require.NotEmpty(t, l.Key.name)
+				require.Empty(t, l.properties)
+				require.Nil(t, l.SenderSettleMode)
+				require.Nil(t, l.ReceiverSettleMode)
+				require.Equal(t, sourceAddr, l.Source.Address)
+			},
+		},
+		{
+			label: "with options",
+			opts: ReceiverOptions{
+				//Batching:                  true,
+				//BatchMaxAge:               1 * time.Minute,
+				Capabilities: []string{"foo", "bar"},
+				//Credit:                    32,
+				Durability:     DurabilityConfiguration,
+				DynamicAddress: true,
+				ExpiryPolicy:   ExpiryNever,
+				ExpiryTimeout:  3,
+				Filters: []LinkFilter{
+					LinkFilterSelector("amqp.annotation.x-opt-offset > '100'"),
+					LinkFilterSource("com.microsoft:session-filter", 0x00000137000000C, "123"),
+				},
+				IgnoreDispositionErrors: true,
+				//ManualCredits:             true,
+				MaxMessageSize: 1024,
+				Name:           name,
+				Properties: map[string]interface{}{
+					"property": 123,
+				},
+				RequestedSenderSettleMode: ModeMixed.Ptr(),
+				SettlementMode:            ModeSecond.Ptr(),
+			},
+			validate: func(t *testing.T, l *link) {
+				//require.True(t, l.receiver.batching)
+				//require.Equal(t, 1*time.Minute, l.receiver.batchMaxAge)
+				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.Target.Capabilities)
+				//require.Equal(t, uint32(32), l.receiver.maxCredit)
+				require.Equal(t, DurabilityConfiguration, l.Target.Durable)
+				require.True(t, l.dynamicAddr)
+				require.Equal(t, ExpiryNever, l.Target.ExpiryPolicy)
+				require.Equal(t, uint32(3), l.Target.Timeout)
+				require.Equal(t, encoding.Filter{
+					selectorFilter: &encoding.DescribedType{
+						Descriptor: selectorFilterCode,
+						Value:      "amqp.annotation.x-opt-offset > '100'",
+					},
+					"com.microsoft:session-filter": &encoding.DescribedType{
+						Descriptor: uint64(0x00000137000000C),
+						Value:      "123",
+					},
+				}, l.Source.Filter)
+				require.False(t, l.detachOnDispositionError)
+				//require.NotNil(t, l.receiver.manualCreditor)
+				require.Equal(t, uint64(1024), l.MaxMessageSize)
+				require.Equal(t, name, l.Key.name)
+				require.Equal(t, map[encoding.Symbol]interface{}{
+					"property": 123,
+				}, l.properties)
+				require.NotNil(t, l.SenderSettleMode)
+				require.Equal(t, ModeMixed, *l.SenderSettleMode)
+				require.NotNil(t, l.ReceiverSettleMode)
+				require.Equal(t, ModeSecond, *l.ReceiverSettleMode)
+				require.Empty(t, l.Source.Address)
+			},
+		},
 	}
 
-	got, err := newLink(nil, nil, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if got.Key.name != expectedSourceName {
-		t.Errorf("Link Source Name does not match expected: %v got: %v", expectedSourceName, got.Key.name)
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			got, err := newReceivingLink(sourceAddr, nil, &Receiver{}, &tt.opts)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			tt.validate(t, got)
+		})
 	}
 }
 
@@ -383,12 +451,10 @@ func TestExactlyOnceDoesntWork(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(
-		ctx,
-		LinkSenderSettle(ModeMixed),
-		LinkReceiverSettle(ModeSecond),
-		LinkTargetAddress("doesntwork"),
-	)
+	snd, err := session.NewSender(ctx, "doesntwork", &SenderOptions{
+		SettlementMode:              ModeMixed.Ptr(),
+		RequestedReceiverSettleMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)

--- a/link_test.go
+++ b/link_test.go
@@ -329,7 +329,7 @@ func TestNewReceivingLink(t *testing.T) {
 				require.Empty(t, l.Target.ExpiryPolicy)
 				require.Zero(t, l.Target.Timeout)
 				require.Empty(t, l.Source.Filter)
-				require.True(t, l.detachOnDispositionError)
+				require.False(t, l.detachOnDispositionError)
 				//require.Nil(t, l.receiver.manualCreditor)
 				require.Zero(t, l.MaxMessageSize)
 				require.NotEmpty(t, l.Key.name)
@@ -354,7 +354,6 @@ func TestNewReceivingLink(t *testing.T) {
 					LinkFilterSelector("amqp.annotation.x-opt-offset > '100'"),
 					LinkFilterSource("com.microsoft:session-filter", 0x00000137000000C, "123"),
 				},
-				IgnoreDispositionErrors: true,
 				//ManualCredits:             true,
 				MaxMessageSize: 1024,
 				Name:           name,

--- a/receiver.go
+++ b/receiver.go
@@ -46,7 +46,7 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 // When using ModeSecond, you *must* take an action on the message by calling
 // one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
 // When using ModeFirst, the message is spontaneously Accepted at reception.
-func (r *Receiver) Prefetched() (*Message, error) {
+func (r *Receiver) Prefetched() *Message {
 	select {
 	case r.link.ReceiverReady <- struct{}{}:
 	default:
@@ -58,10 +58,10 @@ func (r *Receiver) Prefetched() (*Message, error) {
 	case msg := <-r.link.Messages:
 		log.Debug(3, "Receive() non blocking %d", msg.deliveryID)
 		msg.link = r.link
-		return &msg, nil
+		return &msg
 	default:
 		// done draining messages
-		return nil, nil
+		return nil
 	}
 }
 
@@ -72,10 +72,8 @@ func (r *Receiver) Prefetched() (*Message, error) {
 // one of the following: AcceptMessage, RejectMessage, ReleaseMessage, ModifyMessage.
 // When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
-	msg, err := r.Prefetched()
-
-	if err != nil || msg != nil {
-		return msg, err
+	if msg := r.Prefetched(); msg != nil {
+		return msg, nil
 	}
 
 	// wait for the next message

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -750,9 +750,8 @@ func TestReceiverPrefetch(t *testing.T) {
 	}
 
 	// if there are no cached messages we just return immediately - no error, no message.
-	msg, err := receiver.Prefetched()
+	msg := receiver.Prefetched()
 	require.Nil(t, msg)
-	require.Nil(t, err)
 
 	messagesCh <- Message{
 		ApplicationProperties: map[string]interface{}{
@@ -762,10 +761,9 @@ func TestReceiverPrefetch(t *testing.T) {
 	}
 
 	require.NotEmpty(t, messagesCh)
-	msg, err = receiver.Prefetched()
+	msg = receiver.Prefetched()
 
 	require.EqualValues(t, "hello", msg.ApplicationProperties["prop"].(string))
-	require.Nil(t, err)
 	require.Empty(t, messagesCh)
 }
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -23,19 +23,25 @@ func TestReceiverInvalidOptions(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(3))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleMode(3).Ptr(),
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, r)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx, LinkTargetDurability(3))
+	r, err = session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Durability: Durability(3),
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, r)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx, LinkTargetExpiryPolicy("not-a-real-policy"))
+	r, err = session.NewReceiver(ctx, "source", &ReceiverOptions{
+		ExpiryPolicy: ExpiryPolicy("not-a-real-policy"),
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, r)
@@ -71,14 +77,12 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 	require.NoError(t, err)
 	const sourceAddr = "thesource"
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(
-		ctx,
-		LinkName(linkName),
-		LinkSourceAddress(sourceAddr),
-		LinkTargetDurability(DurabilityUnsettledState),
-		LinkTargetExpiryPolicy(ExpiryNever),
-		LinkTargetTimeout(300),
-	)
+	r, err := session.NewReceiver(ctx, sourceAddr, &ReceiverOptions{
+		Name:          linkName,
+		Durability:    DurabilityUnsettledState,
+		ExpiryPolicy:  ExpiryNever,
+		ExpiryTimeout: 300,
+	})
 	cancel()
 	require.NoError(t, err)
 	require.Equal(t, sourceAddr, r.Address())
@@ -100,7 +104,12 @@ func TestReceiverLinkSourceFilter(t *testing.T) {
 	const filterName = "myfilter"
 	const filterExp = "filter_exp"
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkAddressDynamic(), LinkSourceFilter(filterName, 0, filterExp))
+	r, err := session.NewReceiver(ctx, "ignored", &ReceiverOptions{
+		DynamicAddress: true,
+		Filters: []LinkFilter{
+			LinkFilterSource(filterName, 0, filterExp),
+		},
+	})
 	cancel()
 	require.NoError(t, err)
 	require.Equal(t, "test", r.Address())
@@ -120,7 +129,7 @@ func TestReceiverOnClosed(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -151,7 +160,7 @@ func TestReceiverOnSessionClosed(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -182,7 +191,7 @@ func TestReceiverOnConnClosed(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -213,7 +222,7 @@ func TestReceiverOnDetached(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -270,7 +279,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -303,7 +312,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 
 	// missing MessageFormat
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx)
+	r, err = session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 	go func() {
@@ -332,7 +341,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 	// missing delivery tag
 	format := uint32(0)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx)
+	r, err = session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 	go func() {
@@ -392,7 +401,9 @@ func TestReceiveSuccessModeFirst(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeFirst))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeFirst.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -449,7 +460,9 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -527,7 +540,9 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -599,7 +614,9 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -676,7 +693,9 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -778,7 +797,9 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	msgChan := make(chan *Message)
@@ -855,7 +876,9 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	msgChan := make(chan *Message)
@@ -887,7 +910,9 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 
 	// mismatched MessageFormat
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err = session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	go func() {
@@ -912,7 +937,9 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 
 	// mismatched DeliveryTag
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err = session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err = session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	go func() {
@@ -965,7 +992,9 @@ func TestReceiveMultiFrameMessageAborted(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	msgChan := make(chan *Message)
@@ -1024,7 +1053,10 @@ func TestReceiveMessageTooBig(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond), LinkMaxMessageSize(128))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+		MaxMessageSize: 128,
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -1067,7 +1099,9 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -1130,7 +1164,12 @@ func TestReceiverDispositionBatcherTimer(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond), LinkCredit(2), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching:       true,
+		BatchMaxAge:    time.Second,
+		Credit:         2,
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -1191,7 +1230,12 @@ func TestReceiverDispositionBatcherFull(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond), LinkCredit(credit), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching:       true,
+		BatchMaxAge:    time.Second,
+		Credit:         credit,
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	wg := &sync.WaitGroup{}
@@ -1260,7 +1304,12 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx, LinkReceiverSettle(ModeSecond), LinkCredit(credit), LinkBatchMaxAge(time.Second), LinkBatching(true))
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching:       true,
+		BatchMaxAge:    time.Second,
+		Credit:         credit,
+		SettlementMode: ModeSecond.Ptr(),
+	})
 	cancel()
 	require.NoError(t, err)
 	wg := &sync.WaitGroup{}
@@ -1306,7 +1355,7 @@ func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -1337,7 +1386,7 @@ func TestReceiverConnReaderError(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -1371,7 +1420,7 @@ func TestReceiverConnWriterError(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := session.NewReceiver(ctx)
+	r, err := session.NewReceiver(ctx, "source", nil)
 	cancel()
 	require.NoError(t, err)
 
@@ -1396,3 +1445,5 @@ func TestReceiverConnWriterError(t *testing.T) {
 	}
 	require.Error(t, conn.Close())
 }
+
+// TODO: add unit tests for manual credit management

--- a/session.go
+++ b/session.go
@@ -117,15 +117,19 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 }
 
 // NewReceiver opens a new receiver link on the session.
-func (s *Session) NewReceiver(ctx context.Context, opts ...LinkOption) (*Receiver, error) {
+// opts: pass nil to accept the default values.
+func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
 	r := &Receiver{
 		batching:    defaultLinkBatching,
 		batchMaxAge: defaultLinkBatchMaxAge,
 		maxCredit:   defaultLinkCredit,
 	}
 
-	l, err := attachLink(ctx, s, r, opts)
+	l, err := newReceivingLink(source, s, r, opts)
 	if err != nil {
+		return nil, err
+	}
+	if err = l.attach(ctx, s); err != nil {
 		return nil, err
 	}
 
@@ -147,9 +151,13 @@ func (s *Session) NewReceiver(ctx context.Context, opts ...LinkOption) (*Receive
 }
 
 // NewSender opens a new sender link on the session.
-func (s *Session) NewSender(ctx context.Context, opts ...LinkOption) (*Sender, error) {
-	l, err := attachLink(ctx, s, nil, opts)
+// opts: pass nil to accept the default values.
+func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
+	l, err := newSendingLink(target, s, opts)
 	if err != nil {
+		return nil, err
+	}
+	if err = l.attach(ctx, s); err != nil {
 		return nil, err
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -163,7 +163,11 @@ func TestSessionNewReceiverBadOptionFails(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	recv, err := session.NewReceiver(ctx, LinkProperty("", "bad_key"))
+	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Properties: map[string]interface{}{
+			"": "bad_key",
+		},
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, recv)
@@ -203,7 +207,9 @@ func TestSessionNewReceiverBatchingOneCredit(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	recv, err := session.NewReceiver(ctx, LinkBatching(true))
+	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching: true,
+	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, recv)
@@ -244,7 +250,10 @@ func TestSessionNewReceiverBatchingEnabled(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	recv, err := session.NewReceiver(ctx, LinkBatching(true), LinkCredit(10))
+	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching: true,
+		Credit:   10,
+	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, recv)
@@ -283,7 +292,10 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	recv, err := session.NewReceiver(ctx, LinkBatching(true), LinkCredit(10))
+	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		Batching: true,
+		Credit:   10,
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, recv)
@@ -305,7 +317,11 @@ func TestSessionNewSenderBadOptionFails(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(ctx, LinkProperty("", "bad_key"))
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		Properties: map[string]interface{}{
+			"": "bad_key",
+		},
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)
@@ -343,7 +359,7 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(ctx)
+	snd, err := session.NewSender(ctx, "target", nil)
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)
@@ -365,12 +381,16 @@ func TestSessionNewSenderDuplicateLinks(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(ctx, LinkName("test"))
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		Name: "test",
+	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, snd)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err = session.NewSender(ctx, LinkName("test"))
+	snd, err = session.NewSender(ctx, "target", &SenderOptions{
+		Name: "test",
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)
@@ -391,13 +411,17 @@ func TestSessionNewSenderMaxHandles(t *testing.T) {
 	session, err := client.NewSession(ctx, &SessionOptions{MaxLinks: 1})
 	cancel()
 	require.NoError(t, err)
-	ctx, cancel = context.WithTimeout(context.Background(), 100000*time.Second)
-	snd, err := session.NewSender(ctx, LinkName("test1"))
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		Name: "test1",
+	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, snd)
-	ctx, cancel = context.WithTimeout(context.Background(), 100000*time.Second)
-	snd, err = session.NewSender(ctx, LinkName("test2"))
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	snd, err = session.NewSender(ctx, "target", &SenderOptions{
+		Name: "test2",
+	})
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)
@@ -564,7 +588,7 @@ func TestSessionInvalidAttachDeadlock(t *testing.T) {
 		netConn.SendFrame(b)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(ctx)
+	snd, err := session.NewSender(ctx, "target", nil)
 	cancel()
 	require.Error(t, err)
 	require.Nil(t, snd)


### PR DESCRIPTION
Added SenderOptions and ReceiverOptions types which replicates the
previous functional options.
Options that are specific to senders/receivers have been moved to their
respective options types.
Added Ptr() methods to SenderSettleMode and ReceiverSettleMode to
simplify setting these optional values.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
