### PR TITLE
Select between dispositions channel and detached channel when pushing dispositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Incoming transfer frames received during initial link detach are no longer discarded.
 * Session will no longer flood peer with flow frames when half its incoming window is consumed.
 * Newly created `Session` won't leak if the context passed to `Client.NewSession()` expires before exit.
+* Fixed an issue causing dispositions to hang indefinitely with batching enabled when the receiver link is disconnected.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.

--- a/receiver.go
+++ b/receiver.go
@@ -294,7 +294,11 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	}
 
 	if r.batching {
-		r.dispositions <- messageDisposition{id: msg.deliveryID, state: state}
+		select {
+		case r.dispositions <- messageDisposition{id: msg.deliveryID, state: state}:
+		case <-r.link.Detached:
+			return ErrLinkClosed
+		}
 	} else {
 		err := r.sendDisposition(msg.deliveryID, nil, state)
 		if err != nil {


### PR DESCRIPTION
Fixes #184

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes. 
   - The race condition causing 184 is so small that it would be somewhat impractical to test with unit tests
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.
  - No new files added

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
