### PR TITLE
Make Session allocation/deallocation deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * `New()` will no longer return a broken `*Client` in some instances.
 * Incoming transfer frames received during initial link detach are no longer discarded.
 * Session will no longer flood peer with flow frames when half its incoming window is consumed.
+* Newly created `Session` won't leak if the context passed to `Client.NewSession()` expires before exit.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
@@ -40,3 +41,4 @@
 * Removed `link.Paused` as it didn't add much value and was broken in some cases.
 * Only send one flow frame when a drain has been requested.
 * Session window size increased to 5000.
+* Creation and deletion of `Session` instances have been made deterministic.

--- a/client.go
+++ b/client.go
@@ -96,13 +96,13 @@ func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session
 				_ = s.txFrame(&frames.PerformEnd{}, nil)
 				select {
 				case <-c.conn.Done:
-					// conn has terminated
+					// conn has terminated, no need to delete the session
 				case <-time.After(5 * time.Second):
-					// timed out
+					log.Debug(3, "NewSession clean-up timed out waiting for PerformEnd ack")
 				case <-s.rx:
-					// received ack that session was closed
+					// received ack that session was closed, safe to delete session
+					c.conn.DeleteSession(s)
 				}
-				c.conn.DeleteSession(s)
 			}()
 		default:
 			// begin wasn't written to the network, so delete session

--- a/client.go
+++ b/client.go
@@ -63,20 +63,10 @@ func (c *Client) Close() error {
 // Returns ErrConnClosed if the underlying connection has been closed.
 // opts: pass nil to accept the default values.
 func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
-	// get a session allocated by Client.mux
-	var sResp newSessionResp
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-c.conn.Done:
-		return nil, c.conn.Err()
-	case sResp = <-c.conn.NewSession:
+	s, err := c.conn.NewSession()
+	if err != nil {
+		return nil, err
 	}
-
-	if sResp.err != nil {
-		return nil, sResp.err
-	}
-	s := sResp.session
 	s.init(opts)
 
 	// send Begin to server
@@ -87,13 +77,37 @@ func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session
 		HandleMax:      s.handleMax,
 	}
 	log.Debug(1, "TX (NewSession): %s", begin)
-	_ = s.txFrame(begin, nil)
+
+	// we use send to have positive confirmation on transmission
+	send := make(chan encoding.DeliveryState)
+	_ = s.txFrame(begin, send)
 
 	// wait for response
 	var fr frames.Frame
 	select {
 	case <-ctx.Done():
-		// TODO: this will leak s
+		select {
+		case <-send:
+			// begin was written to the network.  assume it was
+			// received and that the ctx was too short to wait for
+			// the ack. in this case we must send an end before we
+			// can delete the session
+			go func() {
+				_ = s.txFrame(&frames.PerformEnd{}, nil)
+				select {
+				case <-c.conn.Done:
+					// conn has terminated
+				case <-time.After(5 * time.Second):
+					// timed out
+				case <-s.rx:
+					// received ack
+				}
+				c.conn.DeleteSession(s)
+			}()
+		default:
+			// begin wasn't written to the network, so delete session
+			c.conn.DeleteSession(s)
+		}
 		return nil, ctx.Err()
 	case <-c.conn.Done:
 		return nil, c.conn.Err()
@@ -109,12 +123,7 @@ func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session
 		// either swallow the frame or blow up in some other way, both causing this call to hang.
 		// deallocate session on error.  we can't call
 		// s.Close() as the session mux hasn't started yet.
-		select {
-		case <-ctx.Done():
-			// TODO: this will leak s
-			return nil, ctx.Err()
-		case c.conn.DelSession <- s:
-		}
+		c.conn.DeleteSession(s)
 		return nil, fmt.Errorf("unexpected begin response: %+v", fr.Body)
 	}
 

--- a/client.go
+++ b/client.go
@@ -100,7 +100,7 @@ func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session
 				case <-time.After(5 * time.Second):
 					// timed out
 				case <-s.rx:
-					// received ack
+					// received ack that session was closed
 				}
 				c.conn.DeleteSession(s)
 			}()
@@ -112,6 +112,7 @@ func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session
 	case <-c.conn.Done:
 		return nil, c.conn.Err()
 	case fr = <-s.rx:
+		// received ack that session was created
 	}
 	log.Debug(1, "RX (NewSession): %s", fr.Body)
 

--- a/client_test.go
+++ b/client_test.go
@@ -398,3 +398,116 @@ func TestClientNewSessionInvalidSecondResponseDifferentChannel(t *testing.T) {
 	require.Nil(t, session)
 	require.Error(t, client.Close())
 }
+
+func TestNewSessionTimedOut(t *testing.T) {
+	endAck := make(chan struct{})
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			// swallow the frame so NewSession never gets an ack
+			return nil, nil
+		case *frames.PerformEnd:
+			close(endAck)
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn, nil)
+	require.NoError(t, err)
+	// fisrt session succeeds
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, session)
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive end ack")
+	case <-endAck:
+		// expected
+	}
+}
+
+func TestNewSessionWriteError(t *testing.T) {
+	endAck := make(chan struct{})
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			return nil, errors.New("write error")
+		case *frames.PerformEnd:
+			close(endAck)
+			return mocks.PerformEnd(0, nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn, nil)
+	require.NoError(t, err)
+	// fisrt session succeeds
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	var connErr *ConnectionError
+	require.ErrorAs(t, err, &connErr)
+	require.Equal(t, "write error", connErr.Error())
+	require.Nil(t, session)
+
+	select {
+	case <-time.After(time.Second):
+		// expected
+	case <-endAck:
+		t.Fatal("unexpected ack")
+	}
+}
+
+func TestNewSessionTimedOutAckTimedOut(t *testing.T) {
+	endAck := make(chan struct{})
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch req.(type) {
+		case *mocks.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return mocks.PerformOpen("container")
+		case *frames.PerformBegin:
+			// swallow the frame so NewSession never gets an ack
+			return nil, nil
+		case *frames.PerformEnd:
+			close(endAck)
+			// swallow the frame so the closing goroutine never gets an ack
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := mocks.NewNetConn(responder)
+
+	client, err := New(netConn, nil)
+	require.NoError(t, err)
+	// fisrt session succeeds
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, session)
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive end ack")
+	case <-endAck:
+		// expected
+	}
+}

--- a/conn.go
+++ b/conn.go
@@ -126,11 +126,14 @@ type conn struct {
 	Done  chan struct{} // indicates the connection is done
 
 	// mux
-	NewSession   chan newSessionResp // new Sessions are requested from mux by reading off this channel
-	DelSession   chan *Session       // session completion is indicated to mux by sending the Session on this channel
-	connErr      chan error          // connReader/Writer notifications of an error
-	closeMux     chan struct{}       // indicates that the mux should stop
+	connErr      chan error    // connReader/Writer notifications of an error
+	closeMux     chan struct{} // indicates that the mux should stop
 	closeMuxOnce sync.Once
+
+	// session tracking
+	channels            *bitmap.Bitmap
+	sessionsByChannel   map[uint16]*Session
+	sessionsByChannelMu sync.RWMutex
 
 	// connReader
 	rxProto       chan protoHeader  // protoHeaders received by connReader
@@ -142,11 +145,6 @@ type conn struct {
 	txFrame chan frames.Frame // AMQP frames to be sent by connWriter
 	txBuf   buffer.Buffer     // buffer for marshaling frames before transmitting
 	txDone  chan struct{}
-}
-
-type newSessionResp struct {
-	session *Session
-	err     error
 }
 
 // implements the dialer interface
@@ -216,24 +214,23 @@ func dialConn(addr string, opts *ConnOptions) (*conn, error) {
 
 func newConn(netConn net.Conn, opts *ConnOptions) (*conn, error) {
 	c := &conn{
-		dialer:           defaultDialer{},
-		net:              netConn,
-		maxFrameSize:     defaultMaxFrameSize,
-		PeerMaxFrameSize: defaultMaxFrameSize,
-		channelMax:       defaultMaxSessions - 1, // -1 because channel-max starts at zero
-		idleTimeout:      defaultIdleTimeout,
-		containerID:      randString(40),
-		Done:             make(chan struct{}),
-		connErr:          make(chan error, 2), // buffered to ensure connReader/Writer won't leak
-		closeMux:         make(chan struct{}),
-		rxProto:          make(chan protoHeader),
-		rxFrame:          make(chan frames.Frame),
-		rxDone:           make(chan struct{}),
-		connReaderRun:    make(chan func(), 1), // buffered to allow queueing function before interrupt
-		NewSession:       make(chan newSessionResp),
-		DelSession:       make(chan *Session),
-		txFrame:          make(chan frames.Frame),
-		txDone:           make(chan struct{}),
+		dialer:            defaultDialer{},
+		net:               netConn,
+		maxFrameSize:      defaultMaxFrameSize,
+		PeerMaxFrameSize:  defaultMaxFrameSize,
+		channelMax:        defaultMaxSessions - 1, // -1 because channel-max starts at zero
+		idleTimeout:       defaultIdleTimeout,
+		containerID:       randString(40),
+		Done:              make(chan struct{}),
+		connErr:           make(chan error, 2), // buffered to ensure connReader/Writer won't leak
+		closeMux:          make(chan struct{}),
+		rxProto:           make(chan protoHeader),
+		rxFrame:           make(chan frames.Frame),
+		rxDone:            make(chan struct{}),
+		connReaderRun:     make(chan func(), 1), // buffered to allow queueing function before interrupt
+		txFrame:           make(chan frames.Frame),
+		txDone:            make(chan struct{}),
+		sessionsByChannel: map[uint16]*Session{},
 	}
 
 	// apply options
@@ -314,6 +311,10 @@ func (c *conn) Start() error {
 		}
 	}
 
+	// we can't create the channel bitmap until the connection has been established.
+	// this is because our peer can tell us the max channels they support.
+	c.channels = bitmap.New(uint32(c.channelMax))
+
 	// start multiplexor and writer
 	go c.mux()
 	go c.connWriter()
@@ -378,20 +379,35 @@ func (c *conn) Err() error {
 	return &ConnectionError{inner: c.err}
 }
 
+func (c *conn) NewSession() (*Session, error) {
+	c.sessionsByChannelMu.Lock()
+	defer c.sessionsByChannelMu.Unlock()
+
+	// create the next session to allocate
+	// note that channel always start at 0
+	channel, ok := c.channels.Next()
+	if !ok {
+		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
+	}
+	session := newSession(c, uint16(channel))
+	ch := session.channel
+	c.sessionsByChannel[ch] = session
+	return session, nil
+}
+
+func (c *conn) DeleteSession(s *Session) {
+	c.sessionsByChannelMu.Lock()
+	defer c.sessionsByChannelMu.Unlock()
+
+	delete(c.sessionsByChannel, s.channel)
+	c.channels.Remove(uint32(s.channel))
+}
+
 // mux is started in it's own goroutine after initial connection establishment.
 // It handles muxing of sessions, keepalives, and connection errors.
 func (c *conn) mux() {
 	var (
-		// allocated channels
-		channels = bitmap.New(uint32(c.channelMax))
-
-		// create the next session to allocate
-		// note that channel always start at 0, and 0 is special and can't be deleted
-		nextChannel, _ = channels.Next()
-		nextSession    = newSessionResp{session: newSession(c, uint16(nextChannel))}
-
 		// map channels to sessions
-		sessionsByChannel       = make(map[uint16]*Session)
 		sessionsByRemoteChannel = make(map[uint16]*Session)
 	)
 
@@ -433,9 +449,11 @@ func (c *conn) mux() {
 					c.err = fmt.Errorf("%T: nil RemoteChannel", fr.Body)
 					break
 				}
-				session, ok = sessionsByChannel[*body.RemoteChannel]
+				c.sessionsByChannelMu.RLock()
+				session, ok = c.sessionsByChannel[*body.RemoteChannel]
+				c.sessionsByChannelMu.RUnlock()
 				if !ok {
-					c.err = fmt.Errorf("unexpected remote channel number %d, expected %d", *body.RemoteChannel, nextChannel)
+					c.err = fmt.Errorf("unexpected remote channel number %d", *body.RemoteChannel)
 					break
 				}
 
@@ -470,37 +488,6 @@ func (c *conn) mux() {
 			case <-c.closeMux:
 				return
 			}
-
-		// new session request
-		//
-		// Continually try to send the next session on the channel,
-		// then add it to the sessions map. This allows us to control ID
-		// allocation and prevents the need to have shared map. Since new
-		// sessions are far less frequent than frames being sent to sessions,
-		// this avoids the lock/unlock for session lookup.
-		case c.NewSession <- nextSession:
-			if nextSession.err != nil {
-				continue
-			}
-
-			// save session into map
-			ch := nextSession.session.channel
-			sessionsByChannel[ch] = nextSession.session
-
-			// get next available channel
-			next, ok := channels.Next()
-			if !ok {
-				nextSession = newSessionResp{err: fmt.Errorf("reached connection channel max (%d)", c.channelMax)}
-				continue
-			}
-
-			// create the next session to send
-			nextSession = newSessionResp{session: newSession(c, uint16(next))}
-
-		// session deletion
-		case s := <-c.DelSession:
-			delete(sessionsByChannel, s.channel)
-			channels.Remove(uint32(s.channel))
 
 		// connection is complete
 		case <-c.closeMux:

--- a/conn.go
+++ b/conn.go
@@ -390,8 +390,7 @@ func (c *conn) NewSession() (*Session, error) {
 		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
 	}
 	session := newSession(c, uint16(channel))
-	ch := session.channel
-	c.sessionsByChannel[ch] = session
+	c.sessionsByChannel[session.channel] = session
 	return session, nil
 }
 

--- a/session.go
+++ b/session.go
@@ -167,15 +167,7 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
-		// clean up session record in conn.mux()
-		select {
-		case <-s.rx:
-			// discard any incoming frames to keep conn mux unblocked
-		case s.conn.DelSession <- s:
-			// successfully deleted session
-		case <-s.conn.Done:
-			s.err = s.conn.Err()
-		}
+		s.conn.DeleteSession(s)
 		if s.err == nil {
 			s.err = ErrSessionClosed
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -33,10 +33,7 @@ func TestSessionClose(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-			// channel 0 can never be deleted, however other channels can.
-			if channelNum > 1 {
-				channelNum = 0
-			}
+			channelNum--
 			return b, nil
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)


### PR DESCRIPTION
Session objects are now managed via NewSession() and DeleteSession()
APIs on conn, no longer requiring mux to be "pumped".
Potential Session object leak due to expiring context has been fixed.

Fixes https://github.com/Azure/go-amqp/issues/164
