### PR TITLE
Update Go version to 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `Ptr()` method to `SenderSettleMode` and `ReceiverSettleMode` types.
 
 ### Breaking Changes
+* The minimum version of Go required to build this module is now 1.18.
 * Removed `ErrConnClosed` and `ErrTimeout` sentinel error types.
 * The following methods now require a `context.Context` as their first parameter.
   * `Client.NewSession()`, `Session.NewReceiver()`, `Session.NewSender()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Thank you for your interest in contributing to go-amqp.
 
 To enable debug logging, build with `-tags debug`. This enables debug level 1 by default. You can increase the level by setting the `DEBUG_LEVEL` environment variable to 2 or higher. (Debug logging is disabled entirely without `-tags debug`, regardless of `DEBUG_LEVEL` setting.)
 
-To add additional logging, use the `debug(level int, format string, v ...interface{})` function, which is similar to `fmt.Printf` but takes a level as it's first argument.
+To add additional logging, use the `debug.Log(level int, format string, v ...any)` function, which is similar to `fmt.Printf` but takes a level as its first argument.
 
 ### Packet Capture
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This library aims to be stable and worthy of production usage, but the API is st
 
 ## Install
 
+NOTE: Go 1.18 or later is required to build this module.
+
 ```
-go get -u github.com/Azure/go-amqp
+go get github.com/Azure/go-amqp
 ```
 
 ## Contributing
@@ -37,92 +39,6 @@ For more information, see the
 [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
-
-## Example Usage
-
-``` go
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-	"time"
-
-	"github.com/Azure/go-amqp"
-)
-
-func main() {
-	// Create client
-	client, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net",
-		amqp.ConnSASLPlain("access-key-name", "access-key"),
-	)
-	if err != nil {
-		log.Fatal("Dialing AMQP server:", err)
-	}
-	defer client.Close()
-
-	// Open a session
-	session, err := client.NewSession()
-	if err != nil {
-		log.Fatal("Creating AMQP session:", err)
-	}
-
-	ctx := context.Background()
-
-	// Send a message
-	{
-		// Create a sender
-		sender, err := session.NewSender(
-			amqp.LinkTargetAddress("/queue-name"),
-		)
-		if err != nil {
-			log.Fatal("Creating sender link:", err)
-		}
-
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-
-		// Send message
-		err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
-		if err != nil {
-			log.Fatal("Sending message:", err)
-		}
-
-		sender.Close(ctx)
-		cancel()
-	}
-
-	// Continuously read messages
-	{
-		// Create a receiver
-		receiver, err := session.NewReceiver(
-			amqp.LinkSourceAddress("/queue-name"),
-			amqp.LinkCredit(10),
-		)
-		if err != nil {
-			log.Fatal("Creating receiver link:", err)
-		}
-		defer func() {
-			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-			receiver.Close(ctx)
-			cancel()
-		}()
-
-		for {
-			// Receive next message
-			msg, err := receiver.Receive(ctx)
-			if err != nil {
-				log.Fatal("Reading message from AMQP:", err)
-			}
-
-			// Accept message
-			msg.Accept(context.Background())
-
-			fmt.Printf("Message received: %s\n", msg.GetData())
-		}
-	}
-}
-```
 
 ## Related Projects
 

--- a/conn.go
+++ b/conn.go
@@ -60,7 +60,7 @@ type ConnOptions struct {
 	MaxSessions uint16
 
 	// Properties sets an entry in the connection properties map sent to the server.
-	Properties map[string]interface{}
+	Properties map[string]any
 
 	// SASLType contains the specified SASL authentication mechanism.
 	SASLType SASLType
@@ -109,12 +109,12 @@ type conn struct {
 	saslComplete bool                          // SASL negotiation complete; internal *except* for SASL auth methods
 
 	// local settings
-	maxFrameSize uint32                          // max frame size to accept
-	channelMax   uint16                          // maximum number of channels to allow
-	hostname     string                          // hostname of remote server (set explicitly or parsed from URL)
-	idleTimeout  time.Duration                   // maximum period between receiving frames
-	properties   map[encoding.Symbol]interface{} // additional properties sent upon connection open
-	containerID  string                          // set explicitly or randomly generated
+	maxFrameSize uint32                  // max frame size to accept
+	channelMax   uint16                  // maximum number of channels to allow
+	hostname     string                  // hostname of remote server (set explicitly or parsed from URL)
+	idleTimeout  time.Duration           // maximum period between receiving frames
+	properties   map[encoding.Symbol]any // additional properties sent upon connection open
+	containerID  string                  // set explicitly or randomly generated
 
 	// peer settings
 	peerIdleTimeout  time.Duration // maximum period between sending frames
@@ -266,7 +266,7 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*conn, error) {
 		c.connectTimeout = opts.Timeout
 	}
 	if opts.Properties != nil {
-		c.properties = make(map[encoding.Symbol]interface{})
+		c.properties = make(map[encoding.Symbol]any)
 		for key, val := range opts.Properties {
 			c.properties[encoding.Symbol(key)] = val
 		}

--- a/conn_test.go
+++ b/conn_test.go
@@ -29,13 +29,13 @@ func TestConnOptions(t *testing.T) {
 		{
 			label: "multiple properties",
 			opts: ConnOptions{
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					"x-opt-test1": "test3",
 					"x-opt-test2": "test2",
 				},
 			},
 			verify: func(t *testing.T, c *conn) {
-				wantProperties := map[encoding.Symbol]interface{}{
+				wantProperties := map[encoding.Symbol]any{
 					"x-opt-test1": "test3",
 					"x-opt-test2": "test2",
 				}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,7 +2,6 @@ package amqp
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -91,7 +90,7 @@ func fuzzConn(data []byte) int {
 }
 
 func fuzzUnmarshal(data []byte) int {
-	types := []interface{}{
+	types := []any{
 		new(frames.PerformAttach),
 		new(*frames.PerformAttach),
 		new(frames.PerformBegin),
@@ -511,7 +510,7 @@ func TestFuzzMarshalCrashers(t *testing.T) {
 }
 
 func testDirFiles(t *testing.T, dir string) []string {
-	finfos, err := ioutil.ReadDir(dir)
+	finfos, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +530,7 @@ func TestFuzzConnCorpus(t *testing.T) {
 
 	for _, path := range testDirFiles(t, "internal/encoding/testdata/fuzz/conn/corpus") {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -549,7 +548,7 @@ func TestFuzzMarshalCorpus(t *testing.T) {
 
 	for _, path := range testDirFiles(t, "internal/encoding/testdata/fuzz/marshal/corpus") {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module github.com/Azure/go-amqp
 
-go 1.13
+go 1.18
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -133,7 +133,7 @@ func TestIntegrationRoundTrip(t *testing.T) {
 						go func(index int, data string) {
 							defer func() { <-maxSendSemaphore }()
 							msg := amqp.NewMessage([]byte(data))
-							msg.ApplicationProperties = make(map[string]interface{})
+							msg.ApplicationProperties = make(map[string]any)
 							msg.ApplicationProperties["i"] = index
 							ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 							err := sender.Send(ctx, msg)

--- a/internal/bitmap/bitmap_test.go
+++ b/internal/bitmap/bitmap_test.go
@@ -17,7 +17,7 @@ func TestBitmap(t *testing.T) {
 
 	tests := []struct {
 		max uint32
-		ops []interface{}
+		ops []any
 
 		nextFail bool
 		next     uint32
@@ -25,7 +25,7 @@ func TestBitmap(t *testing.T) {
 	}{
 		{
 			max: 9,
-			ops: []interface{}{
+			ops: []any{
 				add(0), add(1), add(2), add(3), add(4), add(5), add(6), add(7), add(8), add(9),
 				rem(3), rem(7),
 			},
@@ -41,7 +41,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: math.MaxUint32,
-			ops: []interface{}{
+			ops: []any{
 				add(13000),
 			},
 
@@ -50,7 +50,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: math.MaxUint32,
-			ops: []interface{}{
+			ops: []any{
 				next(64),
 			},
 
@@ -59,7 +59,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: math.MaxUint32,
-			ops: []interface{}{
+			ops: []any{
 				next(65535),
 			},
 
@@ -68,7 +68,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: math.MaxUint32,
-			ops: []interface{}{
+			ops: []any{
 				next(300),
 				rem(32), rem(78), rem(13),
 				next(1),
@@ -79,7 +79,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: 63,
-			ops: []interface{}{
+			ops: []any{
 				next(64),
 			},
 
@@ -88,7 +88,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: 31,
-			ops: []interface{}{
+			ops: []any{
 				next(32),
 			},
 
@@ -97,7 +97,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: 31,
-			ops: []interface{}{
+			ops: []any{
 				add(32),
 			},
 
@@ -106,7 +106,7 @@ func TestBitmap(t *testing.T) {
 		},
 		{
 			max: 63,
-			ops: []interface{}{
+			ops: []any{
 				next(64),
 				rem(64),
 			},

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -8,10 +8,10 @@ package debug
 // Log writes the formatted string to stderr.
 // Level indicates the verbosity of the messages to log.
 // The greater the value, the more verbose messages will be logged.
-func Log(_ int, _ string, _ ...interface{}) {}
+func Log(_ int, _ string, _ ...any) {}
 
 // Assert panics if the specified condition is false.
 func Assert(bool) {}
 
 // Assert panics with the provided message if the specified condition is false.
-func Assertf(bool, string, ...interface{}) {}
+func Assertf(bool, string, ...any) {}

--- a/internal/debug/debug_debug.go
+++ b/internal/debug/debug_debug.go
@@ -27,7 +27,7 @@ func init() {
 // Log writes the formatted string to stderr.
 // Level indicates the verbosity of the messages to log.
 // The greater the value, the more verbose messages will be logged.
-func Log(level int, format string, v ...interface{}) {
+func Log(level int, format string, v ...any) {
 	if level <= debugLevel {
 		logger.Printf(format, v...)
 	}
@@ -41,7 +41,7 @@ func Assert(condition bool) {
 }
 
 // Assert panics with the provided message if the specified condition is false.
-func Assertf(condition bool, msg string, v ...interface{}) {
+func Assertf(condition bool, msg string, v ...any) {
 	if !condition {
 		panic(fmt.Sprintf(msg, v...))
 	}

--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -30,10 +30,10 @@ type unmarshaler interface {
 // If i is a pointer to a pointer (**Type), it will be dereferenced and a new instance
 // of (*Type) is allocated via reflection.
 //
-// Common map types (map[string]string, map[Symbol]interface{}, and
-// map[interface{}]interface{}), will be decoded via conversion to the mapStringAny,
+// Common map types (map[string]string, map[Symbol]any, and
+// map[any]any), will be decoded via conversion to the mapStringAny,
 // mapSymbolAny, and mapAnyAny types.
-func Unmarshal(r *buffer.Buffer, i interface{}) error {
+func Unmarshal(r *buffer.Buffer, i any) error {
 	if tryReadNull(r) {
 		return nil
 	}
@@ -171,13 +171,13 @@ func Unmarshal(r *buffer.Buffer, i interface{}) error {
 		return (*arrayTimestamp)(t).Unmarshal(r)
 	case *[]UUID:
 		return (*arrayUUID)(t).Unmarshal(r)
-	case *[]interface{}:
+	case *[]any:
 		return (*list)(t).Unmarshal(r)
-	case *map[interface{}]interface{}:
+	case *map[any]any:
 		return (*mapAnyAny)(t).Unmarshal(r)
-	case *map[string]interface{}:
+	case *map[string]any:
 		return (*mapStringAny)(t).Unmarshal(r)
-	case *map[Symbol]interface{}:
+	case *map[Symbol]any:
 		return (*mapSymbolAny)(t).Unmarshal(r)
 	case *DeliveryState:
 		type_, _, err := PeekMessageType(r.Bytes())
@@ -201,7 +201,7 @@ func Unmarshal(r *buffer.Buffer, i interface{}) error {
 		}
 		return Unmarshal(r, *t)
 
-	case *interface{}:
+	case *any:
 		v, err := ReadAny(r)
 		if err != nil {
 			return err
@@ -288,7 +288,7 @@ func UnmarshalComposite(r *buffer.Buffer, type_ AMQPType, fields ...UnmarshalFie
 // An optional nullHandler can be set. If the composite field being unmarshaled
 // is null and handleNull is not nil, nullHandler will be called.
 type UnmarshalField struct {
-	Field      interface{}
+	Field      any
 	HandleNull NullHandler
 }
 
@@ -479,7 +479,7 @@ func readBinary(r *buffer.Buffer) ([]byte, error) {
 	return append([]byte(nil), buf...), nil
 }
 
-func ReadAny(r *buffer.Buffer) (interface{}, error) {
+func ReadAny(r *buffer.Buffer) (any, error) {
 	if tryReadNull(r) {
 		return nil, nil
 	}
@@ -580,8 +580,8 @@ func ReadAny(r *buffer.Buffer) (interface{}, error) {
 	}
 }
 
-func readAnyMap(r *buffer.Buffer) (interface{}, error) {
-	var m map[interface{}]interface{}
+func readAnyMap(r *buffer.Buffer) (any, error) {
+	var m map[any]any
 	err := (*mapAnyAny)(&m).Unmarshal(r)
 	if err != nil {
 		return nil, err
@@ -604,7 +604,7 @@ Loop:
 	}
 
 	if stringKeys {
-		mm := make(map[string]interface{}, len(m))
+		mm := make(map[string]any, len(m))
 		for key, value := range m {
 			switch key := key.(type) {
 			case string:
@@ -619,13 +619,13 @@ Loop:
 	return m, nil
 }
 
-func readAnyList(r *buffer.Buffer) (interface{}, error) {
-	var a []interface{}
+func readAnyList(r *buffer.Buffer) (any, error) {
+	var a []any
 	err := (*list)(&a).Unmarshal(r)
 	return a, err
 }
 
-func readAnyArray(r *buffer.Buffer) (interface{}, error) {
+func readAnyArray(r *buffer.Buffer) (any, error) {
 	// get the array type
 	buf := r.Bytes()
 	if len(buf) < 1 {
@@ -715,7 +715,7 @@ func readAnyArray(r *buffer.Buffer) (interface{}, error) {
 	}
 }
 
-func readComposite(r *buffer.Buffer) (interface{}, error) {
+func readComposite(r *buffer.Buffer) (any, error) {
 	buf := r.Bytes()
 
 	if len(buf) < 2 {

--- a/internal/encoding/encode.go
+++ b/internal/encoding/encode.go
@@ -15,7 +15,7 @@ type marshaler interface {
 	Marshal(*buffer.Buffer) error
 }
 
-func Marshal(wr *buffer.Buffer, i interface{}) error {
+func Marshal(wr *buffer.Buffer, i any) error {
 	switch t := i.(type) {
 	case nil:
 		wr.AppendByte(byte(TypeCodeNull))
@@ -103,17 +103,17 @@ func Marshal(wr *buffer.Buffer, i interface{}) error {
 		return WriteBinary(wr, t)
 	case *[]byte:
 		return WriteBinary(wr, *t)
-	case map[interface{}]interface{}:
+	case map[any]any:
 		return writeMap(wr, t)
-	case *map[interface{}]interface{}:
+	case *map[any]any:
 		return writeMap(wr, *t)
-	case map[string]interface{}:
+	case map[string]any:
 		return writeMap(wr, t)
-	case *map[string]interface{}:
+	case *map[string]any:
 		return writeMap(wr, *t)
-	case map[Symbol]interface{}:
+	case map[Symbol]any:
 		return writeMap(wr, t)
-	case *map[Symbol]interface{}:
+	case *map[Symbol]any:
 		return writeMap(wr, *t)
 	case Unsettled:
 		return writeMap(wr, t)
@@ -183,9 +183,9 @@ func Marshal(wr *buffer.Buffer, i interface{}) error {
 		return arrayUUID(t).Marshal(wr)
 	case *[]UUID:
 		return arrayUUID(*t).Marshal(wr)
-	case []interface{}:
+	case []any:
 		return list(t).Marshal(wr)
-	case *[]interface{}:
+	case *[]any:
 		return list(*t).Marshal(wr)
 	case marshaler:
 		return t.Marshal(wr)
@@ -275,8 +275,8 @@ func writeTimestamp(wr *buffer.Buffer, t time.Time) {
 
 // marshalField is a field to be marshaled
 type MarshalField struct {
-	Value interface{} // value to be marshaled, use pointers to avoid interface conversion overhead
-	Omit  bool        // indicates that this field should be omitted (set to null)
+	Value any  // value to be marshaled, use pointers to avoid interface conversion overhead
+	Omit  bool // indicates that this field should be omitted (set to null)
 }
 
 // marshalComposite is a helper for us in a composite's marshal() function.
@@ -404,7 +404,7 @@ func WriteBinary(wr *buffer.Buffer, bin []byte) error {
 	}
 }
 
-func writeMap(wr *buffer.Buffer, m interface{}) error {
+func writeMap(wr *buffer.Buffer, m any) error {
 	startIdx := wr.Len()
 	wr.Append([]byte{
 		byte(TypeCodeMap32), // type
@@ -414,7 +414,7 @@ func writeMap(wr *buffer.Buffer, m interface{}) error {
 
 	var pairs int
 	switch m := m.(type) {
-	case map[interface{}]interface{}:
+	case map[any]any:
 		pairs = len(m) * 2
 		for key, val := range m {
 			err := Marshal(wr, key)
@@ -426,7 +426,7 @@ func writeMap(wr *buffer.Buffer, m interface{}) error {
 				return err
 			}
 		}
-	case map[string]interface{}:
+	case map[string]any:
 		pairs = len(m) * 2
 		for key, val := range m {
 			err := writeString(wr, key)
@@ -438,7 +438,7 @@ func writeMap(wr *buffer.Buffer, m interface{}) error {
 				return err
 			}
 		}
-	case map[Symbol]interface{}:
+	case map[Symbol]any:
 		pairs = len(m) * 2
 		for key, val := range m {
 			err := key.Marshal(wr)

--- a/internal/encoding/fuzz_test.go
+++ b/internal/encoding/fuzz_test.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,7 +11,7 @@ import (
 )
 
 func fuzzUnmarshal(data []byte) int {
-	types := []interface{}{
+	types := []any{
 		new(Error),
 		new(*Error),
 		new(StateReceived),
@@ -65,14 +64,14 @@ func fuzzUnmarshal(data []byte) int {
 		new(*[]string),
 		new([]Symbol),
 		new(*[]Symbol),
-		new(map[interface{}]interface{}),
-		new(*map[interface{}]interface{}),
-		new(map[string]interface{}),
-		new(*map[string]interface{}),
-		new(map[Symbol]interface{}),
-		new(*map[Symbol]interface{}),
-		new(interface{}),
-		new(*interface{}),
+		new(map[any]any),
+		new(*map[any]any),
+		new(map[string]any),
+		new(*map[string]any),
+		new(map[Symbol]any),
+		new(*map[Symbol]any),
+		new(any),
+		new(*any),
 		new(ErrorCondition),
 		new(*ErrorCondition),
 		new(UUID),
@@ -128,7 +127,7 @@ func TestFuzzMarshalCrashers(t *testing.T) {
 }
 
 func testDirFiles(t *testing.T, dir string) []string {
-	finfos, err := ioutil.ReadDir(dir)
+	finfos, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +147,7 @@ func TestFuzzMarshalCorpus(t *testing.T) {
 
 	for _, path := range testDirFiles(t, "testdata/fuzz/marshal/corpus") {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/encoding/types.go
+++ b/internal/encoding/types.go
@@ -463,7 +463,7 @@ func tryReadNull(r *buffer.Buffer) bool {
 // Annotations keys must be of type string, int, or int64.
 //
 // String keys are encoded as AMQP Symbols.
-type Annotations map[interface{}]interface{}
+type Annotations map[any]any
 
 func (a Annotations) Marshal(wr *buffer.Buffer) error {
 	return writeMap(wr, a)
@@ -525,7 +525,7 @@ type Error struct {
 	Description string
 
 	// map carrying information about the error condition
-	Info map[string]interface{}
+	Info map[string]any
 }
 
 func (e *Error) Marshal(wr *buffer.Buffer) error {
@@ -775,10 +775,10 @@ func (m *Milliseconds) Unmarshal(r *buffer.Buffer) error {
 
 // mapAnyAny is used to decode AMQP maps who's keys are undefined or
 // inconsistently typed.
-type mapAnyAny map[interface{}]interface{}
+type mapAnyAny map[any]any
 
 func (m mapAnyAny) Marshal(wr *buffer.Buffer) error {
-	return writeMap(wr, map[interface{}]interface{}(m))
+	return writeMap(wr, map[any]any(m))
 }
 
 func (m *mapAnyAny) Unmarshal(r *buffer.Buffer) error {
@@ -814,10 +814,10 @@ func (m *mapAnyAny) Unmarshal(r *buffer.Buffer) error {
 }
 
 // mapStringAny is used to decode AMQP maps that have string keys
-type mapStringAny map[string]interface{}
+type mapStringAny map[string]any
 
 func (m mapStringAny) Marshal(wr *buffer.Buffer) error {
-	return writeMap(wr, map[string]interface{}(m))
+	return writeMap(wr, map[string]any(m))
 }
 
 func (m *mapStringAny) Unmarshal(r *buffer.Buffer) error {
@@ -844,10 +844,10 @@ func (m *mapStringAny) Unmarshal(r *buffer.Buffer) error {
 }
 
 // mapStringAny is used to decode AMQP maps that have Symbol keys
-type mapSymbolAny map[Symbol]interface{}
+type mapSymbolAny map[Symbol]any
 
 func (m mapSymbolAny) Marshal(wr *buffer.Buffer) error {
-	return writeMap(wr, map[Symbol]interface{}(m))
+	return writeMap(wr, map[Symbol]any(m))
 }
 
 func (m *mapSymbolAny) Unmarshal(r *buffer.Buffer) error {
@@ -934,8 +934,8 @@ func (p *LifetimePolicy) Unmarshal(r *buffer.Buffer) error {
 }
 
 type DescribedType struct {
-	Descriptor interface{}
-	Value      interface{}
+	Descriptor any
+	Value      any
 }
 
 func (t DescribedType) Marshal(wr *buffer.Buffer) error {
@@ -2064,7 +2064,7 @@ func (a *arrayUUID) Unmarshal(r *buffer.Buffer) error {
 
 // LIST
 
-type list []interface{}
+type list []any
 
 func (l list) Marshal(wr *buffer.Buffer) error {
 	length := len(l)
@@ -2109,7 +2109,7 @@ func (l *list) Unmarshal(r *buffer.Buffer) error {
 
 	ll := *l
 	if int64(cap(ll)) < length {
-		ll = make([]interface{}, length)
+		ll = make([]any, length)
 	} else {
 		ll = ll[:length]
 	}

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -110,7 +110,7 @@ type Source struct {
 	//					distribution-modes. That is, the value MUST be of the same type as
 	//					would be valid in a field defined with the following attributes:
 	//						type="symbol" multiple="true" requires="distribution-mode"
-	DynamicNodeProperties map[encoding.Symbol]interface{} // TODO: implement custom type with validation
+	DynamicNodeProperties map[encoding.Symbol]any // TODO: implement custom type with validation
 
 	// the distribution mode of the link
 	//
@@ -132,7 +132,7 @@ type Source struct {
 	// Indicates the outcome to be used for transfers that have not reached a terminal
 	// state at the receiver when the transfer is settled, including when the source
 	// is destroyed. The value MUST be a valid outcome (e.g., released or rejected).
-	DefaultOutcome interface{}
+	DefaultOutcome any
 
 	// descriptors for the outcomes that can be chosen on this link
 	//
@@ -292,7 +292,7 @@ type Target struct {
 	//					distribution-modes. That is, the value MUST be of the same type as
 	//					would be valid in a field defined with the following attributes:
 	//						type="symbol" multiple="true" requires="distribution-mode"
-	DynamicNodeProperties map[encoding.Symbol]interface{} // TODO: implement custom type with validation
+	DynamicNodeProperties map[encoding.Symbol]any // TODO: implement custom type with validation
 
 	// the extension capabilities the sender supports/desires
 	//
@@ -378,7 +378,7 @@ type PerformOpen struct {
 	IncomingLocales     encoding.MultiSymbol
 	OfferedCapabilities encoding.MultiSymbol
 	DesiredCapabilities encoding.MultiSymbol
-	Properties          map[encoding.Symbol]interface{}
+	Properties          map[encoding.Symbol]any
 }
 
 func (o *PerformOpen) frameBody() {}
@@ -482,7 +482,7 @@ type PerformBegin struct {
 
 	// session properties
 	// http://www.amqp.org/specification/1.0/session-properties
-	Properties map[encoding.Symbol]interface{}
+	Properties map[encoding.Symbol]any
 }
 
 func (b *PerformBegin) frameBody() {}
@@ -684,7 +684,7 @@ type PerformAttach struct {
 
 	// link properties
 	// http://www.amqp.org/specification/1.0/link-properties
-	Properties map[encoding.Symbol]interface{}
+	Properties map[encoding.Symbol]any
 }
 
 func (a *PerformAttach) frameBody() {}
@@ -862,7 +862,7 @@ type PerformFlow struct {
 
 	// link state properties
 	// http://www.amqp.org/specification/1.0/link-state-properties
-	Properties map[encoding.Symbol]interface{}
+	Properties map[encoding.Symbol]any
 }
 
 func (f *PerformFlow) frameBody() {}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func Equal(x, y interface{}) bool {
+func Equal(x, y any) bool {
 	return cmp.Equal(x, y, compareOpts(x, y)...)
 }
 
-func Diff(x, y interface{}) string {
+func Diff(x, y any) string {
 	return cmp.Diff(x, y, compareOpts(x, y)...)
 }
 
-func compareOpts(x, y interface{}) []cmp.Option {
+func compareOpts(x, y any) []cmp.Option {
 	return cmp.Options{
 		deepAllowUnexported(x, y),
 		cmpopts.EquateNaNs(),
@@ -23,12 +23,12 @@ func compareOpts(x, y interface{}) []cmp.Option {
 }
 
 // from https://github.com/google/go-cmp/issues/40
-func deepAllowUnexported(vs ...interface{}) cmp.Option {
+func deepAllowUnexported(vs ...any) cmp.Option {
 	m := make(map[reflect.Type]struct{})
 	for _, v := range vs {
 		structTypes(reflect.ValueOf(v), m)
 	}
-	var types []interface{}
+	var types []any
 	for t := range m {
 		types = append(types, reflect.New(t).Elem().Interface())
 	}

--- a/link.go
+++ b/link.go
@@ -30,12 +30,12 @@ type link struct {
 	// This will be initiated if the service sends back an error or requests the link detach.
 	detached chan struct{}
 
-	detachErrorMu sync.Mutex                      // protects detachError
-	detachError   *Error                          // error to send to remote on detach, set by closeWithError
-	session       *Session                        // parent session
-	source        *frames.Source                  // used for Receiver links
-	target        *frames.Target                  // used for Sender links
-	properties    map[encoding.Symbol]interface{} // additional properties sent upon link attach
+	detachErrorMu sync.Mutex              // protects detachError
+	detachError   *Error                  // error to send to remote on detach, set by closeWithError
+	session       *Session                // parent session
+	source        *frames.Source          // used for Receiver links
+	target        *frames.Target          // used for Sender links
+	properties    map[encoding.Symbol]any // additional properties sent upon link attach
 
 	// "The delivery-count is initialized by the sender when a link endpoint is created,
 	// and is incremented whenever a message is sent. Only the sender MAY independently

--- a/link_options.go
+++ b/link_options.go
@@ -46,7 +46,7 @@ type SenderOptions struct {
 	Name string
 
 	// Properties sets an entry in the link properties map sent to the server.
-	Properties map[string]interface{}
+	Properties map[string]any
 
 	// RequestedReceiverSettleMode sets the requested receiver settlement mode.
 	//
@@ -140,7 +140,7 @@ type ReceiverOptions struct {
 	Name string
 
 	// Properties sets an entry in the link properties map sent to the server.
-	Properties map[string]interface{}
+	Properties map[string]any
 
 	// RequestedSenderSettleMode sets the requested sender settlement mode.
 	//
@@ -190,9 +190,9 @@ type ReceiverOptions struct {
 type LinkFilter func(encoding.Filter)
 
 // LinkFilterSource creates or updates the named filter for this LinkFilter.
-func LinkFilterSource(name string, code uint64, value interface{}) LinkFilter {
+func LinkFilterSource(name string, code uint64, value any) LinkFilter {
 	return func(f encoding.Filter) {
-		var descriptor interface{}
+		var descriptor any
 		if code != 0 {
 			descriptor = code
 		} else {

--- a/link_test.go
+++ b/link_test.go
@@ -259,7 +259,7 @@ func TestNewSendingLink(t *testing.T) {
 				ExpiryTimeout:           5,
 				IgnoreDispositionErrors: true,
 				Name:                    name,
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					"property": 123,
 				},
 				RequestedReceiverSettleMode: ModeFirst.Ptr(),
@@ -273,7 +273,7 @@ func TestNewSendingLink(t *testing.T) {
 				require.Equal(t, uint32(5), l.l.source.Timeout)
 				require.False(t, l.detachOnDispositionError)
 				require.Equal(t, name, l.l.key.name)
-				require.Equal(t, map[encoding.Symbol]interface{}{
+				require.Equal(t, map[encoding.Symbol]any{
 					"property": 123,
 				}, l.l.properties)
 				require.NotNil(t, l.l.senderSettleMode)
@@ -310,7 +310,7 @@ func TestNewReceivingLink(t *testing.T) {
 
 		wantSource     *frames.Source
 		wantTarget     *frames.Target
-		wantProperties map[encoding.Symbol]interface{}
+		wantProperties map[encoding.Symbol]any
 	}{
 		{
 			label: "default options",
@@ -351,7 +351,7 @@ func TestNewReceivingLink(t *testing.T) {
 				//ManualCredits:             true,
 				MaxMessageSize: 1024,
 				Name:           name,
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					"property": 123,
 				},
 				RequestedSenderSettleMode: ModeMixed.Ptr(),
@@ -379,7 +379,7 @@ func TestNewReceivingLink(t *testing.T) {
 				//require.NotNil(t, l.receiver.manualCreditor)
 				require.Equal(t, uint64(1024), l.l.maxMessageSize)
 				require.Equal(t, name, l.l.key.name)
-				require.Equal(t, map[encoding.Symbol]interface{}{
+				require.Equal(t, map[encoding.Symbol]any{
 					"property": 123,
 				}, l.l.properties)
 				require.NotNil(t, l.l.senderSettleMode)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -187,7 +186,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 				name = strings.TrimPrefix(name, "amqp.")
 				name = strings.TrimPrefix(name, "*amqp.")
 				path := filepath.Join("fuzz/marshal/corpus", name)
-				err = ioutil.WriteFile(path, buf.Bytes(), 0644)
+				err = os.WriteFile(path, buf.Bytes(), 0644)
 				if err != nil {
 					t.Error(err)
 				}
@@ -264,7 +263,7 @@ var (
 
 	remoteChannel = uint16(4321)
 
-	protoTypes = []interface{}{
+	protoTypes = []any{
 		&frames.PerformOpen{
 			ContainerID:         "foo",
 			Hostname:            "bar.host",
@@ -274,7 +273,7 @@ var (
 			IncomingLocales:     []encoding.Symbol{"barLocale"},
 			OfferedCapabilities: []encoding.Symbol{"fooCap"},
 			DesiredCapabilities: []encoding.Symbol{"barCap"},
-			Properties: map[encoding.Symbol]interface{}{
+			Properties: map[encoding.Symbol]any{
 				"fooProp": int32(45),
 			},
 		},
@@ -286,7 +285,7 @@ var (
 			HandleMax:           9757,
 			OfferedCapabilities: []encoding.Symbol{"fooCap"},
 			DesiredCapabilities: []encoding.Symbol{"barCap"},
-			Properties: map[encoding.Symbol]interface{}{
+			Properties: map[encoding.Symbol]any{
 				"fooProp": int32(45),
 			},
 		},
@@ -302,7 +301,7 @@ var (
 				ExpiryPolicy: ExpiryLinkDetach,
 				Timeout:      635,
 				Dynamic:      true,
-				DynamicNodeProperties: map[encoding.Symbol]interface{}{
+				DynamicNodeProperties: map[encoding.Symbol]any{
 					"lifetime-policy": encoding.DeleteOnClose,
 				},
 				DistributionMode: "some-mode",
@@ -321,7 +320,7 @@ var (
 				ExpiryPolicy: ExpiryLinkDetach,
 				Timeout:      635,
 				Dynamic:      true,
-				DynamicNodeProperties: map[encoding.Symbol]interface{}{
+				DynamicNodeProperties: map[encoding.Symbol]any{
 					"lifetime-policy": encoding.DeleteOnClose,
 				},
 				Capabilities: []encoding.Symbol{"barCap"},
@@ -334,7 +333,7 @@ var (
 			MaxMessageSize:       75983,
 			OfferedCapabilities:  []encoding.Symbol{"fooCap"},
 			DesiredCapabilities:  []encoding.Symbol{"barCap"},
-			Properties: map[encoding.Symbol]interface{}{
+			Properties: map[encoding.Symbol]any{
 				"fooProp": int32(45),
 			},
 		},
@@ -348,7 +347,7 @@ var (
 			ExpiryPolicy: ExpiryLinkDetach,
 			Timeout:      635,
 			Dynamic:      true,
-			DynamicNodeProperties: map[encoding.Symbol]interface{}{
+			DynamicNodeProperties: map[encoding.Symbol]any{
 				"lifetime-policy": encoding.DeleteOnClose,
 			},
 			DistributionMode: "some-mode",
@@ -367,7 +366,7 @@ var (
 			ExpiryPolicy: ExpiryLinkDetach,
 			Timeout:      635,
 			Dynamic:      true,
-			DynamicNodeProperties: map[encoding.Symbol]interface{}{
+			DynamicNodeProperties: map[encoding.Symbol]any{
 				"lifetime-policy": encoding.DeleteOnClose,
 			},
 			Capabilities: []encoding.Symbol{"barCap"},
@@ -383,7 +382,7 @@ var (
 			Available:      uint32Ptr(878321),
 			Drain:          true,
 			Echo:           true,
-			Properties: map[encoding.Symbol]interface{}{
+			Properties: map[encoding.Symbol]any{
 				"fooProp": int32(45),
 			},
 		},
@@ -415,7 +414,7 @@ var (
 			Error: &Error{
 				Condition:   ErrorNotAllowed,
 				Description: "foo description",
-				Info: map[string]interface{}{
+				Info: map[string]any{
 					"other": "info",
 					"and":   uint16(875),
 				},
@@ -428,7 +427,7 @@ var (
 				Condition:   ErrorLinkRedirect,
 				Description: "",
 				// payload is bigger than map8 encoding size
-				Info: map[string]interface{}{
+				Info: map[string]any{
 					"hostname":     "redirected.myservicebus.example.org",
 					"network-host": "redirected.myservicebus.example.org",
 					"port":         uint32(5671),
@@ -440,7 +439,7 @@ var (
 		&Error{
 			Condition:   ErrorNotAllowed,
 			Description: "foo description",
-			Info: map[string]interface{}{
+			Info: map[string]any{
 				"other": "info",
 				"and":   uint16(875),
 			},
@@ -449,7 +448,7 @@ var (
 			Error: &Error{
 				Condition:   ErrorNotAllowed,
 				Description: "foo description",
-				Info: map[string]interface{}{
+				Info: map[string]any{
 					"other": "info",
 					"and":   uint16(875),
 				},
@@ -459,7 +458,7 @@ var (
 			Error: &Error{
 				Condition:   ErrorNotAllowed,
 				Description: "foo description",
-				Info: map[string]interface{}{
+				Info: map[string]any{
 					"other": "info",
 					"and":   uint16(875),
 				},
@@ -494,7 +493,7 @@ var (
 				GroupSequence:      uint32Ptr(89324),
 				ReplyToGroupID:     stringPtr("barGroup"),
 			},
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"baz": "foo",
 			},
 			Data: [][]byte{
@@ -535,7 +534,7 @@ var (
 				GroupSequence:      nil,
 				ReplyToGroupID:     nil,
 			},
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"baz": "foo",
 			},
 			Data: [][]byte{
@@ -578,7 +577,7 @@ var (
 			Error: &Error{
 				Condition:   ErrorStolen,
 				Description: "foo description",
-				Info: map[string]interface{}{
+				Info: map[string]any{
 					"other": "info",
 					"and":   int32(uint16(875)),
 				},
@@ -615,12 +614,12 @@ var (
 		},
 		encoding.Milliseconds(10 * time.Second),
 		encoding.Symbol("a symbol"),
-		map[encoding.Symbol]interface{}{
+		map[encoding.Symbol]any{
 			"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
 		},
 	}
 
-	generalTypes = []interface{}{
+	generalTypes = []any{
 		nil,
 		encoding.UUID{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16},
 		bool(true),
@@ -648,10 +647,10 @@ var (
 			Descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x46, 0x8C, 0x00, 0x00, 0x00, 0x04}),
 			Value:      "amqp.annotation.x-opt-offset > '312'",
 		},
-		map[interface{}]interface{}{
+		map[any]any{
 			int32(-1234): []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
 		},
 		encoding.ArrayUByte{1, 2, 3, math.MaxUint8, 0},
@@ -679,7 +678,7 @@ var (
 			{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31},
 		},
-		[]interface{}{int16(1), "hello", false},
+		[]any{int16(1), "hello", false},
 	}
 )
 

--- a/message.go
+++ b/message.go
@@ -76,7 +76,7 @@ type Message struct {
 	// The application-properties section is a part of the bare message used for
 	// structured application data. Intermediaries can use the data within this
 	// structure for the purposes of filtering or routing.
-	ApplicationProperties map[string]interface{}
+	ApplicationProperties map[string]any
 	// The keys of this map are restricted to be of type string (which excludes
 	// the possibility of a null key) and the values are restricted to be of
 	// simple types only, that is, excluding map, list, and array types.
@@ -87,11 +87,11 @@ type Message struct {
 
 	// Value payload.
 	// An amqp-value section contains a single AMQP value.
-	Value interface{}
+	Value any
 
 	// Sequence will contain AMQP sequence sections from the body of the message.
 	// An amqp-sequence section contains an AMQP sequence.
-	Sequence [][]interface{}
+	Sequence [][]any
 
 	// The footer section is used for details about the message or delivery which
 	// can only be calculated or evaluated once the whole bare message has been
@@ -242,7 +242,7 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 		}
 
 		var (
-			section interface{}
+			section any
 			// section header is read from r before
 			// unmarshaling section is set to true
 			discardHeader = true
@@ -281,7 +281,7 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 		case encoding.TypeCodeAMQPSequence:
 			r.Skip(int(headerLength))
 
-			var data []interface{}
+			var data []any
 			err = encoding.Unmarshal(r, &data)
 			if err != nil {
 				return err
@@ -365,7 +365,7 @@ type (
 	// - amqp.UUID: <type name="message-id-uuid" class="restricted" source="uuid" provides="message-id"/>
 	// - []byte:    <type name="message-id-binary" class="restricted" source="binary" provides="message-id"/>
 	// - string:    <type name="message-id-string" class="restricted" source="string" provides="message-id"/>
-	MessageID = interface{}
+	MessageID = any
 
 	// AMQPSymbol corresponds to the 'symbol' type in the AMQP spec.
 	// <type name="symbol" class="primitive"/>

--- a/message_test.go
+++ b/message_test.go
@@ -28,7 +28,7 @@ var exampleEncodedMessages = []struct {
 				MessageID: "7735812932138480283/1/12",
 				To:        &helperTo,
 			},
-			ApplicationProperties: map[string]interface{}{
+			ApplicationProperties: map[string]any{
 				"prop002":       "v2",
 				"prop000000003": int64(100000),
 				"prop4":         "val000004",
@@ -63,7 +63,7 @@ func TestMessageUnmarshaling(t *testing.T) {
 
 func TestMessageWithSequence(t *testing.T) {
 	m := &Message{
-		Sequence: [][]interface{}{
+		Sequence: [][]any{
 			{"hello1", "world1", 11, 12, 13},
 			{"hello2", "world2", 21, 22, 23},
 		},
@@ -76,7 +76,7 @@ func TestMessageWithSequence(t *testing.T) {
 	err = newM.UnmarshalBinary(bytes)
 	require.NoError(t, err)
 
-	require.EqualValues(t, [][]interface{}{
+	require.EqualValues(t, [][]any{
 		{"hello1", "world1", int64(11), int64(12), int64(13)},
 		{"hello2", "world2", int64(21), int64(22), int64(23)},
 	}, newM.Sequence)

--- a/receiver.go
+++ b/receiver.go
@@ -201,7 +201,7 @@ func (r *Receiver) LinkName() string {
 }
 
 // LinkSourceFilterValue retrieves the specified link source filter value or nil if it doesn't exist.
-func (r *Receiver) LinkSourceFilterValue(name string) interface{} {
+func (r *Receiver) LinkSourceFilterValue(name string) any {
 	if r.l.source == nil {
 		return nil
 	}
@@ -450,7 +450,7 @@ func newReceiver(source string, s *Session, opts *ReceiverOptions) (*Receiver, e
 		l.l.key.name = opts.Name
 	}
 	if opts.Properties != nil {
-		l.l.properties = make(map[encoding.Symbol]interface{})
+		l.l.properties = make(map[encoding.Symbol]any)
 		for k, v := range opts.Properties {
 			if k == "" {
 				return nil, errors.New("link property key must not be empty")

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -812,7 +812,7 @@ func TestReceiverPrefetch(t *testing.T) {
 	require.Nil(t, msg)
 
 	messagesCh <- Message{
-		ApplicationProperties: map[string]interface{}{
+		ApplicationProperties: map[string]any{
 			"prop": "hello",
 		},
 		settled: true,

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -265,7 +265,7 @@ func TestConnSASLExternal(t *testing.T) {
 	defer client.Close()
 }
 
-func peerResponse(items ...interface{}) ([]byte, error) {
+func peerResponse(items ...any) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, item := range items {
 		switch v := item.(type) {

--- a/sender.go
+++ b/sender.go
@@ -213,7 +213,7 @@ func newSender(target string, s *Session, opts *SenderOptions) (*Sender, error) 
 		l.l.key.name = opts.Name
 	}
 	if opts.Properties != nil {
-		l.l.properties = make(map[encoding.Symbol]interface{})
+		l.l.properties = make(map[encoding.Symbol]any)
 		for k, v := range opts.Properties {
 			if k == "" {
 				return nil, errors.New("link property key must not be empty")

--- a/session_test.go
+++ b/session_test.go
@@ -161,7 +161,7 @@ func TestSessionNewReceiverBadOptionFails(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"": "bad_key",
 		},
 	})
@@ -315,7 +315,7 @@ func TestSessionNewSenderBadOptionFails(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	snd, err := session.NewSender(ctx, "target", &SenderOptions{
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"": "bad_key",
 		},
 	})


### PR DESCRIPTION
Allows usage of any instead of interface{}.
Removed imports of ioutil and replaced with equivalent packages. Cleaned up README.md a little.

No functional/test changes.