### PR TITLE
Fix panic due to sending on closed channel

### DIFF
--- a/link.go
+++ b/link.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
@@ -90,38 +89,15 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// send Attach frame
 	debug.Log(1, "TX (attachLink): %s", attach)
 
-	// we use send to have positive confirmation on transmission
-	send := make(chan encoding.DeliveryState)
-	_ = l.session.txFrame(attach, send)
+	_ = l.session.txFrame(attach, nil)
 
 	// wait for response
 	var fr frames.FrameBody
 	select {
 	case <-ctx.Done():
-		select {
-		case <-send:
-			// attach was written to the network. assume it was received
-			// and that the ctx was too short to wait for the ack. in this
-			// case we must send a detach before deallocation
-			go func() {
-				_ = l.session.txFrame(&frames.PerformDetach{
-					Handle: l.handle,
-					Closed: true,
-				}, nil)
-				select {
-				case <-l.session.done:
-					// session has terminated, no need to deallocate in this case
-				case <-time.After(5 * time.Second):
-					debug.Log(3, "link.attach() clean-up timed out waiting for ack")
-				case <-l.rx:
-					// received ack, safe to delete handle
-					l.session.deallocateHandle(l)
-				}
-			}()
-		default:
-			// attach wasn't written to the network, so delete the handle
-			l.session.deallocateHandle(l)
-		}
+		// attach was written to the network. assume it was received
+		// and that the ctx was too short to wait for the ack.
+		go l.muxDetach(nil, nil)
 		return ctx.Err()
 	case <-l.session.done:
 		// session has terminated, no need to deallocate in this case
@@ -148,13 +124,7 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		select {
 		case <-ctx.Done():
 			// if we don't send an ack then we're in violation of the protocol
-			go func() {
-				_ = l.session.txFrame(&frames.PerformDetach{
-					Handle: l.handle,
-					Closed: true,
-				}, nil)
-				l.session.deallocateHandle(l)
-			}()
+			go l.muxDetach(nil, nil)
 			return ctx.Err()
 		case <-l.session.done:
 			return l.session.err

--- a/receiver.go
+++ b/receiver.go
@@ -537,7 +537,7 @@ func (r *Receiver) attach(ctx context.Context) error {
 }
 
 func (r *Receiver) mux() {
-	defer r.l.muxDetach(func() {
+	defer r.l.muxDetach(context.Background(), func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.err)
 

--- a/sender.go
+++ b/sender.go
@@ -289,7 +289,7 @@ func (s *Sender) attach(ctx context.Context) error {
 }
 
 func (s *Sender) mux() {
-	defer s.l.muxDetach(nil, nil)
+	defer s.l.muxDetach(context.Background(), nil, nil)
 
 Loop:
 	for {

--- a/session.go
+++ b/session.go
@@ -129,6 +129,8 @@ func (s *Session) begin(ctx context.Context) error {
 			case <-s.conn.done:
 				// conn has terminated, no need to delete the session
 			case <-time.After(5 * time.Second):
+				// don't delete the session in this case. this is to avoid recylcing
+				// a channel number for a session that might not have terminated
 				debug.Log(3, "session.begin clean-up timed out waiting for PerformEnd ack")
 			case <-s.rx:
 				// received ack that session was closed, safe to delete session

--- a/session.go
+++ b/session.go
@@ -114,36 +114,27 @@ func (s *Session) begin(ctx context.Context) error {
 	}
 	debug.Log(1, "TX (NewSession): %s", begin)
 
-	// we use send to have positive confirmation on transmission
-	send := make(chan encoding.DeliveryState)
-	_ = s.txFrame(begin, send)
+	_ = s.txFrame(begin, nil)
 
 	// wait for response
 	var fr frames.Frame
 	select {
 	case <-ctx.Done():
-		select {
-		case <-send:
-			// begin was written to the network.  assume it was
-			// received and that the ctx was too short to wait for
-			// the ack. in this case we must send an end before we
-			// can delete the session
-			go func() {
-				_ = s.txFrame(&frames.PerformEnd{}, nil)
-				select {
-				case <-s.conn.done:
-					// conn has terminated, no need to delete the session
-				case <-time.After(5 * time.Second):
-					debug.Log(3, "NewSession clean-up timed out waiting for PerformEnd ack")
-				case <-s.rx:
-					// received ack that session was closed, safe to delete session
-					s.conn.deleteSession(s)
-				}
-			}()
-		default:
-			// begin wasn't written to the network, so delete session
-			s.conn.deleteSession(s)
-		}
+		// begin was written to the network.  assume it was
+		// received and that the ctx was too short to wait for
+		// the ack.
+		go func() {
+			_ = s.txFrame(&frames.PerformEnd{}, nil)
+			select {
+			case <-s.conn.done:
+				// conn has terminated, no need to delete the session
+			case <-time.After(5 * time.Second):
+				debug.Log(3, "session.begin clean-up timed out waiting for PerformEnd ack")
+			case <-s.rx:
+				// received ack that session was closed, safe to delete session
+				s.conn.deleteSession(s)
+			}
+		}()
 		return ctx.Err()
 	case <-s.conn.done:
 		return s.conn.err()


### PR DESCRIPTION
Early exit in link.attach was closing l.rx on receiving of attach performative.  When the detach performative arrives, the session mux would panic attempting to send to a closed channel. Removed channel for "positive confirmation on transmission" as it's racy and doesn't actually work that way.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
