### PR TITLE
Don't flood peer with flow frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,11 @@
 * Fixed potential panic in `attachLink()` when copying source filters.
 * `New()` will no longer return a broken `*Client` in some instances.
 * Incoming transfer frames received during initial link detach are no longer discarded.
+* Session will no longer flood peer with flow frames when half its incoming window is consumed.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
 * Disambiguate error message for distinct cases where a session wasn't found for the specified remote channel.
 * Removed `link.Paused` as it didn't add much value and was broken in some cases.
 * Only send one flow frame when a drain has been requested.
+* Session window size increased to 5000.

--- a/session.go
+++ b/session.go
@@ -16,7 +16,7 @@ import (
 
 // Default session options
 const (
-	defaultWindow = 1000
+	defaultWindow = 5000
 )
 
 // Default link options
@@ -40,6 +40,7 @@ type Session struct {
 	// flow control
 	incomingWindow uint32
 	outgoingWindow uint32
+	needFlowCount  uint32
 
 	handleMax        uint32
 	allocateHandle   chan *link // link handles are allocated by sending a link on this channel, nil is sent on link.rx once allocated
@@ -389,6 +390,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				s.muxFrameToLink(link, fr.Body)
 
 			case *frames.PerformTransfer:
+				s.needFlowCount++
 				// "Upon receiving a transfer, the receiving endpoint will
 				// increment the next-incoming-id to match the implicit
 				// transfer-id of the incoming transfer plus one, as well
@@ -415,9 +417,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					handlesByRemoteDeliveryID[*body.DeliveryID] = body.Handle
 				}
 
-				log.Debug(3, "TX(Session) Flow? remoteOutgoingWindow(%d) < s.incomingWindow(%d)/2\n", remoteOutgoingWindow, s.incomingWindow)
 				// Update peer's outgoing window if half has been consumed.
-				if remoteOutgoingWindow < s.incomingWindow/2 {
+				if s.needFlowCount >= s.incomingWindow/2 {
+					log.Debug(3, "TX(Session %d) Flow s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s.channel, s.needFlowCount, s.incomingWindow)
+					s.needFlowCount = 0
 					nID := nextIncomingID
 					flow := &frames.PerformFlow{
 						NextIncomingID: &nID,


### PR DESCRIPTION
Track the number of received transfer frames.  Once it's half or more of
the incoming window, send a flow frame to the peer to expand the window
and then reset the count.  This preserves the existing window behavior
without continuously sending flow frames until our peer sends one.
Increase window size to align with other implementations and also
resolve some issues uncovered during stress.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
