### PR TITLE
Fix test bug

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,7 @@ jobs:
 
       - script: |
           set -e
+          export TEST_CORPUS=1
           echo '##[command]Starting broker at $(AMQP_BROKER_ADDR)'
           $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net461/TestAmqpBroker.exe $AMQP_BROKER_ADDR /headless &
           brokerPID=$!

--- a/link_test.go
+++ b/link_test.go
@@ -128,16 +128,6 @@ func TestLinkFlowWithDrain(t *testing.T) {
 	errChan := make(chan error)
 
 	go func(errChan chan error) {
-		<-l.receiverReady
-
-		select {
-		case l.receiverReady <- struct{}{}:
-			// woke up mux
-		default:
-			errChan <- errors.New("failed to wake up mux")
-			return
-		}
-
 		// flow happens immmediately in 'mux'
 		txFrame := <-l.l.session.tx
 


### PR DESCRIPTION
Link refactoring introduced a regression in TestLinkFlowWithDrain. Removed reading from l.receiverReader as the mux reads it now.
Enable test corpus in CI.
