### PR TITLE
Enable configuration of durable subscriptions

### DIFF
--- a/link_options.go
+++ b/link_options.go
@@ -63,6 +63,23 @@ type SenderOptions struct {
 
 	// SourceAddress specifies the source address for this sender.
 	SourceAddress string
+
+	// TargetDurability indicates what state of the peer will be retained durably.
+	//
+	// Default: DurabilityNone.
+	TargetDurability Durability
+
+	// TargetExpiryPolicy determines when the expiry timer of the peer starts counting
+	// down from the timeout value.  If the link is subsequently re-attached before
+	// the timeout is reached, the count down is aborted.
+	//
+	// Default: ExpirySessionEnd.
+	TargetExpiryPolicy ExpiryPolicy
+
+	// ExpiryTimeout is the duration in seconds that the peer will be retained.
+	//
+	// Default: 0.
+	TargetExpiryTimeout uint32
 }
 
 type ReceiverOptions struct {
@@ -157,6 +174,23 @@ type ReceiverOptions struct {
 
 	// TargetAddress specifies the target address for this receiver.
 	TargetAddress string
+
+	// SenderDurability indicates what state of the peer will be retained durably.
+	//
+	// Default: DurabilityNone.
+	SenderDurability Durability
+
+	// SenderExpiryPolicy determines when the expiry timer of the peer starts counting
+	// down from the timeout value.  If the link is subsequently re-attached before
+	// the timeout is reached, the count down is aborted.
+	//
+	// Default: ExpirySessionEnd.
+	SenderExpiryPolicy ExpiryPolicy
+
+	// SenderExpiryTimeout is the duration in seconds that the peer will be retained.
+	//
+	// Default: 0.
+	SenderExpiryTimeout uint32
 }
 
 // LinkFilter is an advanced API for setting non-standard source filters.

--- a/link_options.go
+++ b/link_options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SenderOptions struct {
-	// Capabilities is the list of extension capabilities the sender supports/desires.
+	// Capabilities is the list of extension capabilities the sender supports.
 	Capabilities []string
 
 	// Durability indicates what state of the sender will be retained durably.
@@ -64,6 +64,9 @@ type SenderOptions struct {
 	// SourceAddress specifies the source address for this sender.
 	SourceAddress string
 
+	// TargetCapabilities is the list of extension capabilities the sender desires.
+	TargetCapabilities []string
+
 	// TargetDurability indicates what state of the peer will be retained durably.
 	//
 	// Default: DurabilityNone.
@@ -100,7 +103,7 @@ type ReceiverOptions struct {
 	// Default: 5 seconds.
 	BatchMaxAge time.Duration
 
-	// Capabilities is the list of extension capabilities the receiver supports/desires.
+	// Capabilities is the list of extension capabilities the receiver supports.
 	Capabilities []string
 
 	// Credit specifies the maximum number of unacknowledged messages
@@ -174,6 +177,9 @@ type ReceiverOptions struct {
 
 	// TargetAddress specifies the target address for this receiver.
 	TargetAddress string
+
+	// SenderCapabilities is the list of extension capabilities the receiver desires.
+	SenderCapabilities []string
 
 	// SenderDurability indicates what state of the peer will be retained durably.
 	//

--- a/message.go
+++ b/message.go
@@ -32,7 +32,7 @@ type Message struct {
 	// The delivery-annotations section is used for delivery-specific non-standard
 	// properties at the head of the message. Delivery annotations convey information
 	// from the sending peer to the receiving peer.
-	DeliveryAnnotations encoding.Annotations
+	DeliveryAnnotations Annotations
 	// If the recipient does not understand the annotation it cannot be acted upon
 	// and its effects (such as any implied propagation) cannot be acted upon.
 	// Annotations might be specific to one implementation, or common to multiple
@@ -48,7 +48,7 @@ type Message struct {
 
 	// The message-annotations section is used for properties of the message which
 	// are aimed at the infrastructure.
-	Annotations encoding.Annotations
+	Annotations Annotations
 	// The message-annotations section is used for properties of the message which
 	// are aimed at the infrastructure and SHOULD be propagated across every
 	// delivery step. Message annotations convey information about the message.
@@ -97,7 +97,7 @@ type Message struct {
 	// can only be calculated or evaluated once the whole bare message has been
 	// constructed or seen (for example message hashes, HMACs, signatures and
 	// encryption details).
-	Footer encoding.Annotations
+	Footer Annotations
 
 	// Mark the message as settled when LinkSenderSettle is ModeMixed.
 	//
@@ -524,4 +524,5 @@ func (p *MessageProperties) Unmarshal(r *buffer.Buffer) error {
 // String keys are encoded as AMQP Symbols.
 type Annotations = encoding.Annotations
 
+// UUID is a 128 bit identifier as defined in RFC 4122.
 type UUID = encoding.UUID

--- a/receiver.go
+++ b/receiver.go
@@ -471,6 +471,15 @@ func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, e
 		l.l.receiverSettleMode = opts.SettlementMode
 	}
 	l.l.target.Address = opts.TargetAddress
+	if opts.SenderDurability != DurabilityNone {
+		l.l.source.Durable = opts.SenderDurability
+	}
+	if opts.SenderExpiryPolicy != ExpirySessionEnd {
+		l.l.source.ExpiryPolicy = opts.SenderExpiryPolicy
+	}
+	if opts.SenderExpiryTimeout != 0 {
+		l.l.source.Timeout = opts.SenderExpiryTimeout
+	}
 	return l, nil
 }
 

--- a/receiver.go
+++ b/receiver.go
@@ -471,6 +471,9 @@ func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, e
 		l.l.receiverSettleMode = opts.SettlementMode
 	}
 	l.l.target.Address = opts.TargetAddress
+	for _, v := range opts.SenderCapabilities {
+		l.l.source.Capabilities = append(l.l.source.Capabilities, encoding.Symbol(v))
+	}
 	if opts.SenderDurability != DurabilityNone {
 		l.l.source.Durable = opts.SenderDurability
 	}

--- a/receiver.go
+++ b/receiver.go
@@ -477,7 +477,7 @@ func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, e
 	if opts.SenderDurability != DurabilityNone {
 		l.l.source.Durable = opts.SenderDurability
 	}
-	if opts.SenderExpiryPolicy != ExpirySessionEnd {
+	if opts.SenderExpiryPolicy != ExpiryPolicySessionEnd {
 		l.l.source.ExpiryPolicy = opts.SenderExpiryPolicy
 	}
 	if opts.SenderExpiryTimeout != 0 {

--- a/sender.go
+++ b/sender.go
@@ -234,6 +234,15 @@ func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) 
 		l.l.senderSettleMode = opts.SettlementMode
 	}
 	l.l.source.Address = opts.SourceAddress
+	if opts.TargetDurability != DurabilityNone {
+		l.l.target.Durable = opts.TargetDurability
+	}
+	if opts.TargetExpiryPolicy != ExpirySessionEnd {
+		l.l.target.ExpiryPolicy = opts.TargetExpiryPolicy
+	}
+	if opts.TargetExpiryTimeout != 0 {
+		l.l.target.Timeout = opts.TargetExpiryTimeout
+	}
 	return l, nil
 }
 

--- a/sender.go
+++ b/sender.go
@@ -240,7 +240,7 @@ func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) 
 	if opts.TargetDurability != DurabilityNone {
 		l.l.target.Durable = opts.TargetDurability
 	}
-	if opts.TargetExpiryPolicy != ExpirySessionEnd {
+	if opts.TargetExpiryPolicy != ExpiryPolicySessionEnd {
 		l.l.target.ExpiryPolicy = opts.TargetExpiryPolicy
 	}
 	if opts.TargetExpiryTimeout != 0 {

--- a/sender.go
+++ b/sender.go
@@ -234,6 +234,9 @@ func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) 
 		l.l.senderSettleMode = opts.SettlementMode
 	}
 	l.l.source.Address = opts.SourceAddress
+	for _, v := range opts.TargetCapabilities {
+		l.l.target.Capabilities = append(l.l.target.Capabilities, encoding.Symbol(v))
+	}
 	if opts.TargetDurability != DurabilityNone {
 		l.l.target.Durable = opts.TargetDurability
 	}


### PR DESCRIPTION
Refactor from variadic config inadvertently removed this ability.  Added config options to sender and receiver for specifying peer durability.

Fixes https://github.com/Azure/go-amqp/issues/191