### PR TITLE
Fixing disposition hanging if the link is closed

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -277,8 +277,13 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 		State:   state,
 	}
 
-	log.Debug(1, "TX (sendDisposition): %s", fr)
-	return r.link.Session.txFrame(fr, nil)
+	select {
+	case <-r.link.Detached:
+		return r.link.err
+	default:
+		log.Debug(1, "TX (sendDisposition): %s", fr)
+		return r.link.Session.txFrame(fr, nil)
+	}
 }
 
 func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state encoding.DeliveryState) error {

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -507,6 +507,66 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
+func TestReceiveSuccessModeSecondAcceptHang(t *testing.T) {
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch ff := req.(type) {
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return mocks.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			if _, ok := ff.State.(*encoding.StateAccepted); !ok {
+				return nil, fmt.Errorf("unexpected State %T", ff.State)
+			}
+			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := mocks.NewNetConn(responder)
+	client, err := New(conn, nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ModeSecond.Ptr(),
+	})
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx)
+	cancel()
+	require.NoError(t, err)
+	if c := r.link.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// wait for the link to pause as we've consumed all available credit
+	require.NoError(t, waitForLink(r.link, true))
+	// link credit must be zero since we only started with 1
+	if c := r.link.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+
+	require.NoError(t, r.Close(context.Background()))
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	require.ErrorIs(t, err, ErrLinkClosed)
+}
+
 func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -507,7 +507,7 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
-func TestReceiveSuccessModeSecondAcceptHang(t *testing.T) {
+func TestReceiveSuccessModeSecondAcceptOnClosedLink(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)
 	responder := func(req frames.FrameBody) ([]byte, error) {


### PR DESCRIPTION
Disposition of a message would hang if the link was closed prior to the settlement function being called.

The problem is that we don't do a link check to see if our link is valid anymore, which can lead to:

1. Receive message
2. Link is detached
3. Settle message

For message settlement all the traffic happens through the session and connection, not necessarily the link, which means that if the link is detached or dead we have a disposition that has a channel that we never close, resulting in a hang.

Fixes #126 