### PR TITLE
Refactor link implementation

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -115,7 +115,7 @@ func waitForReceiver(r *Receiver, paused bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	for {
-		credit := atomic.LoadUint32(&r.linkCredit)
+		credit := atomic.LoadUint32(&r.l.linkCredit)
 		// waiting for the link to pause means its credit has been consumed
 		if (paused && credit == 0) || (!paused && credit > 0) {
 			return nil
@@ -123,8 +123,8 @@ func waitForReceiver(r *Receiver, paused bool) error {
 			return err
 		}
 		select {
-		case <-r.detached:
-			return fmt.Errorf("link detached: detachErr %v, error %v", r.detachError, r.err)
+		case <-r.l.detached:
+			return fmt.Errorf("link detached: detachErr %v, error %v", r.l.detachError, r.l.err)
 		case <-time.After(50 * time.Millisecond):
 			// try again
 		}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -111,11 +111,11 @@ func receiverFrameHandlerNoUnhandled(rsm encoding.ReceiverSettleMode) func(frame
 
 // helper to wait for a link to pause/resume
 // returns an error if it times out waiting
-func waitForLink(l *link, paused bool) error {
+func waitForReceiver(r *Receiver, paused bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	for {
-		credit := atomic.LoadUint32(&l.linkCredit)
+		credit := atomic.LoadUint32(&r.linkCredit)
 		// waiting for the link to pause means its credit has been consumed
 		if (paused && credit == 0) || (!paused && credit > 0) {
 			return nil
@@ -123,8 +123,8 @@ func waitForLink(l *link, paused bool) error {
 			return err
 		}
 		select {
-		case <-l.Detached:
-			return fmt.Errorf("link detached: detachErr %v, error %v", l.detachError, l.err)
+		case <-r.detached:
+			return fmt.Errorf("link detached: detachErr %v, error %v", r.detachError, r.err)
 		case <-time.After(50 * time.Millisecond):
 			// try again
 		}

--- a/link.go
+++ b/link.go
@@ -54,7 +54,7 @@ type link struct {
 
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
-func (l *link) attachLink(ctx context.Context, s *Session, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
+func (l *link) attach(ctx context.Context, s *Session, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
 	if err := s.allocateHandle(l); err != nil {
 		return err
 	}

--- a/link.go
+++ b/link.go
@@ -208,21 +208,6 @@ func (l *link) setSettleModes(resp *frames.PerformAttach) error {
 	return nil
 }
 
-// Close closes the Sender and AMQP link.
-func (l *link) closeLink(ctx context.Context) error {
-	l.closeOnce.Do(func() { close(l.close) })
-	select {
-	case <-l.detached:
-		// mux exited
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	if l.err == ErrLinkClosed {
-		return nil
-	}
-	return l.err
-}
-
 // muxHandleFrame processes fr based on type.
 func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 	switch fr := fr.(type) {
@@ -245,6 +230,21 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 	}
 
 	return nil
+}
+
+// Close closes the Sender and AMQP link.
+func (l *link) closeLink(ctx context.Context) error {
+	l.closeOnce.Do(func() { close(l.close) })
+	select {
+	case <-l.detached:
+		// mux exited
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if l.err == ErrLinkClosed {
+		return nil
+	}
+	return l.err
 }
 
 func (l *link) muxDetach(deferred func(), onRXTransfer func(frames.PerformTransfer)) {

--- a/link.go
+++ b/link.go
@@ -1,31 +1,25 @@
 package amqp
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
-	"github.com/Azure/go-amqp/internal/buffer"
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
-	"github.com/Azure/go-amqp/internal/shared"
 )
 
-// link is a unidirectional route.
-//
-// May be used for sending or receiving.
+// link contains the common state and methods for sending and receiving links
 type link struct {
-	Key          linkKey                     // Name and direction
-	Handle       uint32                      // our handle
-	RemoteHandle uint32                      // remote's handle
-	dynamicAddr  bool                        // request a dynamic link address from the server
-	RX           chan frames.FrameBody       // sessions sends frames for this link on this channel
-	Transfers    chan frames.PerformTransfer // sender uses to send transfer frames
-	closeOnce    sync.Once                   // closeOnce protects close from being closed multiple times
+	key          linkKey               // Name and direction
+	handle       uint32                // our handle
+	remoteHandle uint32                // remote's handle
+	dynamicAddr  bool                  // request a dynamic link address from the server
+	rx           chan frames.FrameBody // sessions sends frames for this link on this channel
+
+	closeOnce sync.Once // closeOnce protects close from being closed multiple times
 
 	// close signals the mux to shutdown. This indicates that `Close()` was called on this link.
 	// NOTE: observers outside of link.go *must only* use the Detached channel to check if the link is unavailable.
@@ -34,20 +28,14 @@ type link struct {
 
 	// detached is closed by mux/muxDetach when the link is fully detached.
 	// This will be initiated if the service sends back an error or requests the link detach.
-	Detached chan struct{}
+	detached chan struct{}
 
 	detachErrorMu sync.Mutex                      // protects detachError
 	detachError   *Error                          // error to send to remote on detach, set by closeWithError
-	Session       *Session                        // parent session
-	receiver      *Receiver                       // allows link options to modify Receiver
-	Source        *frames.Source                  // used for Receiver links
-	Target        *frames.Target                  // used for Sender links
+	session       *Session                        // parent session
+	source        *frames.Source                  // used for Receiver links
+	target        *frames.Target                  // used for Sender links
 	properties    map[encoding.Symbol]interface{} // additional properties sent upon link attach
-	// Indicates whether we should allow detaches on disposition errors or not.
-	// Some AMQP servers (like Event Hubs) benefit from keeping the link open on disposition errors
-	// (for instance, if you're doing many parallel sends over the same link and you get back a
-	// throttling error, which is not fatal)
-	detachOnDispositionError bool
 
 	// "The delivery-count is initialized by the sender when a link endpoint is created,
 	// and is incremented whenever a message is sent. Only the sender MAY independently
@@ -57,218 +45,33 @@ type link struct {
 	// initialized at an arbitrary point by the sender."
 	deliveryCount      uint32
 	linkCredit         uint32 // maximum number of messages allowed between flow updates
-	SenderSettleMode   *SenderSettleMode
-	ReceiverSettleMode *ReceiverSettleMode
-	MaxMessageSize     uint64
+	senderSettleMode   *SenderSettleMode
+	receiverSettleMode *ReceiverSettleMode
+	maxMessageSize     uint64
 	detachReceived     bool
 	err                error // err returned on Close()
-
-	// message receiving
-	ReceiverReady         chan struct{}       // receiver sends on this when mux is paused to indicate it can handle more messages
-	Messages              chan Message        // used to send completed messages to receiver
-	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
-	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
-	buf                   buffer.Buffer       // buffered bytes for current message
-	more                  bool                // if true, buf contains a partial message
-	msg                   Message             // current message being decoded
-}
-
-// newSendingLink creates a new sending link and attaches it to the session
-func newSendingLink(target string, s *Session, opts *SenderOptions) (*link, error) {
-	l := &link{
-		Key:                      linkKey{shared.RandString(40), encoding.RoleSender},
-		Session:                  s,
-		close:                    make(chan struct{}),
-		Detached:                 make(chan struct{}),
-		ReceiverReady:            make(chan struct{}, 1),
-		detachOnDispositionError: true,
-		Target:                   &frames.Target{Address: target},
-		Source:                   new(frames.Source),
-	}
-
-	if opts == nil {
-		return l, nil
-	}
-
-	for _, v := range opts.Capabilities {
-		l.Source.Capabilities = append(l.Source.Capabilities, encoding.Symbol(v))
-	}
-	if opts.Durability > DurabilityUnsettledState {
-		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
-	}
-	l.Source.Durable = opts.Durability
-	if opts.DynamicAddress {
-		l.Target.Address = ""
-		l.dynamicAddr = opts.DynamicAddress
-	}
-	if opts.ExpiryPolicy != "" {
-		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
-			return nil, err
-		}
-		l.Source.ExpiryPolicy = opts.ExpiryPolicy
-	}
-	l.Source.Timeout = opts.ExpiryTimeout
-	l.detachOnDispositionError = !opts.IgnoreDispositionErrors
-	if opts.Name != "" {
-		l.Key.name = opts.Name
-	}
-	if opts.Properties != nil {
-		l.properties = make(map[encoding.Symbol]interface{})
-		for k, v := range opts.Properties {
-			if k == "" {
-				return nil, errors.New("link property key must not be empty")
-			}
-			l.properties[encoding.Symbol(k)] = v
-		}
-	}
-	if opts.RequestedReceiverSettleMode != nil {
-		if rsm := *opts.RequestedReceiverSettleMode; rsm > ModeSecond {
-			return nil, fmt.Errorf("invalid RequestedReceiverSettleMode %d", rsm)
-		}
-		l.ReceiverSettleMode = opts.RequestedReceiverSettleMode
-	}
-	if opts.SettlementMode != nil {
-		if ssm := *opts.SettlementMode; ssm > ModeMixed {
-			return nil, fmt.Errorf("invalid SettlementMode %d", ssm)
-		}
-		l.SenderSettleMode = opts.SettlementMode
-	}
-	l.Source.Address = opts.SourceAddress
-	return l, nil
-}
-
-func newReceivingLink(source string, s *Session, r *Receiver, opts *ReceiverOptions) (*link, error) {
-	l := &link{
-		Key:           linkKey{shared.RandString(40), encoding.RoleReceiver},
-		Session:       s,
-		receiver:      r,
-		close:         make(chan struct{}),
-		Detached:      make(chan struct{}),
-		ReceiverReady: make(chan struct{}, 1),
-		Source:        &frames.Source{Address: source},
-		Target:        new(frames.Target),
-	}
-
-	if opts == nil {
-		return l, nil
-	}
-
-	l.receiver.batching = opts.Batching
-	if opts.BatchMaxAge > 0 {
-		l.receiver.batchMaxAge = opts.BatchMaxAge
-	}
-	for _, v := range opts.Capabilities {
-		l.Target.Capabilities = append(l.Target.Capabilities, encoding.Symbol(v))
-	}
-	if opts.Credit > 0 {
-		l.receiver.maxCredit = opts.Credit
-	}
-	if opts.Durability > DurabilityUnsettledState {
-		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
-	}
-	l.Target.Durable = opts.Durability
-	if opts.DynamicAddress {
-		l.Source.Address = ""
-		l.dynamicAddr = opts.DynamicAddress
-	}
-	if opts.ExpiryPolicy != "" {
-		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
-			return nil, err
-		}
-		l.Target.ExpiryPolicy = opts.ExpiryPolicy
-	}
-	l.Target.Timeout = opts.ExpiryTimeout
-	if opts.Filters != nil {
-		l.Source.Filter = make(encoding.Filter)
-		for _, f := range opts.Filters {
-			f(l.Source.Filter)
-		}
-	}
-	if opts.ManualCredits {
-		l.receiver.manualCreditor = &manualCreditor{}
-	}
-	if opts.MaxMessageSize > 0 {
-		l.MaxMessageSize = opts.MaxMessageSize
-	}
-	if opts.Name != "" {
-		l.Key.name = opts.Name
-	}
-	if opts.Properties != nil {
-		l.properties = make(map[encoding.Symbol]interface{})
-		for k, v := range opts.Properties {
-			if k == "" {
-				return nil, errors.New("link property key must not be empty")
-			}
-			l.properties[encoding.Symbol(k)] = v
-		}
-	}
-	if opts.RequestedSenderSettleMode != nil {
-		if rsm := *opts.RequestedSenderSettleMode; rsm > ModeMixed {
-			return nil, fmt.Errorf("invalid RequestedSenderSettleMode %d", rsm)
-		}
-		l.SenderSettleMode = opts.RequestedSenderSettleMode
-	}
-	if opts.SettlementMode != nil {
-		if rsm := *opts.SettlementMode; rsm > ModeSecond {
-			return nil, fmt.Errorf("invalid SettlementMode %d", rsm)
-		}
-		l.ReceiverSettleMode = opts.SettlementMode
-	}
-	l.Target.Address = opts.TargetAddress
-	return l, nil
 }
 
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
-func (l *link) attach(ctx context.Context, s *Session) error {
-	// sending unsettled messages when the receiver is in mode-second is currently
-	// broken and causes a hang after sending, so just disallow it for now.
-	if l.receiver == nil && senderSettleModeValue(l.SenderSettleMode) != ModeSettled && receiverSettleModeValue(l.ReceiverSettleMode) == ModeSecond {
-		return errors.New("sender does not support exactly-once guarantee")
-	}
-
-	isReceiver := l.receiver != nil
-
-	// buffer rx to linkCredit so that conn.mux won't block
-	// attempting to send to a slow reader
-	if isReceiver {
-		if l.receiver.manualCreditor != nil {
-			l.RX = make(chan frames.FrameBody, l.receiver.maxCredit)
-		} else {
-			l.RX = make(chan frames.FrameBody, l.linkCredit)
-		}
-	} else {
-		l.RX = make(chan frames.FrameBody, 1)
-	}
-
+func (l *link) attachLink(ctx context.Context, s *Session, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
 	if err := s.allocateHandle(l); err != nil {
 		return err
 	}
 
 	attach := &frames.PerformAttach{
-		Name:               l.Key.name,
-		Handle:             l.Handle,
-		ReceiverSettleMode: l.ReceiverSettleMode,
-		SenderSettleMode:   l.SenderSettleMode,
-		MaxMessageSize:     l.MaxMessageSize,
-		Source:             l.Source,
-		Target:             l.Target,
+		Name:               l.key.name,
+		Handle:             l.handle,
+		ReceiverSettleMode: l.receiverSettleMode,
+		SenderSettleMode:   l.senderSettleMode,
+		MaxMessageSize:     l.maxMessageSize,
+		Source:             l.source,
+		Target:             l.target,
 		Properties:         l.properties,
 	}
 
-	if isReceiver {
-		attach.Role = encoding.RoleReceiver
-		if attach.Source == nil {
-			attach.Source = new(frames.Source)
-		}
-		attach.Source.Dynamic = l.dynamicAddr
-	} else {
-		attach.Role = encoding.RoleSender
-		if attach.Target == nil {
-			attach.Target = new(frames.Target)
-		}
-		attach.Target.Dynamic = l.dynamicAddr
-	}
+	// link-specific configuration of the attach frame
+	beforeAttach(attach)
 
 	// send Attach frame
 	debug.Log(1, "TX (attachLink): %s", attach)
@@ -288,7 +91,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 			// case we must send a detach before deallocation
 			go func() {
 				_ = s.txFrame(&frames.PerformDetach{
-					Handle: l.Handle,
+					Handle: l.handle,
 					Closed: true,
 				}, nil)
 				select {
@@ -296,7 +99,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 					// session has terminated, no need to deallocate in this case
 				case <-time.After(5 * time.Second):
 					debug.Log(3, "link.attach() clean-up timed out waiting for ack")
-				case <-l.RX:
+				case <-l.rx:
 					// received ack, safe to delete handle
 					s.deallocateHandle(l)
 				}
@@ -309,7 +112,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 	case <-s.done:
 		// session has terminated, no need to deallocate in this case
 		return s.err
-	case fr = <-l.RX:
+	case fr = <-l.rx:
 	}
 	debug.Log(3, "RX (attachLink): %s", fr)
 	resp, ok := fr.(*frames.PerformAttach)
@@ -333,7 +136,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 			// if we don't send an ack then we're in violation of the protocol
 			go func() {
 				_ = s.txFrame(&frames.PerformDetach{
-					Handle: l.Handle,
+					Handle: l.handle,
 					Closed: true,
 				}, nil)
 				s.deallocateHandle(l)
@@ -341,7 +144,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 			return ctx.Err()
 		case <-s.done:
 			return s.err
-		case fr = <-l.RX:
+		case fr = <-l.rx:
 			s.deallocateHandle(l)
 		}
 
@@ -352,7 +155,7 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 
 		// send return detach
 		fr = &frames.PerformDetach{
-			Handle: l.Handle,
+			Handle: l.handle,
 			Closed: true,
 		}
 		debug.Log(1, "TX (attachLink): %s", fr)
@@ -364,66 +167,19 @@ func (l *link) attach(ctx context.Context, s *Session) error {
 		return detach.Error
 	}
 
-	if l.MaxMessageSize == 0 || resp.MaxMessageSize < l.MaxMessageSize {
-		l.MaxMessageSize = resp.MaxMessageSize
+	if l.maxMessageSize == 0 || resp.MaxMessageSize < l.maxMessageSize {
+		l.maxMessageSize = resp.MaxMessageSize
 	}
 
-	if isReceiver {
-		if l.Source == nil {
-			l.Source = new(frames.Source)
-		}
-		// if dynamic address requested, copy assigned name to address
-		if l.dynamicAddr && resp.Source != nil {
-			l.Source.Address = resp.Source.Address
-		}
-		// deliveryCount is a sequence number, must initialize to sender's initial sequence number
-		l.deliveryCount = resp.InitialDeliveryCount
-		// buffer receiver so that link.mux doesn't block
-		l.Messages = make(chan Message, l.receiver.maxCredit)
-		l.unsettledMessages = map[string]struct{}{}
-		// copy the received filter values
-		if resp.Source != nil {
-			l.Source.Filter = resp.Source.Filter
-		}
-	} else {
-		if l.Target == nil {
-			l.Target = new(frames.Target)
-		}
-		// if dynamic address requested, copy assigned name to address
-		if l.dynamicAddr && resp.Target != nil {
-			l.Target.Address = resp.Target.Address
-		}
-		l.Transfers = make(chan frames.PerformTransfer)
-	}
+	// link-specific configuration post attach
+	afterAttach(resp)
 
 	if err := l.setSettleModes(resp); err != nil {
-		l.muxDetach()
+		l.muxDetach(nil, nil)
 		return err
 	}
 
-	go l.mux()
-
 	return nil
-}
-
-func (l *link) addUnsettled(msg *Message) {
-	l.unsettledMessagesLock.Lock()
-	l.unsettledMessages[string(msg.DeliveryTag)] = struct{}{}
-	l.unsettledMessagesLock.Unlock()
-}
-
-// DeleteUnsettled removes the message from the map of unsettled messages.
-func (l *link) DeleteUnsettled(msg *Message) {
-	l.unsettledMessagesLock.Lock()
-	delete(l.unsettledMessages, string(msg.DeliveryTag))
-	l.unsettledMessagesLock.Unlock()
-}
-
-func (l *link) countUnsettled() int {
-	l.unsettledMessagesLock.RLock()
-	count := len(l.unsettledMessages)
-	l.unsettledMessagesLock.RUnlock()
-	return count
 }
 
 // setSettleModes sets the settlement modes based on the resp frames.PerformAttach.
@@ -432,422 +188,44 @@ func (l *link) countUnsettled() int {
 // server an error is returned.
 func (l *link) setSettleModes(resp *frames.PerformAttach) error {
 	var (
-		localRecvSettle = receiverSettleModeValue(l.ReceiverSettleMode)
+		localRecvSettle = receiverSettleModeValue(l.receiverSettleMode)
 		respRecvSettle  = receiverSettleModeValue(resp.ReceiverSettleMode)
 	)
-	if l.ReceiverSettleMode != nil && localRecvSettle != respRecvSettle {
-		return fmt.Errorf("amqp: receiver settlement mode %q requested, received %q from server", l.ReceiverSettleMode, &respRecvSettle)
+	if l.receiverSettleMode != nil && localRecvSettle != respRecvSettle {
+		return fmt.Errorf("amqp: receiver settlement mode %q requested, received %q from server", l.receiverSettleMode, &respRecvSettle)
 	}
-	l.ReceiverSettleMode = &respRecvSettle
+	l.receiverSettleMode = &respRecvSettle
 
 	var (
-		localSendSettle = senderSettleModeValue(l.SenderSettleMode)
+		localSendSettle = senderSettleModeValue(l.senderSettleMode)
 		respSendSettle  = senderSettleModeValue(resp.SenderSettleMode)
 	)
-	if l.SenderSettleMode != nil && localSendSettle != respSendSettle {
-		return fmt.Errorf("amqp: sender settlement mode %q requested, received %q from server", l.SenderSettleMode, &respSendSettle)
+	if l.senderSettleMode != nil && localSendSettle != respSendSettle {
+		return fmt.Errorf("amqp: sender settlement mode %q requested, received %q from server", l.senderSettleMode, &respSendSettle)
 	}
-	l.SenderSettleMode = &respSendSettle
+	l.senderSettleMode = &respSendSettle
 
 	return nil
 }
 
-// doFlow handles the logical 'flow' event for a link.
-// For receivers it will send (if needed) an AMQP flow frame, via `muxFlow`. If a fatal error
-// occurs it will be set in `l.err` and 'ok' will be false.
-// For senders it will indicate if we should try to send any outgoing transfers (the logical
-// equivalent of a flow for a sender) by returning true for 'enableOutgoingTransfers'.
-func (l *link) doFlow() (ok bool, enableOutgoingTransfers bool) {
-	var (
-		isReceiver = l.receiver != nil
-		isSender   = !isReceiver
-	)
-
-	switch {
-	// enable outgoing transfers case if sender and credits are available
-	case isSender && l.linkCredit > 0:
-		debug.Log(1, "Link Mux isSender: credit: %d, deliveryCount: %d, messages: %d, unsettled: %d", l.linkCredit, l.deliveryCount, len(l.Messages), l.countUnsettled())
-		return true, true
-
-	case isReceiver && l.receiver.manualCreditor != nil:
-		drain, credits := l.receiver.manualCreditor.FlowBits(l.linkCredit)
-
-		if drain || credits > 0 {
-			debug.Log(1, "FLOW Link Mux (manual): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s",
-				l.Source.Address, l.receiver.inFlight.len(), l.linkCredit, credits, drain, l.deliveryCount, len(l.Messages), l.countUnsettled(), l.receiver.maxCredit, l.ReceiverSettleMode.String())
-
-			// send a flow frame.
-			l.err = l.muxFlow(credits, drain)
-		}
-
-	// if receiver && half maxCredits have been processed, send more credits
-	case isReceiver && l.linkCredit+uint32(l.countUnsettled()) <= l.receiver.maxCredit/2:
-		debug.Log(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.Source.Address, l.receiver.inFlight.len(), l.linkCredit, l.deliveryCount, len(l.Messages), l.countUnsettled(), l.receiver.maxCredit, l.ReceiverSettleMode.String())
-
-		linkCredit := l.receiver.maxCredit - uint32(l.countUnsettled())
-		l.err = l.muxFlow(linkCredit, false)
-
-		if l.err != nil {
-			return false, false
-		}
-
-	case isReceiver && l.linkCredit == 0:
-		debug.Log(1, "PAUSE Link Mux pause: inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.receiver.inFlight.len(), l.linkCredit, l.deliveryCount, len(l.Messages), l.countUnsettled(), l.receiver.maxCredit, l.ReceiverSettleMode.String())
+// Close closes the Sender and AMQP link.
+func (l *link) closeLink(ctx context.Context) error {
+	l.closeOnce.Do(func() { close(l.close) })
+	select {
+	case <-l.detached:
+		// mux exited
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	return true, false
-}
-
-func (l *link) mux() {
-	defer l.muxDetach()
-
-Loop:
-	for {
-		var outgoingTransfers chan frames.PerformTransfer
-
-		ok, enableOutgoingTransfers := l.doFlow()
-
-		if !ok {
-			return
-		}
-
-		if enableOutgoingTransfers {
-			outgoingTransfers = l.Transfers
-		}
-
-		select {
-		// received frame
-		case fr := <-l.RX:
-			l.err = l.muxHandleFrame(fr)
-			if l.err != nil {
-				return
-			}
-
-		// send data
-		case tr := <-outgoingTransfers:
-			debug.Log(3, "TX(link): %s", tr)
-
-			// Ensure the session mux is not blocked
-			for {
-				select {
-				case l.Session.txTransfer <- &tr:
-					// decrement link-credit after entire message transferred
-					if !tr.More {
-						l.deliveryCount++
-						l.linkCredit--
-						// we are the sender and we keep track of the peer's link credit
-						debug.Log(3, "TX(link): key:%s, decremented linkCredit: %d", l.Key.name, l.linkCredit)
-					}
-					continue Loop
-				case fr := <-l.RX:
-					l.err = l.muxHandleFrame(fr)
-					if l.err != nil {
-						return
-					}
-				case <-l.close:
-					l.err = ErrLinkClosed
-					return
-				case <-l.Session.done:
-					l.err = l.Session.err
-					return
-				}
-			}
-
-		case <-l.ReceiverReady:
-			continue
-		case <-l.close:
-			l.err = ErrLinkClosed
-			return
-		case <-l.Session.done:
-			l.err = l.Session.err
-			return
-		}
-	}
-}
-
-// muxFlow sends tr to the session mux.
-// l.linkCredit will also be updated to `linkCredit`
-func (l *link) muxFlow(linkCredit uint32, drain bool) error {
-	var (
-		deliveryCount = l.deliveryCount
-	)
-
-	debug.Log(3, "link.muxFlow(): len(l.Messages):%d - linkCredit: %d - deliveryCount: %d, inFlight: %d", len(l.Messages), linkCredit, deliveryCount, l.receiver.inFlight.len())
-
-	fr := &frames.PerformFlow{
-		Handle:        &l.Handle,
-		DeliveryCount: &deliveryCount,
-		LinkCredit:    &linkCredit, // max number of messages,
-		Drain:         drain,
-	}
-	debug.Log(3, "TX (muxFlow): %s", fr)
-
-	// Update credit. This must happen before entering loop below
-	// because incoming messages handled while waiting to transmit
-	// flow increment deliveryCount. This causes the credit to become
-	// out of sync with the server.
-
-	if !drain {
-		// if we're draining we don't want to touch our internal credit - we're not changing it so any issued credits
-		// are still valid until drain completes, at which point they will be naturally zeroed.
-		l.linkCredit = linkCredit
-	}
-
-	// Ensure the session mux is not blocked
-	for {
-		select {
-		case l.Session.tx <- fr:
-			return nil
-		case fr := <-l.RX:
-			err := l.muxHandleFrame(fr)
-			if err != nil {
-				return err
-			}
-		case <-l.close:
-			return ErrLinkClosed
-		case <-l.Session.done:
-			return l.Session.err
-		}
-	}
-}
-
-func (l *link) muxReceive(fr frames.PerformTransfer) error {
-	if !l.more {
-		// this is the first transfer of a message,
-		// record the delivery ID, message format,
-		// and delivery Tag
-		if fr.DeliveryID != nil {
-			l.msg.deliveryID = *fr.DeliveryID
-		}
-		if fr.MessageFormat != nil {
-			l.msg.Format = *fr.MessageFormat
-		}
-		l.msg.DeliveryTag = fr.DeliveryTag
-
-		// these fields are required on first transfer of a message
-		if fr.DeliveryID == nil {
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: "received message without a delivery-id",
-			})
-		}
-		if fr.MessageFormat == nil {
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: "received message without a message-format",
-			})
-		}
-		if fr.DeliveryTag == nil {
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: "received message without a delivery-tag",
-			})
-		}
-	} else {
-		// this is a continuation of a multipart message
-		// some fields may be omitted on continuation transfers,
-		// but if they are included they must be consistent
-		// with the first.
-
-		if fr.DeliveryID != nil && *fr.DeliveryID != l.msg.deliveryID {
-			msg := fmt.Sprintf(
-				"received continuation transfer with inconsistent delivery-id: %d != %d",
-				*fr.DeliveryID, l.msg.deliveryID,
-			)
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: msg,
-			})
-		}
-		if fr.MessageFormat != nil && *fr.MessageFormat != l.msg.Format {
-			msg := fmt.Sprintf(
-				"received continuation transfer with inconsistent message-format: %d != %d",
-				*fr.MessageFormat, l.msg.Format,
-			)
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: msg,
-			})
-		}
-		if fr.DeliveryTag != nil && !bytes.Equal(fr.DeliveryTag, l.msg.DeliveryTag) {
-			msg := fmt.Sprintf(
-				"received continuation transfer with inconsistent delivery-tag: %q != %q",
-				fr.DeliveryTag, l.msg.DeliveryTag,
-			)
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: msg,
-			})
-		}
-	}
-
-	// discard message if it's been aborted
-	if fr.Aborted {
-		l.buf.Reset()
-		l.msg = Message{}
-		l.more = false
+	if l.err == ErrLinkClosed {
 		return nil
 	}
-
-	// ensure maxMessageSize will not be exceeded
-	if l.MaxMessageSize != 0 && uint64(l.buf.Len())+uint64(len(fr.Payload)) > l.MaxMessageSize {
-		return l.closeWithError(&Error{
-			Condition:   ErrorMessageSizeExceeded,
-			Description: fmt.Sprintf("received message larger than max size of %d", l.MaxMessageSize),
-		})
-	}
-
-	// add the payload the the buffer
-	l.buf.Append(fr.Payload)
-
-	// mark as settled if at least one frame is settled
-	l.msg.settled = l.msg.settled || fr.Settled
-
-	// save in-progress status
-	l.more = fr.More
-
-	if fr.More {
-		return nil
-	}
-
-	// last frame in message
-	err := l.msg.Unmarshal(&l.buf)
-	if err != nil {
-		return err
-	}
-	debug.Log(1, "deliveryID %d before push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.Messages), l.receiver.inFlight.len())
-	// send to receiver
-	if receiverSettleModeValue(l.ReceiverSettleMode) == ModeSecond {
-		l.addUnsettled(&l.msg)
-	}
-	select {
-	case l.Messages <- l.msg:
-		// message received
-	case <-l.Detached:
-		// link has been detached
-		return l.err
-	}
-
-	debug.Log(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.Messages), l.receiver.inFlight.len())
-
-	// reset progress
-	l.buf.Reset()
-	l.msg = Message{}
-
-	// decrement link-credit after entire message received
-	l.deliveryCount++
-	l.linkCredit--
-	debug.Log(1, "deliveryID %d before exit - deliveryCount : %d - linkCredit: %d, len(messages): %d", l.msg.deliveryID, l.deliveryCount, l.linkCredit, len(l.Messages))
-	return nil
-}
-
-// DrainCredit will cause a flow frame with 'drain' set to true when
-// the next flow frame is sent in 'mux()'.
-// Applicable only when manual credit management has been enabled.
-func (l *link) DrainCredit(ctx context.Context) error {
-	if l.receiver == nil || l.receiver.manualCreditor == nil {
-		return errors.New("drain can only be used with receiver links using manual credit management")
-	}
-
-	// cause mux() to check our flow conditions.
-	select {
-	case l.ReceiverReady <- struct{}{}:
-	default:
-	}
-
-	return l.receiver.manualCreditor.Drain(ctx, l)
-}
-
-// IssueCredit requests additional credits be issued for this link.
-// Applicable only when manual credit management has been enabled.
-func (l *link) IssueCredit(credit uint32) error {
-	if l.receiver == nil || l.receiver.manualCreditor == nil {
-		return errors.New("issueCredit can only be used with receiver links using manual credit management")
-	}
-
-	if err := l.receiver.manualCreditor.IssueCredit(credit); err != nil {
-		return err
-	}
-
-	// cause mux() to check our flow conditions.
-	select {
-	case l.ReceiverReady <- struct{}{}:
-	default:
-	}
-
-	return nil
-}
-
-func (l *link) detachOnRejectDisp() bool {
-	// only detach on rejection when no RSM was requested or in ModeFirst.
-	// if the receiver is in ModeSecond, it will send an explicit rejection disposition
-	// that we'll have to ack. so in that case, we don't treat it as a link error.
-	if l.detachOnDispositionError && (l.receiver == nil && (l.ReceiverSettleMode == nil || *l.ReceiverSettleMode == ModeFirst)) {
-		return true
-	}
-	return false
+	return l.err
 }
 
 // muxHandleFrame processes fr based on type.
 func (l *link) muxHandleFrame(fr frames.FrameBody) error {
-	var (
-		isSender = l.receiver == nil
-	)
-
 	switch fr := fr.(type) {
-	// message frame
-	case *frames.PerformTransfer:
-		debug.Log(3, "RX (muxHandleFrame): %s", fr)
-		if isSender {
-			// Senders should never receive transfer frames, but handle it just in case.
-			return l.closeWithError(&Error{
-				Condition:   ErrorNotAllowed,
-				Description: "sender cannot process transfer frame",
-			})
-		}
-
-		return l.muxReceive(*fr)
-
-	// flow control frame
-	case *frames.PerformFlow:
-		debug.Log(3, "RX (muxHandleFrame): %s", fr)
-		if isSender {
-			linkCredit := *fr.LinkCredit - l.deliveryCount
-			if fr.DeliveryCount != nil {
-				// DeliveryCount can be nil if the receiver hasn't processed
-				// the attach. That shouldn't be the case here, but it's
-				// what ActiveMQ does.
-				linkCredit += *fr.DeliveryCount
-			}
-			l.linkCredit = linkCredit
-		}
-
-		if !fr.Echo {
-			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
-			// we signal whomever is waiting (the service has seen and acknowledged our drain)
-			if fr.Drain && l.receiver != nil && l.receiver.manualCreditor != nil {
-				l.linkCredit = 0 // we have no active credits at this point.
-				l.receiver.manualCreditor.EndDrain()
-			}
-			return nil
-		}
-
-		var (
-			// copy because sent by pointer below; prevent race
-			linkCredit    = l.linkCredit
-			deliveryCount = l.deliveryCount
-		)
-
-		// send flow
-		// TODO: missing Available and session info
-		resp := &frames.PerformFlow{
-			Handle:        &l.Handle,
-			DeliveryCount: &deliveryCount,
-			LinkCredit:    &linkCredit, // max number of messages
-		}
-		debug.Log(1, "TX (muxHandleFrame): %s", resp)
-		_ = l.Session.txFrame(resp, nil)
-
 	// remote side is closing links
 	case *frames.PerformDetach:
 		debug.Log(1, "RX (muxHandleFrame): %s", fr)
@@ -861,44 +239,6 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 
 		return &DetachError{fr.Error}
 
-	case *frames.PerformDisposition:
-		debug.Log(3, "RX (muxHandleFrame): %s", fr)
-
-		// Unblock receivers waiting for message disposition
-		if l.receiver != nil {
-			// bubble disposition error up to the receiver
-			var dispositionError error
-			if state, ok := fr.State.(*encoding.StateRejected); ok {
-				// state.Error isn't required to be filled out. For instance if you dead letter a message
-				// you will get a rejected response that doesn't contain an error.
-				if state.Error != nil {
-					dispositionError = state.Error
-				}
-			}
-			// removal from the in-flight map will also remove the message from the unsettled map
-			l.receiver.inFlight.remove(fr.First, fr.Last, dispositionError)
-		}
-
-		// If sending async and a message is rejected, cause a link error.
-		//
-		// This isn't ideal, but there isn't a clear better way to handle it.
-		if fr, ok := fr.State.(*encoding.StateRejected); ok && l.detachOnRejectDisp() {
-			return &DetachError{fr.Error}
-		}
-
-		if fr.Settled {
-			return nil
-		}
-
-		resp := &frames.PerformDisposition{
-			Role:    encoding.RoleSender,
-			First:   fr.First,
-			Last:    fr.Last,
-			Settled: true,
-		}
-		debug.Log(1, "TX (muxHandleFrame): %s", resp)
-		_ = l.Session.txFrame(resp, nil)
-
 	default:
 		// TODO: evaluate
 		debug.Log(1, "muxHandleFrame: unexpected frame: %s\n", fr)
@@ -907,57 +247,19 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 	return nil
 }
 
-// close closes and requests deletion of the link.
-//
-// No operations on link are valid after close.
-//
-// If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Session or Client
-// is closed.
-func (l *link) Close(ctx context.Context) error {
-	l.closeOnce.Do(func() { close(l.close) })
-	select {
-	case <-l.Detached:
-		// mux exited
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	if l.err == ErrLinkClosed {
-		return nil
-	}
-	return l.err
-}
-
-// returns the error passed in
-func (l *link) closeWithError(de *Error) error {
-	l.closeOnce.Do(func() {
-		l.detachErrorMu.Lock()
-		l.detachError = de
-		l.detachErrorMu.Unlock()
-		close(l.close)
-	})
-	return de
-}
-
-func (l *link) muxDetach() {
+func (l *link) muxDetach(deferred func(), onRXTransfer func(frames.PerformTransfer)) {
 	defer func() {
 		// final cleanup and signaling
 
 		// deallocate handle
-		l.Session.deallocateHandle(l)
+		l.session.deallocateHandle(l)
 
-		// unblock any in flight message dispositions
-		if l.receiver != nil {
-			l.receiver.inFlight.clear(l.err)
-		}
-
-		// unblock any pending drain requests
-		if l.receiver != nil && l.receiver.manualCreditor != nil {
-			l.receiver.manualCreditor.EndDrain()
+		if deferred != nil {
+			deferred()
 		}
 
 		// signal that the link mux has exited
-		close(l.Detached)
+		close(l.detached)
 	}()
 
 	// "A peer closes a link by sending the detach frame with the
@@ -976,7 +278,7 @@ func (l *link) muxDetach() {
 	l.detachErrorMu.Unlock()
 
 	fr := &frames.PerformDetach{
-		Handle: l.Handle,
+		Handle: l.handle,
 		Closed: true,
 		Error:  detachError,
 	}
@@ -984,10 +286,10 @@ func (l *link) muxDetach() {
 Loop:
 	for {
 		select {
-		case l.Session.tx <- fr:
+		case l.session.tx <- fr:
 			// after sending the detach frame, break the read loop
 			break Loop
-		case fr := <-l.RX:
+		case fr := <-l.rx:
 			// read from link to avoid blocking session.mux
 			switch fr := fr.(type) {
 			case *frames.PerformDetach:
@@ -995,11 +297,13 @@ Loop:
 					l.detachReceived = true
 				}
 			case *frames.PerformTransfer:
-				_ = l.muxReceive(*fr)
+				if onRXTransfer != nil {
+					onRXTransfer(*fr)
+				}
 			}
-		case <-l.Session.done:
+		case <-l.session.done:
 			if l.err == nil {
-				l.err = l.Session.err
+				l.err = l.session.err
 			}
 			return
 		}
@@ -1013,20 +317,22 @@ Loop:
 	for {
 		select {
 		// read from link until detach with Close == true is received
-		case fr := <-l.RX:
+		case fr := <-l.rx:
 			switch fr := fr.(type) {
 			case *frames.PerformDetach:
 				if fr.Closed {
 					return
 				}
 			case *frames.PerformTransfer:
-				_ = l.muxReceive(*fr)
+				if onRXTransfer != nil {
+					onRXTransfer(*fr)
+				}
 			}
 
 		// connection has ended
-		case <-l.Session.done:
+		case <-l.session.done:
 			if l.err == nil {
-				l.err = l.Session.err
+				l.err = l.session.err
 			}
 			return
 		}

--- a/link_test.go
+++ b/link_test.go
@@ -120,7 +120,6 @@ func TestLinkFlowWithManualCreditor(t *testing.T) {
 }
 
 func TestLinkFlowWithDrain(t *testing.T) {
-	t.Skip("for now")
 	l := newTestLink(t)
 	l.manualCreditor = &manualCreditor{}
 	go l.mux()

--- a/link_test.go
+++ b/link_test.go
@@ -2,8 +2,8 @@ package amqp
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,32 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLinkFlowForSender(t *testing.T) {
-	// senders don't actually send flow frames but they do enable require tranfers to be
-	// assigned. We should refactor, this is just fallout from my "lift and shift" of the
-	// flow logic in `mux`
-	l := newTestLink(t)
-	l.receiver = nil
-
-	err := l.DrainCredit(context.Background())
-	require.Error(t, err, "drain can only be used with receiver links using manual credit management")
-
-	err = l.IssueCredit(1)
-	require.Error(t, err, "issueCredit can only be used with receiver links using manual credit management")
-
-	// and flow goes through the non-manual credit path
-	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
-
-	// if we have link credit we can enable outgoing transfers
-	l.linkCredit = 1
-	ok, enableOutgoingTransfers := l.doFlow()
-
-	require.True(t, ok, "no errors, should continue to process")
-	require.True(t, enableOutgoingTransfers, "outgoing transfers needed for senders")
-}
-
 func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 	l := newTestLink(t)
+	go l.mux()
+	defer close(l.close)
 
 	err := l.DrainCredit(context.Background())
 	require.Error(t, err, "drain can only be used with receiver links using manual credit management")
@@ -50,17 +28,19 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
 
 	// we've consumed half of the maximum credit we're allowed to have - reflow!
-	l.receiver.maxCredit = 2
+	l.maxCredit = 2
 	l.linkCredit = 1
 	l.unsettledMessages = map[string]struct{}{}
 
-	ok, enableOutgoingTransfers := l.doFlow()
-
-	require.True(t, ok, "no errors, should continue to process")
-	require.False(t, enableOutgoingTransfers, "outgoing transfers only needed for senders")
+	select {
+	case l.receiverReady <- struct{}{}:
+		// woke up mux
+	default:
+		t.Fatal("failed to wake up mux")
+	}
 
 	// flow happens immmediately in 'mux'
-	txFrame := <-l.Session.tx
+	txFrame := <-l.session.tx
 
 	switch frame := txFrame.(type) {
 	case *frames.PerformFlow:
@@ -74,6 +54,8 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 
 func TestLinkFlowWithZeroCredits(t *testing.T) {
 	l := newTestLink(t)
+	go l.mux()
+	defer close(l.close)
 
 	err := l.DrainCredit(context.Background())
 	require.Error(t, err, "drain can only be used with receiver links using manual credit management")
@@ -84,31 +66,33 @@ func TestLinkFlowWithZeroCredits(t *testing.T) {
 	// and flow goes through the non-manual credit path
 	require.EqualValues(t, 0, l.linkCredit, "No link credits have been added")
 
-	l.receiver.maxCredit = 2
+	l.maxCredit = 2
 	l.linkCredit = 0
 	l.unsettledMessages = map[string]struct{}{
 		"hello":  {},
 		"hello2": {},
 	}
 
-	ok, enableOutgoingTransfers := l.doFlow()
+	select {
+	case l.receiverReady <- struct{}{}:
+		// woke up mux
+	default:
+		t.Fatal("failed to wake up mux")
+	}
 
-	require.True(t, ok)
-	require.False(t, enableOutgoingTransfers)
+	require.Zero(t, l.linkCredit)
 }
 
 func TestLinkFlowDrain(t *testing.T) {
 	l := newTestLink(t)
-
 	// now initialize it as a manual credit link
-	l.receiver.manualCreditor = &manualCreditor{}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	l.manualCreditor = &manualCreditor{}
+	go l.mux()
+	defer close(l.close)
 
 	go func() {
-		<-l.ReceiverReady
-		l.receiver.manualCreditor.EndDrain()
+		<-l.receiverReady
+		l.manualCreditor.EndDrain()
 	}()
 
 	require.NoError(t, l.DrainCredit(context.Background()))
@@ -116,17 +100,15 @@ func TestLinkFlowDrain(t *testing.T) {
 
 func TestLinkFlowWithManualCreditor(t *testing.T) {
 	l := newTestLink(t)
-	l.receiver.manualCreditor = &manualCreditor{}
-
+	l.manualCreditor = &manualCreditor{}
 	l.linkCredit = 1
+	go l.mux()
+	defer close(l.close)
+
 	require.NoError(t, l.IssueCredit(100))
 
-	ok, enableOutgoingTransfers := l.doFlow()
-	require.True(t, ok)
-	require.False(t, enableOutgoingTransfers, "sender related state is not enabled")
-
 	// flow happens immmediately in 'mux'
-	txFrame := <-l.Session.tx
+	txFrame := <-l.session.tx
 
 	switch frame := txFrame.(type) {
 	case *frames.PerformFlow:
@@ -138,54 +120,78 @@ func TestLinkFlowWithManualCreditor(t *testing.T) {
 }
 
 func TestLinkFlowWithDrain(t *testing.T) {
+	t.Skip("for now")
 	l := newTestLink(t)
-	l.receiver.manualCreditor = &manualCreditor{}
+	l.manualCreditor = &manualCreditor{}
+	go l.mux()
+	defer close(l.close)
 
-	go func() {
-		<-l.ReceiverReady
+	errChan := make(chan error)
 
-		ok, enableOutgoingTransfers := l.doFlow()
-		require.True(t, ok)
-		require.False(t, enableOutgoingTransfers, "sender related state is not enabled")
+	go func(errChan chan error) {
+		<-l.receiverReady
+
+		select {
+		case l.receiverReady <- struct{}{}:
+			// woke up mux
+		default:
+			errChan <- errors.New("failed to wake up mux")
+			return
+		}
 
 		// flow happens immmediately in 'mux'
-		txFrame := <-l.Session.tx
+		txFrame := <-l.session.tx
 
 		switch frame := txFrame.(type) {
 		case *frames.PerformFlow:
-			require.True(t, frame.Drain)
+			if !frame.Drain {
+				errChan <- errors.New("expected drain to be true")
+				return
+			}
+
 			// When we're draining we just automatically set the flow link credit to 0.
 			// This should allow any outstanding messages to get flushed.
-			require.EqualValues(t, 0, *frame.LinkCredit)
+			if lc := *frame.LinkCredit; lc != 0 {
+				errChan <- fmt.Errorf("unepxected LinkCredit: %d", lc)
+				return
+			}
+
 		default:
-			require.Fail(t, fmt.Sprintf("Unexpected frame was transferred: %+v", txFrame))
+			errChan <- fmt.Errorf("Unexpected frame was transferred: %+v", txFrame)
+			return
 		}
 
 		// simulate the return of the flow from the service
-		err := l.muxHandleFrame(&frames.PerformFlow{
-			Drain: true,
-		})
+		if err := l.muxHandleFrame(&frames.PerformFlow{Drain: true}); err != nil {
+			errChan <- err
+			return
+		}
 
-		require.NoError(t, err)
-	}()
+		close(errChan)
+	}(errChan)
 
 	l.linkCredit = 1
 	require.NoError(t, l.DrainCredit(context.Background()))
+	require.NoError(t, <-errChan)
 }
 
 func TestLinkFlowWithManualCreditorAndNoFlowNeeded(t *testing.T) {
 	l := newTestLink(t)
-	l.receiver.manualCreditor = &manualCreditor{}
-
+	l.manualCreditor = &manualCreditor{}
 	l.linkCredit = 1
+	go l.mux()
+	defer close(l.close)
 
-	ok, enableOutgoingTransfers := l.doFlow()
-	require.True(t, ok)
-	require.False(t, enableOutgoingTransfers, "sender related state is not enabled")
+	select {
+	case l.receiverReady <- struct{}{}:
+		// woke up mux
+	default:
+		t.Fatal("failed to wake up mux")
+	}
 
 	// flow happens immmediately in 'mux'
 	select {
-	case fr := <-l.Session.tx: // there won't be a flow this time.
+	case fr := <-l.session.tx: // there won't be a flow this time.
 		require.Failf(t, "No flow frame would be needed since no link credits were added and drain was not requested", "Frame was %+v", fr)
 	case <-time.After(time.Second * 2):
 		// this is the expected case since no frame will be sent.
@@ -194,9 +200,10 @@ func TestLinkFlowWithManualCreditorAndNoFlowNeeded(t *testing.T) {
 
 func TestMuxFlowHandlesDrainProperly(t *testing.T) {
 	l := newTestLink(t)
-	l.receiver.manualCreditor = &manualCreditor{}
-
+	l.manualCreditor = &manualCreditor{}
 	l.linkCredit = 101
+	go l.mux()
+	defer close(l.close)
 
 	// simulate what our 'drain' call to muxFlow would look like
 	// when draining
@@ -208,21 +215,22 @@ func TestMuxFlowHandlesDrainProperly(t *testing.T) {
 	require.EqualValues(t, 501, l.linkCredit, "credits are untouched when draining")
 }
 
-func newTestLink(t *testing.T) *link {
-	l := &link{
-		Source: &frames.Source{},
-		receiver: &Receiver{
+func newTestLink(t *testing.T) *Receiver {
+	l := &Receiver{
+		link: link{
+			source: &frames.Source{},
 			// adding just enough so the debug() print will still work...
 			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
-			inFlight: inFlight{},
+			detached: make(chan struct{}),
+			session: &Session{
+				tx:   make(chan frames.FrameBody, 100),
+				done: make(chan struct{}),
+			},
+			rx:    make(chan frames.FrameBody, 100),
+			close: make(chan struct{}),
 		},
-		Detached: make(chan struct{}),
-		Session: &Session{
-			tx:   make(chan frames.FrameBody, 100),
-			done: make(chan struct{}),
-		},
-		RX:            make(chan frames.FrameBody, 100),
-		ReceiverReady: make(chan struct{}, 1),
+		inFlight:      inFlight{},
+		receiverReady: make(chan struct{}, 1),
 	}
 
 	return l
@@ -236,22 +244,22 @@ func TestNewSendingLink(t *testing.T) {
 	tests := []struct {
 		label    string
 		opts     SenderOptions
-		validate func(t *testing.T, l *link)
+		validate func(t *testing.T, l *Sender)
 	}{
 		{
 			label: "default options",
-			validate: func(t *testing.T, l *link) {
-				require.Empty(t, l.Target.Capabilities)
-				require.Equal(t, DurabilityNone, l.Source.Durable)
+			validate: func(t *testing.T, l *Sender) {
+				require.Empty(t, l.target.Capabilities)
+				require.Equal(t, DurabilityNone, l.source.Durable)
 				require.False(t, l.dynamicAddr)
-				require.Empty(t, l.Source.ExpiryPolicy)
-				require.Zero(t, l.Source.Timeout)
+				require.Empty(t, l.source.ExpiryPolicy)
+				require.Zero(t, l.source.Timeout)
 				require.True(t, l.detachOnDispositionError)
-				require.NotEmpty(t, l.Key.name)
+				require.NotEmpty(t, l.key.name)
 				require.Empty(t, l.properties)
-				require.Nil(t, l.SenderSettleMode)
-				require.Nil(t, l.ReceiverSettleMode)
-				require.Equal(t, targetAddr, l.Target.Address)
+				require.Nil(t, l.senderSettleMode)
+				require.Nil(t, l.receiverSettleMode)
+				require.Equal(t, targetAddr, l.target.Address)
 			},
 		},
 		{
@@ -270,29 +278,29 @@ func TestNewSendingLink(t *testing.T) {
 				RequestedReceiverSettleMode: ModeFirst.Ptr(),
 				SettlementMode:              ModeSettled.Ptr(),
 			},
-			validate: func(t *testing.T, l *link) {
-				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.Source.Capabilities)
-				require.Equal(t, DurabilityUnsettledState, l.Source.Durable)
+			validate: func(t *testing.T, l *Sender) {
+				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.source.Capabilities)
+				require.Equal(t, DurabilityUnsettledState, l.source.Durable)
 				require.True(t, l.dynamicAddr)
-				require.Equal(t, ExpiryLinkDetach, l.Source.ExpiryPolicy)
-				require.Equal(t, uint32(5), l.Source.Timeout)
+				require.Equal(t, ExpiryLinkDetach, l.source.ExpiryPolicy)
+				require.Equal(t, uint32(5), l.source.Timeout)
 				require.False(t, l.detachOnDispositionError)
-				require.Equal(t, name, l.Key.name)
+				require.Equal(t, name, l.key.name)
 				require.Equal(t, map[encoding.Symbol]interface{}{
 					"property": 123,
 				}, l.properties)
-				require.NotNil(t, l.SenderSettleMode)
-				require.Equal(t, ModeSettled, *l.SenderSettleMode)
-				require.NotNil(t, l.ReceiverSettleMode)
-				require.Equal(t, ModeFirst, *l.ReceiverSettleMode)
-				require.Empty(t, l.Target.Address)
+				require.NotNil(t, l.senderSettleMode)
+				require.Equal(t, ModeSettled, *l.senderSettleMode)
+				require.NotNil(t, l.receiverSettleMode)
+				require.Equal(t, ModeFirst, *l.receiverSettleMode)
+				require.Empty(t, l.target.Address)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			got, err := newSendingLink(targetAddr, nil, &tt.opts)
+			got, err := newSender(targetAddr, nil, &tt.opts)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			tt.validate(t, got)
@@ -311,7 +319,7 @@ func TestNewReceivingLink(t *testing.T) {
 	tests := []struct {
 		label    string
 		opts     ReceiverOptions
-		validate func(t *testing.T, l *link)
+		validate func(t *testing.T, l *Receiver)
 
 		wantSource     *frames.Source
 		wantTarget     *frames.Target
@@ -319,24 +327,23 @@ func TestNewReceivingLink(t *testing.T) {
 	}{
 		{
 			label: "default options",
-			validate: func(t *testing.T, l *link) {
+			validate: func(t *testing.T, l *Receiver) {
 				//require.False(t, l.receiver.batching)
 				//require.Equal(t, defaultLinkBatchMaxAge, l.receiver.batchMaxAge)
-				require.Empty(t, l.Target.Capabilities)
+				require.Empty(t, l.target.Capabilities)
 				//require.Equal(t, defaultLinkCredit, l.receiver.maxCredit)
-				require.Equal(t, DurabilityNone, l.Target.Durable)
+				require.Equal(t, DurabilityNone, l.target.Durable)
 				require.False(t, l.dynamicAddr)
-				require.Empty(t, l.Target.ExpiryPolicy)
-				require.Zero(t, l.Target.Timeout)
-				require.Empty(t, l.Source.Filter)
-				require.False(t, l.detachOnDispositionError)
+				require.Empty(t, l.target.ExpiryPolicy)
+				require.Zero(t, l.target.Timeout)
+				require.Empty(t, l.source.Filter)
 				//require.Nil(t, l.receiver.manualCreditor)
-				require.Zero(t, l.MaxMessageSize)
-				require.NotEmpty(t, l.Key.name)
+				require.Zero(t, l.maxMessageSize)
+				require.NotEmpty(t, l.key.name)
 				require.Empty(t, l.properties)
-				require.Nil(t, l.SenderSettleMode)
-				require.Nil(t, l.ReceiverSettleMode)
-				require.Equal(t, sourceAddr, l.Source.Address)
+				require.Nil(t, l.senderSettleMode)
+				require.Nil(t, l.receiverSettleMode)
+				require.Equal(t, sourceAddr, l.source.Address)
 			},
 		},
 		{
@@ -363,15 +370,15 @@ func TestNewReceivingLink(t *testing.T) {
 				RequestedSenderSettleMode: ModeMixed.Ptr(),
 				SettlementMode:            ModeSecond.Ptr(),
 			},
-			validate: func(t *testing.T, l *link) {
+			validate: func(t *testing.T, l *Receiver) {
 				//require.True(t, l.receiver.batching)
 				//require.Equal(t, 1*time.Minute, l.receiver.batchMaxAge)
-				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.Target.Capabilities)
+				require.Equal(t, encoding.MultiSymbol{"foo", "bar"}, l.target.Capabilities)
 				//require.Equal(t, uint32(32), l.receiver.maxCredit)
-				require.Equal(t, DurabilityConfiguration, l.Target.Durable)
+				require.Equal(t, DurabilityConfiguration, l.target.Durable)
 				require.True(t, l.dynamicAddr)
-				require.Equal(t, ExpiryNever, l.Target.ExpiryPolicy)
-				require.Equal(t, uint32(3), l.Target.Timeout)
+				require.Equal(t, ExpiryNever, l.target.ExpiryPolicy)
+				require.Equal(t, uint32(3), l.target.Timeout)
 				require.Equal(t, encoding.Filter{
 					selectorFilter: &encoding.DescribedType{
 						Descriptor: selectorFilterCode,
@@ -381,26 +388,25 @@ func TestNewReceivingLink(t *testing.T) {
 						Descriptor: uint64(0x00000137000000C),
 						Value:      "123",
 					},
-				}, l.Source.Filter)
-				require.False(t, l.detachOnDispositionError)
+				}, l.source.Filter)
 				//require.NotNil(t, l.receiver.manualCreditor)
-				require.Equal(t, uint64(1024), l.MaxMessageSize)
-				require.Equal(t, name, l.Key.name)
+				require.Equal(t, uint64(1024), l.maxMessageSize)
+				require.Equal(t, name, l.key.name)
 				require.Equal(t, map[encoding.Symbol]interface{}{
 					"property": 123,
 				}, l.properties)
-				require.NotNil(t, l.SenderSettleMode)
-				require.Equal(t, ModeMixed, *l.SenderSettleMode)
-				require.NotNil(t, l.ReceiverSettleMode)
-				require.Equal(t, ModeSecond, *l.ReceiverSettleMode)
-				require.Empty(t, l.Source.Address)
+				require.NotNil(t, l.senderSettleMode)
+				require.Equal(t, ModeMixed, *l.senderSettleMode)
+				require.NotNil(t, l.receiverSettleMode)
+				require.Equal(t, ModeSecond, *l.receiverSettleMode)
+				require.Empty(t, l.source.Address)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			got, err := newReceivingLink(sourceAddr, nil, &Receiver{}, &tt.opts)
+			got, err := newReceiver(sourceAddr, nil, &tt.opts)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			tt.validate(t, got)

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -85,8 +85,8 @@ func (mc *manualCreditor) Drain(ctx context.Context, r *Receiver) error {
 	select {
 	case <-drained:
 		return nil
-	case <-r.detached:
-		return &DetachError{RemoteError: r.detachError}
+	case <-r.l.detached:
+		return &DetachError{RemoteError: r.l.detachError}
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -66,7 +66,7 @@ func (mc *manualCreditor) FlowBits(currentCredits uint32) (bool, uint32) {
 }
 
 // Drain initiates a drain and blocks until EndDrain is called.
-func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
+func (mc *manualCreditor) Drain(ctx context.Context, r *Receiver) error {
 	mc.mu.Lock()
 
 	if mc.drained != nil {
@@ -85,8 +85,8 @@ func (mc *manualCreditor) Drain(ctx context.Context, l *link) error {
 	select {
 	case <-drained:
 		return nil
-	case <-l.Detached:
-		return &DetachError{RemoteError: l.detachError}
+	case <-r.detached:
+		return &DetachError{RemoteError: r.detachError}
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -131,8 +131,8 @@ func TestManualCreditorDrainReturnsProperError(t *testing.T) {
 			mc := manualCreditor{}
 			link := newTestLink(t)
 
-			link.detachError = err
-			close(link.detached)
+			link.l.detachError = err
+			close(link.l.detached)
 
 			detachErr := mc.Drain(ctx, link)
 			require.Equal(t, detachErr, &DetachError{RemoteError: err})

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -132,7 +132,7 @@ func TestManualCreditorDrainReturnsProperError(t *testing.T) {
 			link := newTestLink(t)
 
 			link.detachError = err
-			close(link.Detached)
+			close(link.detached)
 
 			detachErr := mc.Drain(ctx, link)
 			require.Equal(t, detachErr, &DetachError{RemoteError: err})

--- a/message.go
+++ b/message.go
@@ -132,7 +132,7 @@ func (m *Message) GetData() []byte {
 // LinkName returns the receiving link name or the empty string.
 func (m *Message) LinkName() string {
 	if m.rcvr != nil {
-		return m.rcvr.key.name
+		return m.rcvr.l.key.name
 	}
 	return ""
 }

--- a/message.go
+++ b/message.go
@@ -104,9 +104,9 @@ type Message struct {
 	// This field is ignored when LinkSenderSettle is not ModeMixed.
 	SendSettled bool
 
-	link       *link  // the receiving link
-	deliveryID uint32 // used when sending disposition
-	settled    bool   // whether transfer was settled by sender
+	rcvr       *Receiver // the receiving link
+	deliveryID uint32    // used when sending disposition
+	settled    bool      // whether transfer was settled by sender
 }
 
 // NewMessage returns a *Message with data as the payload.
@@ -131,8 +131,8 @@ func (m *Message) GetData() []byte {
 
 // LinkName returns the receiving link name or the empty string.
 func (m *Message) LinkName() string {
-	if m.link != nil {
-		return m.link.Key.name
+	if m.rcvr != nil {
+		return m.rcvr.key.name
 	}
 	return ""
 }

--- a/receiver.go
+++ b/receiver.go
@@ -1,13 +1,18 @@
 package amqp
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/Azure/go-amqp/internal/buffer"
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/shared"
 )
 
 type messageDisposition struct {
@@ -17,7 +22,16 @@ type messageDisposition struct {
 
 // Receiver receives messages on a single AMQP link.
 type Receiver struct {
-	link           *link                   // underlying link
+	link
+	// message receiving
+	receiverReady         chan struct{}       // receiver sends on this when mux is paused to indicate it can handle more messages
+	messages              chan Message        // used to send completed messages to receiver
+	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
+	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
+	msgBuf                buffer.Buffer       // buffered bytes for current message
+	more                  bool                // if true, buf contains a partial message
+	msg                   Message             // current message being decoded
+
 	batching       bool                    // enable batching of message dispositions
 	batchMaxAge    time.Duration           // maximum time between the start n batch and sending the batch to the server
 	dispositions   chan messageDisposition // message dispositions are sent on this channel when batching is enabled
@@ -29,13 +43,37 @@ type Receiver struct {
 // IssueCredit adds credits to be requested in the next flow
 // request.
 func (r *Receiver) IssueCredit(credit uint32) error {
-	return r.link.IssueCredit(credit)
+	if r.manualCreditor == nil {
+		return errors.New("issueCredit can only be used with receiver links using manual credit management")
+	}
+
+	if err := r.manualCreditor.IssueCredit(credit); err != nil {
+		return err
+	}
+
+	// cause mux() to check our flow conditions.
+	select {
+	case r.receiverReady <- struct{}{}:
+	default:
+	}
+
+	return nil
 }
 
 // DrainCredit sets the drain flag on the next flow frame and
 // waits for the drain to be acknowledged.
 func (r *Receiver) DrainCredit(ctx context.Context) error {
-	return r.link.DrainCredit(ctx)
+	if r.manualCreditor == nil {
+		return errors.New("drain can only be used with receiver links using manual credit management")
+	}
+
+	// cause mux() to check our flow conditions.
+	select {
+	case r.receiverReady <- struct{}{}:
+	default:
+	}
+
+	return r.manualCreditor.Drain(ctx, r)
 }
 
 // Prefetched returns the next message that is stored in the Receiver's
@@ -48,16 +86,16 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 // When using ModeFirst, the message is spontaneously Accepted at reception.
 func (r *Receiver) Prefetched() *Message {
 	select {
-	case r.link.ReceiverReady <- struct{}{}:
+	case r.receiverReady <- struct{}{}:
 	default:
 	}
 
 	// non-blocking receive to ensure buffered messages are
 	// delivered regardless of whether the link has been closed.
 	select {
-	case msg := <-r.link.Messages:
+	case msg := <-r.messages:
 		debug.Log(3, "Receive() non blocking %d", msg.deliveryID)
-		msg.link = r.link
+		msg.rcvr = r
 		return &msg
 	default:
 		// done draining messages
@@ -78,12 +116,12 @@ func (r *Receiver) Receive(ctx context.Context) (*Message, error) {
 
 	// wait for the next message
 	select {
-	case msg := <-r.link.Messages:
+	case msg := <-r.messages:
 		debug.Log(3, "Receive() blocking %d", msg.deliveryID)
-		msg.link = r.link
+		msg.rcvr = r
 		return &msg, nil
-	case <-r.link.Detached:
-		return nil, r.link.err
+	case <-r.detached:
+		return nil, r.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -151,23 +189,23 @@ type ModifyMessageOptions struct {
 
 // Address returns the link's address.
 func (r *Receiver) Address() string {
-	if r.link.Source == nil {
+	if r.source == nil {
 		return ""
 	}
-	return r.link.Source.Address
+	return r.source.Address
 }
 
 // LinkName returns associated link name or an empty string if link is not defined.
 func (r *Receiver) LinkName() string {
-	return r.link.Key.name
+	return r.key.name
 }
 
 // LinkSourceFilterValue retrieves the specified link source filter value or nil if it doesn't exist.
 func (r *Receiver) LinkSourceFilterValue(name string) interface{} {
-	if r.link.Source == nil {
+	if r.source == nil {
 		return nil
 	}
-	filter, ok := r.link.Source.Filter[encoding.Symbol(name)]
+	filter, ok := r.source.Filter[encoding.Symbol(name)]
 	if !ok {
 		return nil
 	}
@@ -180,7 +218,18 @@ func (r *Receiver) LinkSourceFilterValue(name string) interface{} {
 // The session will continue to wait for the response until the Session or Client
 // is closed.
 func (r *Receiver) Close(ctx context.Context) error {
-	return r.link.Close(ctx)
+	return r.closeLink(ctx)
+}
+
+// returns the error passed in
+func (r *Receiver) closeWithError(de *Error) error {
+	r.closeOnce.Do(func() {
+		r.detachErrorMu.Lock()
+		r.detachError = de
+		r.detachErrorMu.Unlock()
+		close(r.close)
+	})
+	return de
 }
 
 func (r *Receiver) dispositionBatcher() {
@@ -261,7 +310,7 @@ func (r *Receiver) dispositionBatcher() {
 			batchStarted = false
 			batchTimer.Stop()
 
-		case <-r.link.Detached:
+		case <-r.detached:
 			return
 		}
 	}
@@ -273,22 +322,22 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 		Role:    encoding.RoleReceiver,
 		First:   first,
 		Last:    last,
-		Settled: r.link.ReceiverSettleMode == nil || *r.link.ReceiverSettleMode == ModeFirst,
+		Settled: r.receiverSettleMode == nil || *r.receiverSettleMode == ModeFirst,
 		State:   state,
 	}
 
 	select {
-	case <-r.link.Detached:
-		return r.link.err
+	case <-r.detached:
+		return r.err
 	default:
 		debug.Log(1, "TX (sendDisposition): %s", fr)
-		return r.link.Session.txFrame(fr, nil)
+		return r.session.txFrame(fr, nil)
 	}
 }
 
 func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state encoding.DeliveryState) error {
 	var wait chan error
-	if r.link.ReceiverSettleMode != nil && *r.link.ReceiverSettleMode == ModeSecond {
+	if r.receiverSettleMode != nil && *r.receiverSettleMode == ModeSecond {
 		debug.Log(3, "RX (messageDisposition): add %d to inflight", msg.deliveryID)
 		wait = r.inFlight.add(msg.deliveryID)
 	}
@@ -296,8 +345,8 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	if r.batching {
 		select {
 		case r.dispositions <- messageDisposition{id: msg.deliveryID, state: state}:
-		case <-r.link.Detached:
-			return r.link.err
+		case <-r.detached:
+			return r.err
 		}
 	} else {
 		err := r.sendDisposition(msg.deliveryID, nil, state)
@@ -313,11 +362,455 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	select {
 	case err := <-wait:
 		// we've received confirmation of disposition
-		r.link.DeleteUnsettled(msg)
+		r.deleteUnsettled(msg)
 		msg.settled = true
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (r *Receiver) addUnsettled(msg *Message) {
+	r.unsettledMessagesLock.Lock()
+	r.unsettledMessages[string(msg.DeliveryTag)] = struct{}{}
+	r.unsettledMessagesLock.Unlock()
+}
+
+func (r *Receiver) deleteUnsettled(msg *Message) {
+	r.unsettledMessagesLock.Lock()
+	delete(r.unsettledMessages, string(msg.DeliveryTag))
+	r.unsettledMessagesLock.Unlock()
+}
+
+func (r *Receiver) countUnsettled() int {
+	r.unsettledMessagesLock.RLock()
+	count := len(r.unsettledMessages)
+	r.unsettledMessagesLock.RUnlock()
+	return count
+}
+
+func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, error) {
+	l := &Receiver{
+		link: link{
+			key:      linkKey{shared.RandString(40), encoding.RoleReceiver},
+			session:  s,
+			close:    make(chan struct{}),
+			detached: make(chan struct{}),
+			source:   &frames.Source{Address: source},
+			target:   new(frames.Target),
+		},
+		receiverReady: make(chan struct{}, 1),
+		batching:      defaultLinkBatching,
+		batchMaxAge:   defaultLinkBatchMaxAge,
+		maxCredit:     defaultLinkCredit,
+	}
+
+	if opts == nil {
+		return l, nil
+	}
+
+	l.batching = opts.Batching
+	if opts.BatchMaxAge > 0 {
+		l.batchMaxAge = opts.BatchMaxAge
+	}
+	for _, v := range opts.Capabilities {
+		l.target.Capabilities = append(l.target.Capabilities, encoding.Symbol(v))
+	}
+	if opts.Credit > 0 {
+		l.maxCredit = opts.Credit
+	}
+	if opts.Durability > DurabilityUnsettledState {
+		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
+	}
+	l.target.Durable = opts.Durability
+	if opts.DynamicAddress {
+		l.source.Address = ""
+		l.dynamicAddr = opts.DynamicAddress
+	}
+	if opts.ExpiryPolicy != "" {
+		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
+			return nil, err
+		}
+		l.target.ExpiryPolicy = opts.ExpiryPolicy
+	}
+	l.target.Timeout = opts.ExpiryTimeout
+	if opts.Filters != nil {
+		l.source.Filter = make(encoding.Filter)
+		for _, f := range opts.Filters {
+			f(l.source.Filter)
+		}
+	}
+	if opts.ManualCredits {
+		l.manualCreditor = &manualCreditor{}
+	}
+	if opts.MaxMessageSize > 0 {
+		l.maxMessageSize = opts.MaxMessageSize
+	}
+	if opts.Name != "" {
+		l.key.name = opts.Name
+	}
+	if opts.Properties != nil {
+		l.properties = make(map[encoding.Symbol]interface{})
+		for k, v := range opts.Properties {
+			if k == "" {
+				return nil, errors.New("link property key must not be empty")
+			}
+			l.properties[encoding.Symbol(k)] = v
+		}
+	}
+	if opts.RequestedSenderSettleMode != nil {
+		if rsm := *opts.RequestedSenderSettleMode; rsm > ModeMixed {
+			return nil, fmt.Errorf("invalid RequestedSenderSettleMode %d", rsm)
+		}
+		l.senderSettleMode = opts.RequestedSenderSettleMode
+	}
+	if opts.SettlementMode != nil {
+		if rsm := *opts.SettlementMode; rsm > ModeSecond {
+			return nil, fmt.Errorf("invalid SettlementMode %d", rsm)
+		}
+		l.receiverSettleMode = opts.SettlementMode
+	}
+	l.target.Address = opts.TargetAddress
+	return l, nil
+}
+
+// attach sends the Attach performative to establish the link with its parent session.
+// this is automatically called by the new*Link constructors.
+func (r *Receiver) attach(ctx context.Context, s *Session) error {
+	// buffer rx to linkCredit so that conn.mux won't block
+	// attempting to send to a slow reader
+	if r.manualCreditor != nil {
+		r.rx = make(chan frames.FrameBody, r.maxCredit)
+	} else {
+		r.rx = make(chan frames.FrameBody, r.linkCredit)
+	}
+
+	if err := r.attachLink(ctx, s, func(pa *frames.PerformAttach) {
+		pa.Role = encoding.RoleReceiver
+		if pa.Source == nil {
+			pa.Source = new(frames.Source)
+		}
+		pa.Source.Dynamic = r.dynamicAddr
+	}, func(pa *frames.PerformAttach) {
+		if r.source == nil {
+			r.source = new(frames.Source)
+		}
+		// if dynamic address requested, copy assigned name to address
+		if r.dynamicAddr && pa.Source != nil {
+			r.source.Address = pa.Source.Address
+		}
+		// deliveryCount is a sequence number, must initialize to sender's initial sequence number
+		r.deliveryCount = pa.InitialDeliveryCount
+		// buffer receiver so that link.mux doesn't block
+		r.messages = make(chan Message, r.maxCredit)
+		r.unsettledMessages = map[string]struct{}{}
+		// copy the received filter values
+		if pa.Source != nil {
+			r.source.Filter = pa.Source.Filter
+		}
+	}); err != nil {
+		return err
+	}
+
+	go r.mux()
+
+	return nil
+}
+
+func (r *Receiver) mux() {
+	defer r.muxDetach(r.muxDetachDeferred, func(fr frames.PerformTransfer) { _ = r.muxReceive(fr) })
+
+	for {
+		switch {
+		case r.manualCreditor != nil:
+			drain, credits := r.manualCreditor.FlowBits(r.linkCredit)
+
+			if drain || credits > 0 {
+				debug.Log(1, "receiver (manual): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s",
+					r.source.Address, r.inFlight.len(), r.linkCredit, credits, drain, r.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.receiverSettleMode.String())
+
+				// send a flow frame.
+				r.err = r.muxFlow(credits, drain)
+			}
+
+		// if receiver && half maxCredits have been processed, send more credits
+		case r.linkCredit+uint32(r.countUnsettled()) <= r.maxCredit/2:
+			debug.Log(1, "receiver (half): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", r.source.Address, r.inFlight.len(), r.linkCredit, r.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.receiverSettleMode.String())
+
+			linkCredit := r.maxCredit - uint32(r.countUnsettled())
+			r.err = r.muxFlow(linkCredit, false)
+
+		case r.linkCredit == 0:
+			debug.Log(1, "receiver (pause): inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", r.inFlight.len(), r.linkCredit, r.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.receiverSettleMode.String())
+		}
+
+		if r.err != nil {
+			return
+		}
+
+		select {
+		// received frame
+		case fr := <-r.rx:
+			r.err = r.muxHandleFrame(fr)
+			if r.err != nil {
+				return
+			}
+
+		case <-r.receiverReady:
+			continue
+		case <-r.close:
+			r.err = ErrLinkClosed
+			return
+		case <-r.session.done:
+			r.err = r.session.err
+			return
+		}
+	}
+}
+
+// muxFlow sends tr to the session mux.
+// l.linkCredit will also be updated to `linkCredit`
+func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
+	var (
+		deliveryCount = r.deliveryCount
+	)
+
+	debug.Log(3, "muxFlow: len(l.Messages):%d - linkCredit: %d - deliveryCount: %d, inFlight: %d", len(r.messages), linkCredit, deliveryCount, r.inFlight.len())
+
+	fr := &frames.PerformFlow{
+		Handle:        &r.handle,
+		DeliveryCount: &deliveryCount,
+		LinkCredit:    &linkCredit, // max number of messages,
+		Drain:         drain,
+	}
+	debug.Log(3, "TX (muxFlow): %s", fr)
+
+	// Update credit. This must happen before entering loop below
+	// because incoming messages handled while waiting to transmit
+	// flow increment deliveryCount. This causes the credit to become
+	// out of sync with the server.
+
+	if !drain {
+		// if we're draining we don't want to touch our internal credit - we're not changing it so any issued credits
+		// are still valid until drain completes, at which point they will be naturally zeroed.
+		r.linkCredit = linkCredit
+	}
+
+	// Ensure the session mux is not blocked
+	for {
+		select {
+		case r.session.tx <- fr:
+			return nil
+		case fr := <-r.rx:
+			err := r.muxHandleFrame(fr)
+			if err != nil {
+				return err
+			}
+		case <-r.close:
+			return ErrLinkClosed
+		case <-r.session.done:
+			return r.session.err
+		}
+	}
+}
+
+// muxHandleFrame processes fr based on type.
+func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
+	switch fr := fr.(type) {
+	// message frame
+	case *frames.PerformTransfer:
+		return r.muxReceive(*fr)
+
+	// flow control frame
+	case *frames.PerformFlow:
+		debug.Log(3, "RX (receiver): %s", fr)
+		if !fr.Echo {
+			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
+			// we signal whomever is waiting (the service has seen and acknowledged our drain)
+			if fr.Drain && r.manualCreditor != nil {
+				r.linkCredit = 0 // we have no active credits at this point.
+				r.manualCreditor.EndDrain()
+			}
+			return nil
+		}
+
+		var (
+			// copy because sent by pointer below; prevent race
+			linkCredit    = r.linkCredit
+			deliveryCount = r.deliveryCount
+		)
+
+		// send flow
+		// TODO: missing Available and session info
+		resp := &frames.PerformFlow{
+			Handle:        &r.handle,
+			DeliveryCount: &deliveryCount,
+			LinkCredit:    &linkCredit, // max number of messages
+		}
+		debug.Log(1, "TX (receiver): %s", resp)
+		_ = r.session.txFrame(resp, nil)
+
+	case *frames.PerformDisposition:
+		debug.Log(3, "RX (receiver): %s", fr)
+
+		// Unblock receivers waiting for message disposition
+		// bubble disposition error up to the receiver
+		var dispositionError error
+		if state, ok := fr.State.(*encoding.StateRejected); ok {
+			// state.Error isn't required to be filled out. For instance if you dead letter a message
+			// you will get a rejected response that doesn't contain an error.
+			if state.Error != nil {
+				dispositionError = state.Error
+			}
+		}
+		// removal from the in-flight map will also remove the message from the unsettled map
+		r.inFlight.remove(fr.First, fr.Last, dispositionError)
+
+	default:
+		return r.link.muxHandleFrame(fr)
+	}
+
+	return nil
+}
+
+func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
+	if !r.more {
+		// this is the first transfer of a message,
+		// record the delivery ID, message format,
+		// and delivery Tag
+		if fr.DeliveryID != nil {
+			r.msg.deliveryID = *fr.DeliveryID
+		}
+		if fr.MessageFormat != nil {
+			r.msg.Format = *fr.MessageFormat
+		}
+		r.msg.DeliveryTag = fr.DeliveryTag
+
+		// these fields are required on first transfer of a message
+		if fr.DeliveryID == nil {
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: "received message without a delivery-id",
+			})
+		}
+		if fr.MessageFormat == nil {
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: "received message without a message-format",
+			})
+		}
+		if fr.DeliveryTag == nil {
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: "received message without a delivery-tag",
+			})
+		}
+	} else {
+		// this is a continuation of a multipart message
+		// some fields may be omitted on continuation transfers,
+		// but if they are included they must be consistent
+		// with the first.
+
+		if fr.DeliveryID != nil && *fr.DeliveryID != r.msg.deliveryID {
+			msg := fmt.Sprintf(
+				"received continuation transfer with inconsistent delivery-id: %d != %d",
+				*fr.DeliveryID, r.msg.deliveryID,
+			)
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: msg,
+			})
+		}
+		if fr.MessageFormat != nil && *fr.MessageFormat != r.msg.Format {
+			msg := fmt.Sprintf(
+				"received continuation transfer with inconsistent message-format: %d != %d",
+				*fr.MessageFormat, r.msg.Format,
+			)
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: msg,
+			})
+		}
+		if fr.DeliveryTag != nil && !bytes.Equal(fr.DeliveryTag, r.msg.DeliveryTag) {
+			msg := fmt.Sprintf(
+				"received continuation transfer with inconsistent delivery-tag: %q != %q",
+				fr.DeliveryTag, r.msg.DeliveryTag,
+			)
+			return r.closeWithError(&Error{
+				Condition:   ErrorNotAllowed,
+				Description: msg,
+			})
+		}
+	}
+
+	// discard message if it's been aborted
+	if fr.Aborted {
+		r.msgBuf.Reset()
+		r.msg = Message{}
+		r.more = false
+		return nil
+	}
+
+	// ensure maxMessageSize will not be exceeded
+	if r.maxMessageSize != 0 && uint64(r.msgBuf.Len())+uint64(len(fr.Payload)) > r.maxMessageSize {
+		return r.closeWithError(&Error{
+			Condition:   ErrorMessageSizeExceeded,
+			Description: fmt.Sprintf("received message larger than max size of %d", r.maxMessageSize),
+		})
+	}
+
+	// add the payload the the buffer
+	r.msgBuf.Append(fr.Payload)
+
+	// mark as settled if at least one frame is settled
+	r.msg.settled = r.msg.settled || fr.Settled
+
+	// save in-progress status
+	r.more = fr.More
+
+	if fr.More {
+		return nil
+	}
+
+	// last frame in message
+	err := r.msg.Unmarshal(&r.msgBuf)
+	if err != nil {
+		return err
+	}
+	debug.Log(1, "deliveryID %d before push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.deliveryCount, r.linkCredit, len(r.messages), r.inFlight.len())
+	// send to receiver
+	if receiverSettleModeValue(r.receiverSettleMode) == ModeSecond {
+		r.addUnsettled(&r.msg)
+	}
+	select {
+	case r.messages <- r.msg:
+		// message received
+	case <-r.detached:
+		// link has been detached
+		return r.err
+	}
+
+	debug.Log(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.deliveryCount, r.linkCredit, len(r.messages), r.inFlight.len())
+
+	// reset progress
+	r.msgBuf.Reset()
+	r.msg = Message{}
+
+	// decrement link-credit after entire message received
+	r.deliveryCount++
+	r.linkCredit--
+	debug.Log(1, "deliveryID %d before exit - deliveryCount : %d - linkCredit: %d, len(messages): %d", r.msg.deliveryID, r.deliveryCount, r.linkCredit, len(r.messages))
+	return nil
+}
+
+// to be called during detachment
+func (r *Receiver) muxDetachDeferred() {
+	// unblock any in flight message dispositions
+	r.inFlight.clear(r.err)
+
+	// unblock any pending drain requests
+	if r.manualCreditor != nil {
+		r.manualCreditor.EndDrain()
 	}
 }
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -416,7 +416,7 @@ func TestReceiveSuccessModeFirst(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -475,7 +475,7 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -496,7 +496,7 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -555,7 +555,7 @@ func TestReceiveSuccessModeSecondAcceptOnClosedLink(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 
@@ -615,7 +615,7 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -635,7 +635,7 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -689,7 +689,7 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -709,7 +709,7 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -768,7 +768,7 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -793,7 +793,7 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -882,7 +882,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -903,7 +903,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.linkCredit; c != 1 {
+	if c := r.l.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -1170,7 +1170,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.linkCredit; c != 0 {
+	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// close client before accepting the message

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -410,13 +410,13 @@ func TestReceiveSuccessModeFirst(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -469,20 +469,20 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	require.Equal(t, true, msg.settled)
@@ -494,9 +494,9 @@ func TestReceiveSuccessModeSecondAccept(t *testing.T) {
 	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -549,13 +549,13 @@ func TestReceiveSuccessModeSecondAcceptOnClosedLink(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 
@@ -609,20 +609,20 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.RejectMessage(ctx, msg, nil)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// perform a dummy receive with short timeout to trigger flow
@@ -633,9 +633,9 @@ func TestReceiveSuccessModeSecondReject(t *testing.T) {
 	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -683,20 +683,20 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.ReleaseMessage(ctx, msg)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// perform a dummy receive with short timeout to trigger flow
@@ -707,9 +707,9 @@ func TestReceiveSuccessModeSecondRelease(t *testing.T) {
 	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -762,13 +762,13 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -780,7 +780,7 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	})
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// perform a dummy receive with short timeout to trigger flow
@@ -791,9 +791,9 @@ func TestReceiveSuccessModeSecondModify(t *testing.T) {
 	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -803,10 +803,8 @@ func TestReceiverPrefetch(t *testing.T) {
 	messagesCh := make(chan Message, 1)
 
 	receiver := &Receiver{
-		link: &link{
-			Messages:      messagesCh,
-			ReceiverReady: make(chan struct{}),
-		},
+		messages:      messagesCh,
+		receiverReady: make(chan struct{}),
 	}
 
 	// if there are no cached messages we just return immediately - no error, no message.
@@ -878,20 +876,20 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 		result = append(result, msg.Data[i]...)
 	}
 	require.Equal(t, payload, result)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	require.Equal(t, true, msg.settled)
@@ -903,9 +901,9 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	}
 	cancel()
 	// wait for the link to unpause as credit should now be available
-	require.NoError(t, waitForLink(r.link, false))
+	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.link.linkCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -1166,13 +1164,13 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// wait for the link to pause as we've consumed all available credit
-	require.NoError(t, waitForLink(r.link, true))
+	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.link.linkCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// close client before accepting the message
@@ -1184,7 +1182,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 }
@@ -1234,14 +1232,14 @@ func TestReceiverDispositionBatcherTimer(t *testing.T) {
 	msg, err := r.Receive(ctx)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 1 {
+	if c := r.countUnsettled(); c != 1 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
 	require.NoError(t, err)
-	if c := r.link.countUnsettled(); c != 0 {
+	if c := r.countUnsettled(); c != 0 {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	require.Equal(t, 0, r.inFlight.len())

--- a/sender.go
+++ b/sender.go
@@ -3,18 +3,28 @@ package amqp
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/Azure/go-amqp/internal/buffer"
+	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/shared"
 )
 
 // Sender sends messages on a single AMQP link.
 type Sender struct {
-	link *link
+	link
+	transfers chan frames.PerformTransfer // sender uses to send transfer frames
+
+	// Indicates whether we should allow detaches on disposition errors or not.
+	// Some AMQP servers (like Event Hubs) benefit from keeping the link open on disposition errors
+	// (for instance, if you're doing many parallel sends over the same link and you get back a
+	// throttling error, which is not fatal)
+	detachOnDispositionError bool
 
 	mu              sync.Mutex // protects buf and nextDeliveryTag
 	buf             buffer.Buffer
@@ -23,12 +33,12 @@ type Sender struct {
 
 // LinkName() is the name of the link used for this Sender.
 func (s *Sender) LinkName() string {
-	return s.link.Key.name
+	return s.key.name
 }
 
 // MaxMessageSize is the maximum size of a single message.
 func (s *Sender) MaxMessageSize() uint64 {
-	return s.link.MaxMessageSize
+	return s.maxMessageSize
 }
 
 // Send sends a Message.
@@ -44,8 +54,8 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	// check if the link is dead.  while it's safe to call s.send
 	// in this case, this will avoid some allocations etc.
 	select {
-	case <-s.link.Detached:
-		return s.link.err
+	case <-s.detached:
+		return s.err
 	default:
 		// link is still active
 	}
@@ -58,14 +68,14 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	select {
 	case state := <-done:
 		if state, ok := state.(*encoding.StateRejected); ok {
-			if s.link.detachOnRejectDisp() {
+			if s.detachOnRejectDisp() {
 				return &DetachError{state.Error}
 			}
 			return state.Error
 		}
 		return nil
-	case <-s.link.Detached:
-		return s.link.err
+	case <-s.detached:
+		return s.err
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -88,15 +98,15 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 		return nil, err
 	}
 
-	if s.link.MaxMessageSize != 0 && uint64(s.buf.Len()) > s.link.MaxMessageSize {
-		return nil, fmt.Errorf("encoded message size exceeds max of %d", s.link.MaxMessageSize)
+	if s.maxMessageSize != 0 && uint64(s.buf.Len()) > s.maxMessageSize {
+		return nil, fmt.Errorf("encoded message size exceeds max of %d", s.maxMessageSize)
 	}
 
 	var (
-		maxPayloadSize = int64(s.link.Session.conn.PeerMaxFrameSize) - maxTransferFrameHeader
-		sndSettleMode  = s.link.SenderSettleMode
+		maxPayloadSize = int64(s.session.conn.PeerMaxFrameSize) - maxTransferFrameHeader
+		sndSettleMode  = s.senderSettleMode
 		senderSettled  = sndSettleMode != nil && (*sndSettleMode == ModeSettled || (*sndSettleMode == ModeMixed && msg.SendSettled))
-		deliveryID     = atomic.AddUint32(&s.link.Session.nextDeliveryID, 1)
+		deliveryID     = atomic.AddUint32(&s.session.nextDeliveryID, 1)
 	)
 
 	deliveryTag := msg.DeliveryTag
@@ -108,7 +118,7 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 	}
 
 	fr := frames.PerformTransfer{
-		Handle:        s.link.Handle,
+		Handle:        s.handle,
 		DeliveryID:    &deliveryID,
 		DeliveryTag:   deliveryTag,
 		MessageFormat: &msg.Format,
@@ -133,9 +143,9 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 		}
 
 		select {
-		case s.link.Transfers <- fr:
-		case <-s.link.Detached:
-			return nil, s.link.err
+		case s.transfers <- fr:
+		case <-s.detached:
+			return nil, s.err
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -151,13 +161,245 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 
 // Address returns the link's address.
 func (s *Sender) Address() string {
-	if s.link.Target == nil {
+	if s.target == nil {
 		return ""
 	}
-	return s.link.Target.Address
+	return s.target.Address
 }
 
 // Close closes the Sender and AMQP link.
 func (s *Sender) Close(ctx context.Context) error {
-	return s.link.Close(ctx)
+	return s.closeLink(ctx)
+}
+
+// newSendingLink creates a new sending link and attaches it to the session
+func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) {
+	l := &Sender{
+		link: link{
+			key:      linkKey{shared.RandString(40), encoding.RoleSender},
+			session:  s,
+			close:    make(chan struct{}),
+			detached: make(chan struct{}),
+			target:   &frames.Target{Address: target},
+			source:   new(frames.Source),
+		},
+		detachOnDispositionError: true,
+	}
+
+	if opts == nil {
+		return l, nil
+	}
+
+	for _, v := range opts.Capabilities {
+		l.source.Capabilities = append(l.source.Capabilities, encoding.Symbol(v))
+	}
+	if opts.Durability > DurabilityUnsettledState {
+		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
+	}
+	l.source.Durable = opts.Durability
+	if opts.DynamicAddress {
+		l.target.Address = ""
+		l.dynamicAddr = opts.DynamicAddress
+	}
+	if opts.ExpiryPolicy != "" {
+		if err := encoding.ValidateExpiryPolicy(opts.ExpiryPolicy); err != nil {
+			return nil, err
+		}
+		l.source.ExpiryPolicy = opts.ExpiryPolicy
+	}
+	l.source.Timeout = opts.ExpiryTimeout
+	l.detachOnDispositionError = !opts.IgnoreDispositionErrors
+	if opts.Name != "" {
+		l.key.name = opts.Name
+	}
+	if opts.Properties != nil {
+		l.properties = make(map[encoding.Symbol]interface{})
+		for k, v := range opts.Properties {
+			if k == "" {
+				return nil, errors.New("link property key must not be empty")
+			}
+			l.properties[encoding.Symbol(k)] = v
+		}
+	}
+	if opts.RequestedReceiverSettleMode != nil {
+		if rsm := *opts.RequestedReceiverSettleMode; rsm > ModeSecond {
+			return nil, fmt.Errorf("invalid RequestedReceiverSettleMode %d", rsm)
+		}
+		l.receiverSettleMode = opts.RequestedReceiverSettleMode
+	}
+	if opts.SettlementMode != nil {
+		if ssm := *opts.SettlementMode; ssm > ModeMixed {
+			return nil, fmt.Errorf("invalid SettlementMode %d", ssm)
+		}
+		l.senderSettleMode = opts.SettlementMode
+	}
+	l.source.Address = opts.SourceAddress
+	return l, nil
+}
+
+func (s *Sender) attach(ctx context.Context, session *Session) error {
+	// sending unsettled messages when the receiver is in mode-second is currently
+	// broken and causes a hang after sending, so just disallow it for now.
+	if senderSettleModeValue(s.senderSettleMode) != ModeSettled && receiverSettleModeValue(s.receiverSettleMode) == ModeSecond {
+		return errors.New("sender does not support exactly-once guarantee")
+	}
+
+	s.rx = make(chan frames.FrameBody, 1)
+
+	if err := s.attachLink(ctx, session, func(pa *frames.PerformAttach) {
+		pa.Role = encoding.RoleSender
+		if pa.Target == nil {
+			pa.Target = new(frames.Target)
+		}
+		pa.Target.Dynamic = s.dynamicAddr
+	}, func(pa *frames.PerformAttach) {
+		if s.target == nil {
+			s.target = new(frames.Target)
+		}
+
+		// if dynamic address requested, copy assigned name to address
+		if s.dynamicAddr && pa.Target != nil {
+			s.target.Address = pa.Target.Address
+		}
+	}); err != nil {
+		return err
+	}
+
+	s.transfers = make(chan frames.PerformTransfer)
+
+	go s.mux()
+
+	return nil
+}
+
+func (s *Sender) mux() {
+	defer s.muxDetach(nil, nil)
+
+Loop:
+	for {
+		var outgoingTransfers chan frames.PerformTransfer
+		if s.linkCredit > 0 {
+			debug.Log(1, "sender: credit: %d, deliveryCount: %d", s.linkCredit, s.deliveryCount)
+			outgoingTransfers = s.transfers
+		}
+
+		select {
+		// received frame
+		case fr := <-s.rx:
+			s.err = s.muxHandleFrame(fr)
+			if s.err != nil {
+				return
+			}
+
+		// send data
+		case tr := <-outgoingTransfers:
+			debug.Log(3, "TX (sender): %s", tr)
+
+			// Ensure the session mux is not blocked
+			for {
+				select {
+				case s.session.txTransfer <- &tr:
+					// decrement link-credit after entire message transferred
+					if !tr.More {
+						s.deliveryCount++
+						s.linkCredit--
+						// we are the sender and we keep track of the peer's link credit
+						debug.Log(3, "TX (sender): key:%s, decremented linkCredit: %d", s.key.name, s.linkCredit)
+					}
+					continue Loop
+				case fr := <-s.rx:
+					s.err = s.muxHandleFrame(fr)
+					if s.err != nil {
+						return
+					}
+				case <-s.close:
+					s.err = ErrLinkClosed
+					return
+				case <-s.session.done:
+					s.err = s.session.err
+					return
+				}
+			}
+
+		case <-s.close:
+			s.err = ErrLinkClosed
+			return
+		case <-s.session.done:
+			s.err = s.session.err
+			return
+		}
+	}
+}
+
+// muxHandleFrame processes fr based on type.
+func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
+	switch fr := fr.(type) {
+	// flow control frame
+	case *frames.PerformFlow:
+		debug.Log(3, "RX (sender): %s", fr)
+		linkCredit := *fr.LinkCredit - s.deliveryCount
+		if fr.DeliveryCount != nil {
+			// DeliveryCount can be nil if the receiver hasn't processed
+			// the attach. That shouldn't be the case here, but it's
+			// what ActiveMQ does.
+			linkCredit += *fr.DeliveryCount
+		}
+		s.linkCredit = linkCredit
+
+		if !fr.Echo {
+			return nil
+		}
+
+		var (
+			// copy because sent by pointer below; prevent race
+			deliveryCount = s.deliveryCount
+		)
+
+		// send flow
+		// TODO: missing Available and session info
+		resp := &frames.PerformFlow{
+			Handle:        &s.handle,
+			DeliveryCount: &deliveryCount,
+			LinkCredit:    &linkCredit, // max number of messages
+		}
+		debug.Log(1, "TX (sender): %s", resp)
+		_ = s.session.txFrame(resp, nil)
+
+	case *frames.PerformDisposition:
+		debug.Log(3, "RX (sender): %s", fr)
+		// If sending async and a message is rejected, cause a link error.
+		//
+		// This isn't ideal, but there isn't a clear better way to handle it.
+		if fr, ok := fr.State.(*encoding.StateRejected); ok && s.detachOnRejectDisp() {
+			return &DetachError{fr.Error}
+		}
+
+		if fr.Settled {
+			return nil
+		}
+
+		resp := &frames.PerformDisposition{
+			Role:    encoding.RoleSender,
+			First:   fr.First,
+			Last:    fr.Last,
+			Settled: true,
+		}
+		debug.Log(1, "TX (sender): %s", resp)
+		_ = s.session.txFrame(resp, nil)
+
+	default:
+		return s.link.muxHandleFrame(fr)
+	}
+
+	return nil
+}
+
+func (s *Sender) detachOnRejectDisp() bool {
+	// only detach on rejection when no RSM was requested or in ModeFirst.
+	// if the receiver is in ModeSecond, it will send an explicit rejection disposition
+	// that we'll have to ack. so in that case, we don't treat it as a link error.
+	if s.detachOnDispositionError && (s.receiverSettleMode == nil || *s.receiverSettleMode == ModeFirst) {
+		return true
+	}
+	return false
 }

--- a/sender_test.go
+++ b/sender_test.go
@@ -848,7 +848,7 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 
 	nextIncomingID := uint32(1)
 	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
-		Handle:         &sender.link.Handle,
+		Handle:         &sender.handle,
 		NextIncomingID: &nextIncomingID,
 		IncomingWindow: 100,
 		OutgoingWindow: 100,

--- a/sender_test.go
+++ b/sender_test.go
@@ -848,7 +848,7 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 
 	nextIncomingID := uint32(1)
 	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
-		Handle:         &sender.handle,
+		Handle:         &sender.l.handle,
 		NextIncomingID: &nextIncomingID,
 		IncomingWindow: 100,
 		OutgoingWindow: 100,


### PR DESCRIPTION
Split sending and receiving link functionality into their respective Sender and Receiver types.  The remaining content in link.go is what's common for both link types.
Each link type has their own mux and frame handlers as there are subtle differences between sending and receiving links.
The original implementations were cut/paste into their relevant files. Other than some local var renaming, there should be no functional changes.
