### PR TITLE
Don't ignore transfer frames during link detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.
 * Fixed potential panic in `attachLink()` when copying source filters.
 * `New()` will no longer return a broken `*Client` in some instances.
+* Incoming transfer frames received during initial link detach are no longer discarded.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
 * Disambiguate error message for distinct cases where a session wasn't found for the specified remote channel.
 * Removed `link.Paused` as it didn't add much value and was broken in some cases.
+* Only send one flow frame when a drain has been requested.

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -42,8 +42,13 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
-	drain := mc.drained != nil
+	drain := mc.pendingDrain
 	var credits uint32
+
+	if mc.pendingDrain {
+		// only send one drain request
+		mc.pendingDrain = false
+	}
 
 	// either:
 	// drain is true (ie, we're going to send a drain frame, and the credits for it should be 0)
@@ -55,7 +60,6 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	}
 
 	mc.creditsToAdd = 0
-	mc.pendingDrain = false
 
 	return drain, credits
 }
@@ -72,6 +76,7 @@ func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	mc.drained = make(chan struct{})
 	// use a local copy to avoid racing with EndDrain()
 	drained := mc.drained
+	mc.pendingDrain = true
 
 	mc.mu.Unlock()
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1421,10 +1421,6 @@ func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
 	b, err := mocks.PerformTransfer(0, 0, 1, []byte("message 1"))
 	require.NoError(t, err)
 	conn.SendFrame(b)
-	// this one will be pending until the first one is read
-	b, err = mocks.PerformTransfer(0, 0, 1, []byte("message 2"))
-	require.NoError(t, err)
-	conn.SendFrame(b)
 
 	// wait for the messages to "arrive"
 	time.Sleep(time.Second)


### PR DESCRIPTION
Peer can continue to send transfer frames until the detach request has
been acknowledged, so don't discard them.
Don't continuously send flow frames when a drain is requested.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
