### PR TITLE
Make link allocation/deallocation deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Incoming transfer frames received during initial link detach are no longer discarded.
 * Session will no longer flood peer with flow frames when half its incoming window is consumed.
 * Newly created `Session` won't leak if the context passed to `Client.NewSession()` expires before exit.
+* Newly created `link` won't leak if the context passed to `link.attach()` expires before exit.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.
@@ -42,3 +43,4 @@
 * Only send one flow frame when a drain has been requested.
 * Session window size increased to 5000.
 * Creation and deletion of `Session` instances have been made deterministic.
+* Allocation and deallocation of link handles has been made deterministic.

--- a/link.go
+++ b/link.go
@@ -294,11 +294,11 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 				case <-s.done:
 					// session has terminated
 				case <-time.After(5 * time.Second):
-					// timed out
+					log.Debug(3, "link.attach() clean-up timed out waiting for ack")
 				case <-l.RX:
-					// received ack
+					// received ack, safe to delete handle
+					s.deallocateHandle(l)
 				}
-				s.deallocateHandle(l)
 			}()
 		default:
 			// attach wasn't written to the network, so delete the handle

--- a/link.go
+++ b/link.go
@@ -292,7 +292,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 				}, nil)
 				select {
 				case <-s.done:
-					// session has terminated
+					// session has terminated, no need to deallocate in this case
 				case <-time.After(5 * time.Second):
 					log.Debug(3, "link.attach() clean-up timed out waiting for ack")
 				case <-l.RX:
@@ -306,6 +306,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 		}
 		return ctx.Err()
 	case <-s.done:
+		// session has terminated, no need to deallocate in this case
 		return s.err
 	case fr = <-l.RX:
 	}

--- a/link.go
+++ b/link.go
@@ -294,7 +294,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 				case <-s.done:
 					// session has terminated, no need to deallocate in this case
 				case <-time.After(5 * time.Second):
-					log.Debug(3, "link.attach() clean-up timed out waiting for ack")
+					debug.Log(3, "link.attach() clean-up timed out waiting for ack")
 				case <-l.RX:
 					// received ack, safe to delete handle
 					s.deallocateHandle(l)

--- a/link.go
+++ b/link.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Azure/go-amqp/internal/buffer"
 	"github.com/Azure/go-amqp/internal/debug"
@@ -239,28 +240,8 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 		l.RX = make(chan frames.FrameBody, 1)
 	}
 
-	// request handle from Session.mux
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-s.done:
-		return s.err
-	case s.allocateHandle <- l:
-	}
-
-	// wait for handle allocation
-	select {
-	case <-ctx.Done():
-		// TODO: this _might_ leak l's handle
-		return ctx.Err()
-	case <-s.done:
-		return s.err
-	case <-l.RX:
-	}
-
-	// check for link request error
-	if l.err != nil {
-		return l.err
+	if err := s.allocateHandle(l); err != nil {
+		return err
 	}
 
 	attach := &frames.PerformAttach{
@@ -290,13 +271,39 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 
 	// send Attach frame
 	debug.Log(1, "TX (attachLink): %s", attach)
-	_ = s.txFrame(attach, nil)
+
+	// we use send to have positive confirmation on transmission
+	send := make(chan encoding.DeliveryState)
+	_ = s.txFrame(attach, send)
 
 	// wait for response
 	var fr frames.FrameBody
 	select {
 	case <-ctx.Done():
-		// TODO: this leaks l's handle
+		select {
+		case <-send:
+			// attach was written to the network. assume it was received
+			// and that the ctx was too short to wait for the ack. in this
+			// case we must send a detach before deallocation
+			go func() {
+				_ = s.txFrame(&frames.PerformDetach{
+					Handle: l.Handle,
+					Closed: true,
+				}, nil)
+				select {
+				case <-s.done:
+					// session has terminated
+				case <-time.After(5 * time.Second):
+					// timed out
+				case <-l.RX:
+					// received ack
+				}
+				s.deallocateHandle(l)
+			}()
+		default:
+			// attach wasn't written to the network, so delete the handle
+			s.deallocateHandle(l)
+		}
 		return ctx.Err()
 	case <-s.done:
 		return s.err
@@ -321,11 +328,19 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 		// wait for detach
 		select {
 		case <-ctx.Done():
-			// TODO: this leaks l's handle
+			// if we don't send an ack then we're in violation of the protocol
+			go func() {
+				_ = s.txFrame(&frames.PerformDetach{
+					Handle: l.Handle,
+					Closed: true,
+				}, nil)
+				s.deallocateHandle(l)
+			}()
 			return ctx.Err()
 		case <-s.done:
 			return s.err
 		case fr = <-l.RX:
+			s.deallocateHandle(l)
 		}
 
 		detach, ok := fr.(*frames.PerformDetach)
@@ -927,22 +942,7 @@ func (l *link) muxDetach() {
 		// final cleanup and signaling
 
 		// deallocate handle
-	Loop:
-		for {
-			select {
-			case <-l.RX:
-				// at this point we shouldn't be receiving any more frames for
-				// this link. however, if we do, we need to keep the session mux
-				// unblocked else we deadlock.  so just read and discard them.
-			case l.Session.deallocateHandle <- l:
-				break Loop
-			case <-l.Session.done:
-				if l.err == nil {
-					l.err = l.Session.err
-				}
-				break Loop
-			}
-		}
+		l.Session.deallocateHandle(l)
 
 		// unblock any in flight message dispositions
 		if l.receiver != nil {
@@ -1003,9 +1003,8 @@ Loop:
 		}
 	}
 
-	// don't wait for remote to detach when already
-	// received or closing due to error
-	if l.detachReceived || detachError != nil {
+	// don't wait for remote to detach when already received
+	if l.detachReceived {
 		return
 	}
 


### PR DESCRIPTION
Link handles are now managed via allocateHandle() and
deallocationHandle() APIs on Session, no longer requiring mux to be
"pumped".
Potential handle leak due to expiring context has been fixed.

Fixes https://github.com/Azure/go-amqp/issues/166