### PR TITLE
Update to latest two versions of Go

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        Linux_Go117:
-          vm.image: 'ubuntu-18.04'
-          go.version: '1.17.12'
         Linux_Go118:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.18.4'
+          go.version: '1.18.5'
+        Linux_Go119:
+          vm.image: 'ubuntu-18.04'
+          go.version: '1.19'
 
     pool:
       vmImage: '$(vm.image)'
@@ -35,7 +35,7 @@ jobs:
         displayName: 'Install Dependencies'
 
       - script: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0
           golangci-lint --version
           golangci-lint run
         displayName: 'Install and Run GoLintCLI.'

--- a/client.go
+++ b/client.go
@@ -171,7 +171,9 @@ func randString(n int) string {
 // linkKey uniquely identifies a link on a connection by name and direction.
 //
 // A link can be identified uniquely by the ordered tuple
-//     (source-container-id, target-container-id, name)
+//
+//	(source-container-id, target-container-id, name)
+//
 // On a single connection the container ID pairs can be abbreviated
 // to a boolean flag indicating the direction of the link.
 type linkKey struct {

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -12,18 +12,20 @@ import (
 
 /*
 <type name="source" class="composite" source="list" provides="source">
-    <descriptor name="amqp:source:list" code="0x00000000:0x00000028"/>
-    <field name="address" type="*" requires="address"/>
-    <field name="durable" type="terminus-durability" default="none"/>
-    <field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
-    <field name="timeout" type="seconds" default="0"/>
-    <field name="dynamic" type="boolean" default="false"/>
-    <field name="dynamic-node-properties" type="node-properties"/>
-    <field name="distribution-mode" type="symbol" requires="distribution-mode"/>
-    <field name="filter" type="filter-set"/>
-    <field name="default-outcome" type="*" requires="outcome"/>
-    <field name="outcomes" type="symbol" multiple="true"/>
-    <field name="capabilities" type="symbol" multiple="true"/>
+
+	<descriptor name="amqp:source:list" code="0x00000000:0x00000028"/>
+	<field name="address" type="*" requires="address"/>
+	<field name="durable" type="terminus-durability" default="none"/>
+	<field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
+	<field name="timeout" type="seconds" default="0"/>
+	<field name="dynamic" type="boolean" default="false"/>
+	<field name="dynamic-node-properties" type="node-properties"/>
+	<field name="distribution-mode" type="symbol" requires="distribution-mode"/>
+	<field name="filter" type="filter-set"/>
+	<field name="default-outcome" type="*" requires="outcome"/>
+	<field name="outcomes" type="symbol" multiple="true"/>
+	<field name="capabilities" type="symbol" multiple="true"/>
+
 </type>
 */
 type Source struct {
@@ -196,14 +198,16 @@ func (s Source) String() string {
 
 /*
 <type name="target" class="composite" source="list" provides="target">
-    <descriptor name="amqp:target:list" code="0x00000000:0x00000029"/>
-    <field name="address" type="*" requires="address"/>
-    <field name="durable" type="terminus-durability" default="none"/>
-    <field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
-    <field name="timeout" type="seconds" default="0"/>
-    <field name="dynamic" type="boolean" default="false"/>
-    <field name="dynamic-node-properties" type="node-properties"/>
-    <field name="capabilities" type="symbol" multiple="true"/>
+
+	<descriptor name="amqp:target:list" code="0x00000000:0x00000029"/>
+	<field name="address" type="*" requires="address"/>
+	<field name="durable" type="terminus-durability" default="none"/>
+	<field name="expiry-policy" type="terminus-expiry-policy" default="session-end"/>
+	<field name="timeout" type="seconds" default="0"/>
+	<field name="dynamic" type="boolean" default="false"/>
+	<field name="dynamic-node-properties" type="node-properties"/>
+	<field name="capabilities" type="symbol" multiple="true"/>
+
 </type>
 */
 type Target struct {
@@ -425,15 +429,17 @@ func (o *PerformOpen) String() string {
 
 /*
 <type name="begin" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:begin:list" code="0x00000000:0x00000011"/>
-    <field name="remote-channel" type="ushort"/>
-    <field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
-    <field name="incoming-window" type="uint" mandatory="true"/>
-    <field name="outgoing-window" type="uint" mandatory="true"/>
-    <field name="handle-max" type="handle" default="4294967295"/>
-    <field name="offered-capabilities" type="symbol" multiple="true"/>
-    <field name="desired-capabilities" type="symbol" multiple="true"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:begin:list" code="0x00000000:0x00000011"/>
+	<field name="remote-channel" type="ushort"/>
+	<field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
+	<field name="incoming-window" type="uint" mandatory="true"/>
+	<field name="outgoing-window" type="uint" mandatory="true"/>
+	<field name="handle-max" type="handle" default="4294967295"/>
+	<field name="offered-capabilities" type="symbol" multiple="true"/>
+	<field name="desired-capabilities" type="symbol" multiple="true"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformBegin struct {
@@ -526,21 +532,23 @@ func (b *PerformBegin) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="attach" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:attach:list" code="0x00000000:0x00000012"/>
-    <field name="name" type="string" mandatory="true"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="role" type="role" mandatory="true"/>
-    <field name="snd-settle-mode" type="sender-settle-mode" default="mixed"/>
-    <field name="rcv-settle-mode" type="receiver-settle-mode" default="first"/>
-    <field name="source" type="*" requires="source"/>
-    <field name="target" type="*" requires="target"/>
-    <field name="unsettled" type="map"/>
-    <field name="incomplete-unsettled" type="boolean" default="false"/>
-    <field name="initial-delivery-count" type="sequence-no"/>
-    <field name="max-message-size" type="ulong"/>
-    <field name="offered-capabilities" type="symbol" multiple="true"/>
-    <field name="desired-capabilities" type="symbol" multiple="true"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:attach:list" code="0x00000000:0x00000012"/>
+	<field name="name" type="string" mandatory="true"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="role" type="role" mandatory="true"/>
+	<field name="snd-settle-mode" type="sender-settle-mode" default="mixed"/>
+	<field name="rcv-settle-mode" type="receiver-settle-mode" default="first"/>
+	<field name="source" type="*" requires="source"/>
+	<field name="target" type="*" requires="target"/>
+	<field name="unsettled" type="map"/>
+	<field name="incomplete-unsettled" type="boolean" default="false"/>
+	<field name="initial-delivery-count" type="sequence-no"/>
+	<field name="max-message-size" type="ulong"/>
+	<field name="offered-capabilities" type="symbol" multiple="true"/>
+	<field name="desired-capabilities" type="symbol" multiple="true"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformAttach struct {
@@ -737,18 +745,20 @@ func (a *PerformAttach) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="flow" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:flow:list" code="0x00000000:0x00000013"/>
-    <field name="next-incoming-id" type="transfer-number"/>
-    <field name="incoming-window" type="uint" mandatory="true"/>
-    <field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
-    <field name="outgoing-window" type="uint" mandatory="true"/>
-    <field name="handle" type="handle"/>
-    <field name="delivery-count" type="sequence-no"/>
-    <field name="link-credit" type="uint"/>
-    <field name="available" type="uint"/>
-    <field name="drain" type="boolean" default="false"/>
-    <field name="echo" type="boolean" default="false"/>
-    <field name="properties" type="fields"/>
+
+	<descriptor name="amqp:flow:list" code="0x00000000:0x00000013"/>
+	<field name="next-incoming-id" type="transfer-number"/>
+	<field name="incoming-window" type="uint" mandatory="true"/>
+	<field name="next-outgoing-id" type="transfer-number" mandatory="true"/>
+	<field name="outgoing-window" type="uint" mandatory="true"/>
+	<field name="handle" type="handle"/>
+	<field name="delivery-count" type="sequence-no"/>
+	<field name="link-credit" type="uint"/>
+	<field name="available" type="uint"/>
+	<field name="drain" type="boolean" default="false"/>
+	<field name="echo" type="boolean" default="false"/>
+	<field name="properties" type="fields"/>
+
 </type>
 */
 type PerformFlow struct {
@@ -910,18 +920,20 @@ func (f *PerformFlow) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="transfer" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:transfer:list" code="0x00000000:0x00000014"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="delivery-id" type="delivery-number"/>
-    <field name="delivery-tag" type="delivery-tag"/>
-    <field name="message-format" type="message-format"/>
-    <field name="settled" type="boolean"/>
-    <field name="more" type="boolean" default="false"/>
-    <field name="rcv-settle-mode" type="receiver-settle-mode"/>
-    <field name="state" type="*" requires="delivery-state"/>
-    <field name="resume" type="boolean" default="false"/>
-    <field name="aborted" type="boolean" default="false"/>
-    <field name="batchable" type="boolean" default="false"/>
+
+	<descriptor name="amqp:transfer:list" code="0x00000000:0x00000014"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="delivery-id" type="delivery-number"/>
+	<field name="delivery-tag" type="delivery-tag"/>
+	<field name="message-format" type="message-format"/>
+	<field name="settled" type="boolean"/>
+	<field name="more" type="boolean" default="false"/>
+	<field name="rcv-settle-mode" type="receiver-settle-mode"/>
+	<field name="state" type="*" requires="delivery-state"/>
+	<field name="resume" type="boolean" default="false"/>
+	<field name="aborted" type="boolean" default="false"/>
+	<field name="batchable" type="boolean" default="false"/>
+
 </type>
 */
 type PerformTransfer struct {
@@ -1141,13 +1153,15 @@ func (t *PerformTransfer) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="disposition" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:disposition:list" code="0x00000000:0x00000015"/>
-    <field name="role" type="role" mandatory="true"/>
-    <field name="first" type="delivery-number" mandatory="true"/>
-    <field name="last" type="delivery-number"/>
-    <field name="settled" type="boolean" default="false"/>
-    <field name="state" type="*" requires="delivery-state"/>
-    <field name="batchable" type="boolean" default="false"/>
+
+	<descriptor name="amqp:disposition:list" code="0x00000000:0x00000015"/>
+	<field name="role" type="role" mandatory="true"/>
+	<field name="first" type="delivery-number" mandatory="true"/>
+	<field name="last" type="delivery-number"/>
+	<field name="settled" type="boolean" default="false"/>
+	<field name="state" type="*" requires="delivery-state"/>
+	<field name="batchable" type="boolean" default="false"/>
+
 </type>
 */
 type PerformDisposition struct {
@@ -1225,10 +1239,12 @@ func (d *PerformDisposition) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="detach" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:detach:list" code="0x00000000:0x00000016"/>
-    <field name="handle" type="handle" mandatory="true"/>
-    <field name="closed" type="boolean" default="false"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:detach:list" code="0x00000000:0x00000016"/>
+	<field name="handle" type="handle" mandatory="true"/>
+	<field name="closed" type="boolean" default="false"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformDetach struct {
@@ -1273,8 +1289,10 @@ func (d *PerformDetach) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="end" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:end:list" code="0x00000000:0x00000017"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:end:list" code="0x00000000:0x00000017"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformEnd struct {
@@ -1301,8 +1319,10 @@ func (e *PerformEnd) Unmarshal(r *buffer.Buffer) error {
 
 /*
 <type name="close" class="composite" source="list" provides="frame">
-    <descriptor name="amqp:close:list" code="0x00000000:0x00000018"/>
-    <field name="error" type="error"/>
+
+	<descriptor name="amqp:close:list" code="0x00000000:0x00000018"/>
+	<field name="error" type="error"/>
+
 </type>
 */
 type PerformClose struct {

--- a/link_options.go
+++ b/link_options.go
@@ -175,14 +175,18 @@ type ReceiverOptions struct {
 // Example:
 //
 // The standard selector-filter is defined as:
-//  <descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
+//
+//	<descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
+//
 // In this case the name is "apache.org:selector-filter:string" and the code is
 // 0x0000468C00000004.
-//  LinkSourceFilter("apache.org:selector-filter:string", 0x0000468C00000004, exampleValue)
+//
+//	LinkSourceFilter("apache.org:selector-filter:string", 0x0000468C00000004, exampleValue)
 //
 // References:
-//  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
-//  http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
+//
+//	http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
+//	http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
 type LinkFilter func(encoding.Filter)
 
 // LinkFilterSource creates or updates the named filter for this LinkFilter.

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -35,9 +35,10 @@ func (mc *manualCreditor) EndDrain() {
 // FlowBits gets gets the proper values for the next flow frame
 // and resets the internal state.
 // Returns:
-//   (drain: true, credits: 0) if a flow is needed (drain)
-//   (drain: false, credits > 0) if a flow is needed (issue credit)
-//   (drain: false, credits == 0) if no flow needed.
+//
+//	(drain: true, credits: 0) if a flow is needed (drain)
+//	(drain: false, credits > 0) if a flow is needed (issue credit)
+//	(drain: false, credits == 0) if no flow needed.
 func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -34,7 +34,7 @@ func TestSaslXOAUTH2InitialResponse(t *testing.T) {
 	}
 }
 
-//RFC6749 defines the OAUTH2 as comprising VSCHAR elements (\x20-7E)
+// RFC6749 defines the OAUTH2 as comprising VSCHAR elements (\x20-7E)
 func TestSaslXOAUTH2InvalidBearer(t *testing.T) {
 	tests := []struct {
 		label   string


### PR DESCRIPTION
Update to latest golangci-lint for Go 1.19.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
