### PR TITLE
Refactor Session constructor

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,13 +2,9 @@ package amqp
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"time"
 
-	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
-	"github.com/Azure/go-amqp/internal/frames"
 )
 
 // Client is an AMQP client connection.
@@ -60,74 +56,14 @@ func (c *Client) Close() error {
 // Returns ErrConnClosed if the underlying connection has been closed.
 // opts: pass nil to accept the default values.
 func (c *Client) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
-	s, err := c.conn.NewSession()
+	s, err := c.conn.NewSession(opts)
 	if err != nil {
 		return nil, err
 	}
-	s.init(opts)
 
-	// send Begin to server
-	begin := &frames.PerformBegin{
-		NextOutgoingID: 0,
-		IncomingWindow: s.incomingWindow,
-		OutgoingWindow: s.outgoingWindow,
-		HandleMax:      s.handleMax,
+	if err = s.begin(ctx); err != nil {
+		return nil, err
 	}
-	debug.Log(1, "TX (NewSession): %s", begin)
-
-	// we use send to have positive confirmation on transmission
-	send := make(chan encoding.DeliveryState)
-	_ = s.txFrame(begin, send)
-
-	// wait for response
-	var fr frames.Frame
-	select {
-	case <-ctx.Done():
-		select {
-		case <-send:
-			// begin was written to the network.  assume it was
-			// received and that the ctx was too short to wait for
-			// the ack. in this case we must send an end before we
-			// can delete the session
-			go func() {
-				_ = s.txFrame(&frames.PerformEnd{}, nil)
-				select {
-				case <-c.conn.Done:
-					// conn has terminated, no need to delete the session
-				case <-time.After(5 * time.Second):
-					debug.Log(3, "NewSession clean-up timed out waiting for PerformEnd ack")
-				case <-s.rx:
-					// received ack that session was closed, safe to delete session
-					c.conn.DeleteSession(s)
-				}
-			}()
-		default:
-			// begin wasn't written to the network, so delete session
-			c.conn.DeleteSession(s)
-		}
-		return nil, ctx.Err()
-	case <-c.conn.Done:
-		return nil, c.conn.Err()
-	case fr = <-s.rx:
-		// received ack that session was created
-	}
-	debug.Log(1, "RX (NewSession): %s", fr.Body)
-
-	begin, ok := fr.Body.(*frames.PerformBegin)
-	if !ok {
-		// this codepath is hard to hit (impossible?).  if the response isn't a PerformBegin and we've not
-		// yet seen the remote channel number, the default clause in conn.mux will protect us from that.
-		// if we have seen the remote channel number then it's likely the session.mux for that channel will
-		// either swallow the frame or blow up in some other way, both causing this call to hang.
-		// deallocate session on error.  we can't call
-		// s.Close() as the session mux hasn't started yet.
-		c.conn.DeleteSession(s)
-		return nil, fmt.Errorf("unexpected begin response: %+v", fr.Body)
-	}
-
-	// start Session multiplexor
-	go s.mux(begin)
-
 	return s, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -123,8 +123,8 @@ func TestSessionOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			session := newSession(nil, 0)
-			session.init(&tt.opt)
+			session := newSession(nil, 0, &tt.opt)
+			tt.verify(t, session)
 		})
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -379,7 +379,7 @@ func (c *conn) Err() error {
 	return &ConnectionError{inner: c.err}
 }
 
-func (c *conn) NewSession() (*Session, error) {
+func (c *conn) NewSession(opts *SessionOptions) (*Session, error) {
 	c.sessionsByChannelMu.Lock()
 	defer c.sessionsByChannelMu.Unlock()
 
@@ -389,7 +389,7 @@ func (c *conn) NewSession() (*Session, error) {
 	if !ok {
 		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
 	}
-	session := newSession(c, uint16(channel))
+	session := newSession(c, uint16(channel), opts)
 	c.sessionsByChannel[session.channel] = session
 	return session, nil
 }

--- a/receiver.go
+++ b/receiver.go
@@ -476,7 +476,7 @@ func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, e
 
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
-func (r *Receiver) attach(ctx context.Context, s *Session) error {
+func (r *Receiver) attach(ctx context.Context) error {
 	// buffer rx to linkCredit so that conn.mux won't block
 	// attempting to send to a slow reader
 	if r.manualCreditor != nil {
@@ -485,7 +485,7 @@ func (r *Receiver) attach(ctx context.Context, s *Session) error {
 		r.l.rx = make(chan frames.FrameBody, r.l.linkCredit)
 	}
 
-	if err := r.l.attach(ctx, s, func(pa *frames.PerformAttach) {
+	if err := r.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleReceiver
 		if pa.Source == nil {
 			pa.Source = new(frames.Source)

--- a/sender.go
+++ b/sender.go
@@ -237,7 +237,7 @@ func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) 
 	return l, nil
 }
 
-func (s *Sender) attach(ctx context.Context, session *Session) error {
+func (s *Sender) attach(ctx context.Context) error {
 	// sending unsettled messages when the receiver is in mode-second is currently
 	// broken and causes a hang after sending, so just disallow it for now.
 	if senderSettleModeValue(s.l.senderSettleMode) != ModeSettled && receiverSettleModeValue(s.l.receiverSettleMode) == ModeSecond {
@@ -246,7 +246,7 @@ func (s *Sender) attach(ctx context.Context, session *Session) error {
 
 	s.l.rx = make(chan frames.FrameBody, 1)
 
-	if err := s.l.attach(ctx, session, func(pa *frames.PerformAttach) {
+	if err := s.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleSender
 		if pa.Target == nil {
 			pa.Target = new(frames.Target)


### PR DESCRIPTION
Move construction logic out of Client.NewSession and into Session.begin (this mimics the code flow for link attachment).
Merged Session.init into newSession.
Removed redundant *Session param from link.attach().
