### PR TITLE
Refactor error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.18.0 (Unreleased)
 
 ### Features Added
-* Added `ConnectionError` type that's returned when a connection is no longer functional.
+* Added `ConnError` type that's returned when a connection is no longer functional.
 * Added `SessionError` type that's returned when a session has been closed.
 * Added `SASLType` used when configuring the SASL authentication mechanism.
 * Added `Ptr()` method to `SenderSettleMode` and `ReceiverSettleMode` types.
@@ -33,8 +33,7 @@
 * Constant type `ErrorCondition` has been renamed to `ErrCond`.
   * The `ErrCond` values have had their names updated to include the `ErrCond` prefix.
 * `LinkFilterSource` and `LinkFilterSelector` have been renamed to `NewLinkFilter` and `NewSelectorFilter` respectively.
-* The `RemoteError *Error` field in `DetachError` has been removed.
-  * The `DetachError.Unwrap()` method will return the inner `*Error` if present.
+* The `RemoteError` field in `DetachError` has been renamed.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Features Added
 * Added `ConnectionError` type that's returned when a connection is no longer functional.
-* Added `LinkTargetCapabilities()` option to specify desired target capabilities.
+* Added `SessionError` type that's returned when a session has been closed.
 * Added `SASLType` used when configuring the SASL authentication mechanism.
 * Added `Ptr()` method to `SenderSettleMode` and `ReceiverSettleMode` types.
 
 ### Breaking Changes
 * The minimum version of Go required to build this module is now 1.18.
 * The type `Client` has been renamed to `Conn`, and its constructor `New()` renamed to `NewConn()`.
-* Removed `ErrConnClosed` and `ErrTimeout` sentinel error types.
+* Removed `ErrConnClosed`, `ErrSessionClosed`, `ErrLinkClosed`, and `ErrTimeout` sentinel error types.
 * The following methods now require a `context.Context` as their first parameter.
   * `Conn.NewSession()`, `Session.NewReceiver()`, `Session.NewSender()`
 * Removed `context.Context` parameter and `error` return from method `Receiver.Prefetched()`.
@@ -33,6 +33,8 @@
 * Constant type `ErrorCondition` has been renamed to `ErrCond`.
   * The `ErrCond` values have had their names updated to include the `ErrCond` prefix.
 * `LinkFilterSource` and `LinkFilterSelector` have been renamed to `NewLinkFilter` and `NewSelectorFilter` respectively.
+* The `RemoteError *Error` field in `DetachError` has been removed.
+  * The `DetachError.Unwrap()` method will return the inner `*Error` if present.
 
 ### Bugs Fixed
 * Fixed potential panic in `muxHandleFrame()` when checking for manual creditor.
@@ -42,7 +44,7 @@
 * Session will no longer flood peer with flow frames when half its incoming window is consumed.
 * Newly created `Session` won't leak if the context passed to `Conn.NewSession()` expires before exit.
 * Newly created `link` won't leak if the context passed to `link.attach()` expires before exit.
-* Fixed an issue causing dispositions to hang indefinitely with batching enabled when the receiver link is disconnected.
+* Fixed an issue causing dispositions to hang indefinitely with batching enabled when the receiver link is detached.
 
 ### Other Changes
 * Errors when reading/writing to the underlying `net.Conn` are now wrapped in a `ConnectionError` type.

--- a/conn.go
+++ b/conn.go
@@ -784,7 +784,10 @@ func (c *Conn) writeFrame(fr frames.Frame) error {
 	}
 
 	// write to network
-	_, err = c.net.Write(c.txBuf.Bytes())
+	n, err := c.net.Write(c.txBuf.Bytes())
+	if l := c.txBuf.Len(); n > 0 && n < l && err != nil {
+		debug.Log(1, "wrote %d bytes less than len %d: %v", n, l, err)
+	}
 	return err
 }
 

--- a/conn.go
+++ b/conn.go
@@ -121,9 +121,7 @@ func NewConn(conn net.Conn, opts *ConnOptions) (*Conn, error) {
 	return c, nil
 }
 
-// conn is an AMQP connection.
-// only exported fields and methods are part of public surface area,
-// all others are considered to be internal implementation details.
+// Conn is an AMQP connection.
 type Conn struct {
 	net            net.Conn      // underlying connection
 	connectTimeout time.Duration // time to wait for reads/writes during conn establishment
@@ -487,6 +485,8 @@ func (c *Conn) mux() {
 			case *frames.PerformClose:
 				if body.Error != nil {
 					c.doneErr = body.Error
+				} else {
+					c.doneErr = &Error{Condition: "amqp:connection:closed", Description: "connection closed by peer but no error was specified"}
 				}
 				return
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -336,7 +336,7 @@ func TestServerSideClose(t *testing.T) {
 	// wait a bit for connReader to read from the mock
 	time.Sleep(100 * time.Millisecond)
 	err = conn.Close()
-	var connErr *ConnectionError
+	var connErr *ConnError
 	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
@@ -390,7 +390,7 @@ func TestConnReaderError(t *testing.T) {
 	// wait a bit for the connReader goroutine to read from the mock
 	time.Sleep(100 * time.Millisecond)
 	err = conn.Close()
-	var connErr *ConnectionError
+	var connErr *ConnError
 	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
@@ -409,7 +409,7 @@ func TestConnWriterError(t *testing.T) {
 	// wait a bit for connReader to read from the mock
 	time.Sleep(100 * time.Millisecond)
 	err = conn.Close()
-	var connErr *ConnectionError
+	var connErr *ConnError
 	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
@@ -573,7 +573,7 @@ func TestClientNewSession(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err = client.NewSession(ctx, nil)
 	cancel()
-	var connErr *ConnectionError
+	var connErr *ConnError
 	if !errors.As(err, &connErr) {
 		t.Fatalf("unexpected error type %T", err)
 	}
@@ -862,7 +862,7 @@ func TestNewSessionWriteError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
-	var connErr *ConnectionError
+	var connErr *ConnError
 	require.ErrorAs(t, err, &connErr)
 	require.Equal(t, "write error", connErr.Error())
 	require.Nil(t, session)

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,6 @@
 package amqp
 
 import (
-	"errors"
-
 	"github.com/Azure/go-amqp/internal/encoding"
 )
 
@@ -47,75 +45,60 @@ const (
 )
 
 // Error is an AMQP error.
-// DetachError and SessionError will contain instances of this type
-// when detached/closed by the peer with an AMQP error. In this case,
-// use errors.As() to unwrap the inner *Error.
 type Error = encoding.Error
 
 // DetachError is returned by methods on Sender/Receiver when the link has become detached/closed.
 type DetachError struct {
+	// RemoteErr contains any error information provided by the peer in a peer-initiated detach.
+	RemoteErr *Error
+
 	inner error
 }
 
 // Error implements the error interface for DetachError.
 func (e *DetachError) Error() string {
-	if e.inner == nil {
+	if e.RemoteErr == nil && e.inner == nil {
 		return "amqp: link closed"
+	} else if e.RemoteErr != nil {
+		return e.RemoteErr.Error()
 	}
 	return e.inner.Error()
 }
 
-// Unwrap returns the inner *Error or nil.
-func (e *DetachError) Unwrap() error {
-	var err *Error
-	if errors.As(e.inner, &err) {
-		return err
-	}
-	return nil
-}
-
-// ConnectionError is propagated to Session and Senders/Receivers
+// ConnError is propagated to Session and Senders/Receivers
 // when the connection has been closed.
-type ConnectionError struct {
+type ConnError struct {
+	// RemoteErr contains any error information provided by the peer when the peer closes the AMQP connection.
+	RemoteErr *Error
+
 	inner error
 }
 
 // Error implements the error interface for ConnectionError.
-func (c *ConnectionError) Error() string {
-	if c.inner == nil {
+func (e *ConnError) Error() string {
+	if e.RemoteErr == nil && e.inner == nil {
 		return "amqp: connection closed"
+	} else if e.RemoteErr != nil {
+		return e.RemoteErr.Error()
 	}
-	return c.inner.Error()
-}
-
-// Unwrap returns the inner *Error or nil.
-func (e *ConnectionError) Unwrap() error {
-	var err *Error
-	if errors.As(e.inner, &err) {
-		return err
-	}
-	return nil
+	return e.inner.Error()
 }
 
 // SessionError is propagated to Senders/Receivers when the session
 // has been closed.
 type SessionError struct {
+	// RemoteErr contains any error information provided by the peer when the peer closes the session.
+	RemoteErr *Error
+
 	inner error
 }
 
 // Error implements the error interface for SessionError.
-func (s *SessionError) Error() string {
-	if s.inner == nil {
+func (e *SessionError) Error() string {
+	if e.RemoteErr == nil && e.inner == nil {
 		return "amqp: session closed"
+	} else if e.RemoteErr != nil {
+		return e.RemoteErr.Error()
 	}
-	return s.inner.Error()
-}
-
-// Unwrap returns the inner *Error or nil.
-func (e *SessionError) Unwrap() error {
-	var err *Error
-	if errors.As(e.inner, &err) {
-		return err
-	}
-	return nil
+	return e.inner.Error()
 }

--- a/errors.go
+++ b/errors.go
@@ -88,6 +88,15 @@ func (c *ConnectionError) Error() string {
 	return c.inner.Error()
 }
 
+// Unwrap returns the inner *Error or nil.
+func (e *ConnectionError) Unwrap() error {
+	var err *Error
+	if errors.As(e.inner, &err) {
+		return err
+	}
+	return nil
+}
+
 // SessionError is propagated to Senders/Receivers when the session
 // has been closed.
 type SessionError struct {

--- a/errors.go
+++ b/errors.go
@@ -49,7 +49,7 @@ type Error = encoding.Error
 
 // DetachError is returned by methods on Sender/Receiver when the link has become detached/closed.
 type DetachError struct {
-	// RemoteErr contains any error information provided by the peer in a peer-initiated detach.
+	// RemoteErr contains any error information provided by the peer if the peer detached the link.
 	RemoteErr *Error
 
 	inner error
@@ -65,10 +65,10 @@ func (e *DetachError) Error() string {
 	return e.inner.Error()
 }
 
-// ConnError is propagated to Session and Senders/Receivers
+// ConnError is returned by methods on Conn and propagated to Session and Senders/Receivers
 // when the connection has been closed.
 type ConnError struct {
-	// RemoteErr contains any error information provided by the peer when the peer closes the AMQP connection.
+	// RemoteErr contains any error information provided by the peer if the peer closed the AMQP connection.
 	RemoteErr *Error
 
 	inner error
@@ -84,10 +84,10 @@ func (e *ConnError) Error() string {
 	return e.inner.Error()
 }
 
-// SessionError is propagated to Senders/Receivers when the session
-// has been closed.
+// SessionError is returned by methods on Session and propagated to Senders/Receivers
+// when the session has been closed.
 type SessionError struct {
-	// RemoteErr contains any error information provided by the peer when the peer closes the session.
+	// RemoteErr contains any error information provided by the peer if the peer closed the session.
 	RemoteErr *Error
 
 	inner error

--- a/example_test.go
+++ b/example_test.go
@@ -163,14 +163,14 @@ func ExampleSessionError() {
 	// attempt to send message on a closed session
 	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
 
-	var connErr *amqp.SessionError
-	if !errors.As(err, &connErr) {
+	var sessionErr *amqp.SessionError
+	if !errors.As(err, &sessionErr) {
 		log.Fatalf("unexpected error type %T", err)
 	}
 
 	// similarly, methods on session will fail in the same way
 	_, err = session.NewReceiver(ctx, "/queue-name", nil)
-	if !errors.As(err, &connErr) {
+	if !errors.As(err, &sessionErr) {
 		log.Fatalf("unexpected error type %T", err)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package amqp_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -10,26 +11,26 @@ import (
 )
 
 func Example() {
-	// Create client
-	client, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+	// create connection
+	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
 		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
 	})
 	if err != nil {
 		log.Fatal("Dialing AMQP server:", err)
 	}
-	defer client.Close()
+	defer conn.Close()
 
 	ctx := context.TODO()
 
-	// Open a session
-	session, err := client.NewSession(ctx, nil)
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
 	if err != nil {
 		log.Fatal("Creating AMQP session:", err)
 	}
 
-	// Send a message
+	// send a message
 	{
-		// Create a sender
+		// create a sender
 		sender, err := session.NewSender(ctx, "/queue-name", nil)
 		if err != nil {
 			log.Fatal("Creating sender link:", err)
@@ -37,7 +38,7 @@ func Example() {
 
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 
-		// Send message
+		// send message
 		err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
 		if err != nil {
 			log.Fatal("Sending message:", err)
@@ -47,9 +48,9 @@ func Example() {
 		cancel()
 	}
 
-	// Continuously read messages
+	// continuously read messages
 	{
-		// Create a receiver
+		// create a receiver
 		receiver, err := session.NewReceiver(ctx, "/queue-name", &amqp.ReceiverOptions{
 			Credit: 10,
 		})
@@ -63,18 +64,162 @@ func Example() {
 		}()
 
 		for {
-			// Receive next message
+			// receive next message
 			msg, err := receiver.Receive(ctx)
 			if err != nil {
 				log.Fatal("Reading message from AMQP:", err)
 			}
 
-			// Accept message
+			// accept message
 			if err = receiver.AcceptMessage(context.TODO(), msg); err != nil {
 				log.Fatalf("Failure accepting message: %v", err)
 			}
 
 			fmt.Printf("Message received: %s\n", msg.GetData())
 		}
+	}
+}
+
+func ExampleConnError() {
+	// *ConnErrors are returned when the underlying connection has been closed.
+	// this error is propagated to all child Session, Sender, and Receiver instances.
+
+	// create connection
+	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
+	})
+	if err != nil {
+		log.Fatal("Dialing AMQP server:", err)
+	}
+
+	ctx := context.TODO()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	if err != nil {
+		log.Fatal("Creating AMQP session:", err)
+	}
+
+	// create a sender
+	sender, err := session.NewSender(ctx, "/queue-name", nil)
+	if err != nil {
+		log.Fatal("Creating sender link:", err)
+	}
+
+	// close the connection before sending the message
+	conn.Close()
+
+	// attempt to send message on a closed connection
+	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
+
+	var connErr *amqp.ConnError
+	if !errors.As(err, &connErr) {
+		log.Fatalf("unexpected error type %T", err)
+	}
+
+	// similarly, methods on session will fail in the same way
+	_, err = session.NewReceiver(ctx, "/queue-name", nil)
+	if !errors.As(err, &connErr) {
+		log.Fatalf("unexpected error type %T", err)
+	}
+
+	// methods on the connection will also fail
+	_, err = conn.NewSession(ctx, nil)
+	if !errors.As(err, &connErr) {
+		log.Fatalf("unexpected error type %T", err)
+	}
+}
+
+func ExampleSessionError() {
+	// *SessionErrors are returned when a session has been clossed.
+	// this error is propagated to all child Sender and Receiver instances.
+
+	// create connection
+	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
+	})
+	if err != nil {
+		log.Fatal("Dialing AMQP server:", err)
+	}
+	defer conn.Close()
+
+	ctx := context.TODO()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	if err != nil {
+		log.Fatal("Creating AMQP session:", err)
+	}
+
+	// create a sender
+	sender, err := session.NewSender(ctx, "/queue-name", nil)
+	if err != nil {
+		log.Fatal("Creating sender link:", err)
+	}
+
+	// close the session before sending the message
+	session.Close(ctx)
+
+	// attempt to send message on a closed session
+	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
+
+	var connErr *amqp.SessionError
+	if !errors.As(err, &connErr) {
+		log.Fatalf("unexpected error type %T", err)
+	}
+
+	// similarly, methods on session will fail in the same way
+	_, err = session.NewReceiver(ctx, "/queue-name", nil)
+	if !errors.As(err, &connErr) {
+		log.Fatalf("unexpected error type %T", err)
+	}
+}
+
+func ExampleDetachError() {
+	// *DetachErrors are returned by methods on Senders/Receivers after Close() has been called.
+	// it can also be returned if the peer has detached from the link. in this case, the *RemoteErr
+	// field should contain additional information about why the peer detached.
+
+	// create connection
+	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
+	})
+	if err != nil {
+		log.Fatal("Dialing AMQP server:", err)
+	}
+	defer conn.Close()
+
+	ctx := context.TODO()
+
+	// open a session
+	session, err := conn.NewSession(ctx, nil)
+	if err != nil {
+		log.Fatal("Creating AMQP session:", err)
+	}
+
+	// create a sender
+	sender, err := session.NewSender(ctx, "/queue-name", nil)
+	if err != nil {
+		log.Fatal("Creating sender link:", err)
+	}
+
+	// send message
+	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
+	if err != nil {
+		log.Fatal("Creating AMQP session:", err)
+	}
+
+	// now close the sender
+	err = sender.Close(ctx)
+	if err != nil {
+		log.Fatal("Creating AMQP session:", err)
+	}
+
+	// attempt to send a message after close
+	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
+
+	var detachErr *amqp.DetachError
+	if !errors.As(err, &detachErr) {
+		log.Fatalf("unexpected error type %T", err)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -131,7 +131,7 @@ func ExampleConnError() {
 }
 
 func ExampleSessionError() {
-	// *SessionErrors are returned when a session has been clossed.
+	// *SessionErrors are returned when a session has been closed.
 	// this error is propagated to all child Sender and Receiver instances.
 
 	// create connection
@@ -210,10 +210,7 @@ func ExampleDetachError() {
 	}
 
 	// now close the sender
-	err = sender.Close(ctx)
-	if err != nil {
-		log.Fatal("Creating AMQP session:", err)
-	}
+	sender.Close(ctx)
 
 	// attempt to send a message after close
 	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	amqp "github.com/Azure/go-amqp"
 	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 var localBrokerAddr string
@@ -653,10 +654,8 @@ func TestIntegrationClose(t *testing.T) {
 		testClose(t, receiver.Close)
 
 		_, err = receiver.Receive(context.Background())
-		if err != amqp.ErrLinkClosed {
-			t.Fatalf("Expected ErrLinkClosed from receiver.Receiver, got: %+v", err)
-			return
-		}
+		var detachErr *amqp.DetachError
+		require.ErrorAs(t, err, &detachErr)
 
 		err = client.Close() // close before leak check
 		if err != nil {
@@ -696,10 +695,8 @@ func TestIntegrationClose(t *testing.T) {
 		testClose(t, session.Close)
 
 		msg, err := receiver.Receive(context.Background())
-		if !errors.Is(err, amqp.ErrSessionClosed) {
-			t.Fatalf("Expected ErrSessionClosed from receiver.Receiver, got: %+v", err)
-			return
-		}
+		var sessionErr *amqp.SessionError
+		require.ErrorAs(t, err, &sessionErr)
 		if msg != nil {
 			t.Fatal("expected nil message")
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -742,7 +742,7 @@ func TestIntegrationClose(t *testing.T) {
 		}
 
 		msg, err := receiver.Receive(context.Background())
-		var connErr *amqp.ConnectionError
+		var connErr *amqp.ConnError
 		if !errors.As(err, &connErr) {
 			t.Fatalf("unexpected error type %T", err)
 			return

--- a/link.go
+++ b/link.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -229,13 +230,16 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		debug.Log(1, "RX (muxHandleFrame): %s", fr)
 		// don't currently support link detach and reattach
 		if !fr.Closed {
-			return fmt.Errorf("non-closing detach not supported: %+v", fr)
+			return &DetachError{inner: fmt.Errorf("non-closing detach not supported: %+v", fr)}
 		}
 
 		// set detach received and close link
 		l.detachReceived = true
 
-		return &DetachError{fr.Error}
+		if fr.Error != nil {
+			return &DetachError{inner: fr.Error}
+		}
+		return &DetachError{}
 
 	default:
 		// TODO: evaluate
@@ -254,7 +258,9 @@ func (l *link) closeLink(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	if l.err == ErrLinkClosed {
+	var detachErr *DetachError
+	if errors.As(l.err, &detachErr) && detachErr.inner == nil {
+		// an empty DetachError means the link was closed by the caller
 		return nil
 	}
 	return l.err

--- a/link.go
+++ b/link.go
@@ -237,9 +237,9 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		l.detachReceived = true
 
 		if fr.Error != nil {
-			return &DetachError{inner: fr.Error}
+			return &DetachError{RemoteErr: fr.Error}
 		}
-		return &DetachError{inner: &Error{Condition: "amqp:link:closed", Description: "link detached by peer but no error was specified"}}
+		return &DetachError{}
 
 	default:
 		// TODO: evaluate

--- a/link.go
+++ b/link.go
@@ -239,7 +239,7 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		if fr.Error != nil {
 			return &DetachError{inner: fr.Error}
 		}
-		return &DetachError{}
+		return &DetachError{inner: &Error{Condition: "amqp:link:closed", Description: "link detached by peer but no error was specified"}}
 
 	default:
 		// TODO: evaluate

--- a/manualCreditor.go
+++ b/manualCreditor.go
@@ -86,7 +86,7 @@ func (mc *manualCreditor) Drain(ctx context.Context, r *Receiver) error {
 	case <-drained:
 		return nil
 	case <-r.l.detached:
-		return &DetachError{RemoteError: r.l.detachError}
+		return r.l.detachError
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/manualCreditor_test.go
+++ b/manualCreditor_test.go
@@ -135,7 +135,7 @@ func TestManualCreditorDrainReturnsProperError(t *testing.T) {
 			close(link.l.detached)
 
 			detachErr := mc.Drain(ctx, link)
-			require.Equal(t, detachErr, &DetachError{RemoteError: err})
+			require.Equal(t, err, detachErr)
 		})
 	}
 }

--- a/sender.go
+++ b/sender.go
@@ -69,7 +69,8 @@ func (s *Sender) Send(ctx context.Context, msg *Message) error {
 	case state := <-done:
 		if state, ok := state.(*encoding.StateRejected); ok {
 			if s.detachOnRejectDisp() {
-				return &DetachError{state.Error}
+				// TODO: this appears to be duplicated in the mux
+				return &DetachError{RemoteErr: state.Error}
 			}
 			return state.Error
 		}
@@ -386,7 +387,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 		//
 		// This isn't ideal, but there isn't a clear better way to handle it.
 		if fr, ok := fr.State.(*encoding.StateRejected); ok && s.detachOnRejectDisp() {
-			return &DetachError{fr.Error}
+			return &DetachError{RemoteErr: fr.Error}
 		}
 
 		if fr.Settled {

--- a/sender.go
+++ b/sender.go
@@ -328,7 +328,7 @@ Loop:
 						return
 					}
 				case <-s.l.close:
-					s.l.err = ErrLinkClosed
+					s.l.err = &DetachError{}
 					return
 				case <-s.l.session.done:
 					s.l.err = s.l.session.err
@@ -337,7 +337,7 @@ Loop:
 			}
 
 		case <-s.l.close:
-			s.l.err = ErrLinkClosed
+			s.l.err = &DetachError{}
 			return
 		case <-s.l.session.done:
 			s.l.err = s.l.session.err

--- a/session.go
+++ b/session.go
@@ -182,7 +182,7 @@ func (s *Session) Close(ctx context.Context) error {
 		return ctx.Err()
 	}
 	var sessionErr *SessionError
-	if errors.As(s.err, &sessionErr) && sessionErr.inner == nil {
+	if errors.As(s.err, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
 		// an empty SessionError means the session was closed by the caller
 		return nil
 	}
@@ -245,9 +245,14 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		s.conn.deleteSession(s)
 		if s.err == nil {
 			s.err = &SessionError{}
-		} else if connErr := (&ConnectionError{}); !errors.As(s.err, &connErr) {
+		} else if connErr := (&ConnError{}); !errors.As(s.err, &connErr) {
 			// only wrap non-ConnectionError error types
-			s.err = &SessionError{inner: s.err}
+			var amqpErr *Error
+			if errors.As(s.err, &amqpErr) {
+				s.err = &SessionError{RemoteErr: amqpErr}
+			} else {
+				s.err = &SessionError{inner: s.err}
+			}
 		}
 		// Signal goroutines waiting on the session.
 		close(s.done)
@@ -493,8 +498,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				_ = s.txFrame(&frames.PerformEnd{}, nil)
 				if body.Error != nil {
 					s.err = body.Error
-				} else {
-					s.err = &Error{Condition: "amqp:session:closed", Description: "session ended by peer but no error was specified"}
 				}
 				return
 

--- a/session.go
+++ b/session.go
@@ -494,7 +494,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				if body.Error != nil {
 					s.err = body.Error
 				} else {
-					s.err = errors.New("session ended by peer but no error was specified")
+					s.err = &Error{Condition: "amqp:session:closed", Description: "session ended by peer but no error was specified"}
 				}
 				return
 

--- a/session.go
+++ b/session.go
@@ -181,7 +181,9 @@ func (s *Session) Close(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	if s.err == ErrSessionClosed {
+	var sessionErr *SessionError
+	if errors.As(s.err, &sessionErr) && sessionErr.inner == nil {
+		// an empty SessionError means the session was closed by the caller
 		return nil
 	}
 	return s.err
@@ -242,7 +244,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
 		s.conn.deleteSession(s)
 		if s.err == nil {
-			s.err = ErrSessionClosed
+			s.err = &SessionError{}
+		} else if connErr := (&ConnectionError{}); !errors.As(s.err, &connErr) {
+			// only wrap non-ConnectionError error types
+			s.err = &SessionError{inner: s.err}
 		}
 		// Signal goroutines waiting on the session.
 		close(s.done)
@@ -486,7 +491,11 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 			case *frames.PerformEnd:
 				_ = s.txFrame(&frames.PerformEnd{}, nil)
-				s.err = fmt.Errorf("session ended by server: %s", body.Error)
+				if body.Error != nil {
+					s.err = body.Error
+				} else {
+					s.err = errors.New("session ended by peer but no error was specified")
+				}
 				return
 
 			default:

--- a/session_test.go
+++ b/session_test.go
@@ -93,10 +93,9 @@ func TestSessionServerClose(t *testing.T) {
 	require.Error(t, err)
 	var sessionErr *SessionError
 	require.ErrorAs(t, err, &sessionErr)
-	var amqpErr *Error
-	require.ErrorAs(t, sessionErr, &amqpErr)
-	require.Equal(t, ErrCond("closing"), amqpErr.Condition)
-	require.Equal(t, "server side close", amqpErr.Description)
+	require.NotNil(t, sessionErr.RemoteErr)
+	require.Equal(t, ErrCond("closing"), sessionErr.RemoteErr.Condition)
+	require.Equal(t, "server side close", sessionErr.RemoteErr.Description)
 	require.NoError(t, client.Close())
 }
 
@@ -155,7 +154,7 @@ func TestConnCloseSessionClose(t *testing.T) {
 
 	rcv, err := session.NewReceiver(context.Background(), "blah", nil)
 	require.Nil(t, rcv)
-	var connErr *ConnectionError
+	var connErr *ConnError
 	require.ErrorAs(t, err, &connErr)
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -91,7 +91,12 @@ func TestSessionServerClose(t *testing.T) {
 	err = session.Close(ctx)
 	cancel()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "session ended by server")
+	var sessionErr *SessionError
+	require.ErrorAs(t, err, &sessionErr)
+	var amqpErr *Error
+	require.ErrorAs(t, sessionErr, &amqpErr)
+	require.Equal(t, ErrCond("closing"), amqpErr.Condition)
+	require.Equal(t, "server side close", amqpErr.Description)
 	require.NoError(t, client.Close())
 }
 
@@ -147,6 +152,11 @@ func TestConnCloseSessionClose(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("session wasn't closed")
 	}
+
+	rcv, err := session.NewReceiver(context.Background(), "blah", nil)
+	require.Nil(t, rcv)
+	var connErr *ConnectionError
+	require.ErrorAs(t, err, &connErr)
 }
 
 func TestSessionNewReceiverBadOptionFails(t *testing.T) {


### PR DESCRIPTION
The session and link sentinel error types have been removed. Added SessionError type which allows more descriptive errors. Fixed some error corner-cases to ensure they return DetachError. Removed spurious error text on peer-initiated ending of a session.

Fixes:
- https://github.com/Azure/go-amqp/issues/98
- https://github.com/Azure/go-amqp/issues/109
- https://github.com/Azure/go-amqp/issues/127