### PR TITLE
Rename link filter constructors per guidelines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   * `SenderSettleMode`, `ReceiverSettleMode`, `ExpiryPolicy`
 * Constant type `ErrorCondition` has been renamed to `ErrCond`.
   * The `ErrCond` values have had their names updated to include the `ErrCond` prefix.
+* `LinkFilterSource` and `LinkFilterSelector` have been renamed to `NewLinkFilter` and `NewSelectorLinkFilter` respectively.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   * `SenderSettleMode`, `ReceiverSettleMode`, `ExpiryPolicy`
 * Constant type `ErrorCondition` has been renamed to `ErrCond`.
   * The `ErrCond` values have had their names updated to include the `ErrCond` prefix.
-* `LinkFilterSource` and `LinkFilterSelector` have been renamed to `NewLinkFilter` and `NewSelectorLinkFilter` respectively.
+* `LinkFilterSource` and `LinkFilterSelector` have been renamed to `NewLinkFilter` and `NewSelectorFilter` respectively.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.

--- a/link_options.go
+++ b/link_options.go
@@ -229,8 +229,9 @@ type ReceiverOptions struct {
 //	http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-descriptor-values
 type LinkFilter func(encoding.Filter)
 
-// LinkFilterSource creates or updates the named filter for this LinkFilter.
-func LinkFilterSource(name string, code uint64, value any) LinkFilter {
+// NewLinkFilter creates a new LinkFilter with the specified values.
+// Any preexisting link filter with the same name will be updated with the new code and value.
+func NewLinkFilter(name string, code uint64, value any) LinkFilter {
 	return func(f encoding.Filter) {
 		var descriptor any
 		if code != 0 {
@@ -245,9 +246,10 @@ func LinkFilterSource(name string, code uint64, value any) LinkFilter {
 	}
 }
 
-// LinkFilterSelector creates or updates the selector filter (apache.org:selector-filter:string) for this LinkFilter.
-func LinkFilterSelector(filter string) LinkFilter {
-	return LinkFilterSource(selectorFilter, selectorFilterCode, filter)
+// NewSelectorLinkFilter creates a new selector filter (apache.org:selector-filter:string) with the specified filter value.
+// Any preexisting selector filter will be updated with the new filter value.
+func NewSelectorLinkFilter(filter string) LinkFilter {
+	return NewLinkFilter(selectorFilter, selectorFilterCode, filter)
 }
 
 const (

--- a/link_options.go
+++ b/link_options.go
@@ -246,9 +246,9 @@ func NewLinkFilter(name string, code uint64, value any) LinkFilter {
 	}
 }
 
-// NewSelectorLinkFilter creates a new selector filter (apache.org:selector-filter:string) with the specified filter value.
+// NewSelectorFilter creates a new selector filter (apache.org:selector-filter:string) with the specified filter value.
 // Any preexisting selector filter will be updated with the new filter value.
-func NewSelectorLinkFilter(filter string) LinkFilter {
+func NewSelectorFilter(filter string) LinkFilter {
 	return NewLinkFilter(selectorFilter, selectorFilterCode, filter)
 }
 

--- a/link_test.go
+++ b/link_test.go
@@ -345,7 +345,7 @@ func TestNewReceivingLink(t *testing.T) {
 				ExpiryPolicy:   ExpiryPolicyNever,
 				ExpiryTimeout:  3,
 				Filters: []LinkFilter{
-					NewSelectorLinkFilter("amqp.annotation.x-opt-offset > '100'"),
+					NewSelectorFilter("amqp.annotation.x-opt-offset > '100'"),
 					NewLinkFilter("com.microsoft:session-filter", 0x00000137000000C, "123"),
 				},
 				//ManualCredits:             true,

--- a/link_test.go
+++ b/link_test.go
@@ -345,8 +345,8 @@ func TestNewReceivingLink(t *testing.T) {
 				ExpiryPolicy:   ExpiryPolicyNever,
 				ExpiryTimeout:  3,
 				Filters: []LinkFilter{
-					LinkFilterSelector("amqp.annotation.x-opt-offset > '100'"),
-					LinkFilterSource("com.microsoft:session-filter", 0x00000137000000C, "123"),
+					NewSelectorLinkFilter("amqp.annotation.x-opt-offset > '100'"),
+					NewLinkFilter("com.microsoft:session-filter", 0x00000137000000C, "123"),
 				},
 				//ManualCredits:             true,
 				MaxMessageSize: 1024,

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -107,7 +107,7 @@ func TestReceiverLinkSourceFilter(t *testing.T) {
 	r, err := session.NewReceiver(ctx, "ignored", &ReceiverOptions{
 		DynamicAddress: true,
 		Filters: []LinkFilter{
-			LinkFilterSource(filterName, 0, filterExp),
+			NewLinkFilter(filterName, 0, filterExp),
 		},
 	})
 	cancel()


### PR DESCRIPTION
No functional/test changes.