### PR TITLE
Fix potential deadlock between senders and receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 ### Bugs Fixed
 
 * Fixed an issue that could cause `Conn.connReader()` to become blocked in rare circumstances.
-
-### Bugs Fixed
-
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
+* Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 
 ### Other Changes
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -369,7 +369,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 			// ignore future flow frames as we have no response
 			return nil, nil
 		case *frames.PerformDisposition:
-			return mocks.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+			return nil, nil
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
@@ -389,6 +389,17 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	msg, err := r.Receive(ctx)
+	cancel()
+	require.NoError(t, err)
+	if c := r.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	// link credit should be 0
+	if c := r.l.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	err = r.AcceptMessage(ctx, msg)
 	cancel()
 	require.NoError(t, err)
 	if c := r.countUnsettled(); c != 0 {

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -395,7 +395,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// link credit should be 0
-	if c := r.l.linkCredit; c != 0 {
+	if c := r.l.availableCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
Receivers configured for ModeFirst weren't tracking unsettled messages. As a result, their session would send them more messages than their link credit would allow, causing the session mux to be blocked. With the session mux blocked, senders within the same session were unable to send messages.

Fixes https://github.com/Azure/go-amqp/issues/117