### PR TITLE
Fix race condition in tests simulating write errors

### DIFF
--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1428,7 +1428,7 @@ func TestReceiverConnWriterError(t *testing.T) {
 		errChan <- err
 	}()
 
-	conn.WriteErr = errors.New("failed")
+	conn.WriteErr <- errors.New("failed")
 	// trigger the write error
 	conn.SendKeepAlive()
 

--- a/sender_test.go
+++ b/sender_test.go
@@ -790,19 +790,19 @@ func TestSenderConnWriterError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, snd)
 
+	sendInitialFlowFrame(t, netConn, 0, 100)
+
 	// simulate some connWriter error
 	netConn.WriteErr <- errors.New("failed")
 
 	err = snd.Send(context.Background(), NewMessage([]byte("failed")))
 	var connErr *ConnectionError
-	if !errors.As(err, &connErr) {
-		t.Fatalf("unexpected error type %T", err)
-	}
+	require.ErrorAs(t, err, &connErr)
+	require.Equal(t, "failed", connErr.Error())
 
 	err = client.Close()
-	if !errors.As(err, &connErr) {
-		t.Fatalf("unexpected error type %T", err)
-	}
+	require.ErrorAs(t, err, &connErr)
+	require.Equal(t, "failed", connErr.Error())
 }
 
 func TestSenderFlowFrameWithEcho(t *testing.T) {

--- a/sender_test.go
+++ b/sender_test.go
@@ -791,7 +791,7 @@ func TestSenderConnWriterError(t *testing.T) {
 	require.NotNil(t, snd)
 
 	// simulate some connWriter error
-	netConn.WriteErr = errors.New("failed")
+	netConn.WriteErr <- errors.New("failed")
 
 	err = snd.Send(context.Background(), NewMessage([]byte("failed")))
 	var connErr *ConnectionError


### PR DESCRIPTION
Use a channel to communicate the fake write error.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
