### PR TITLE
Consolidate auto and manual link flow control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 * The connection mux goroutine has been removed, eliminating a potential source of deadlocks.
+* Automatic link flow control is built on the manual creditor.
 
 ## 0.18.0 (2022-12-06)
 

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -1090,7 +1090,7 @@ func (t *PerformTransfer) frameBody() {}
 func (t PerformTransfer) String() string {
 	deliveryTag := "<nil>"
 	if t.DeliveryTag != nil {
-		deliveryTag = fmt.Sprintf("%q", t.DeliveryTag)
+		deliveryTag = fmt.Sprintf("%X", t.DeliveryTag)
 	}
 
 	return fmt.Sprintf("Transfer{Handle: %d, DeliveryID: %s, DeliveryTag: %s, MessageFormat: %s, "+

--- a/link_options.go
+++ b/link_options.go
@@ -142,6 +142,8 @@ type ReceiverOptions struct {
 	// ManualCredits enables manual credit management for this link.
 	// Credits can be added with IssueCredit(), and links can also be
 	// drained with DrainCredit().
+	// This should only be enabled when complete control of the link's
+	// flow control is required.
 	ManualCredits bool
 
 	// MaxMessageSize sets the maximum message size that can

--- a/receiver.go
+++ b/receiver.go
@@ -39,22 +39,23 @@ type Receiver struct {
 	more                  bool                // if true, buf contains a partial message
 	msg                   Message             // current message being decoded
 
-	batching       bool                    // enable batching of message dispositions
-	batchMaxAge    time.Duration           // maximum time between the start n batch and sending the batch to the server
-	dispositions   chan messageDisposition // message dispositions are sent on this channel when batching is enabled
-	maxCredit      uint32                  // maximum allowed inflight messages
-	inFlight       inFlight                // used to track message disposition when rcv-settle-mode == second
-	manualCreditor *manualCreditor         // allows for credits to be managed manually (via calls to IssueCredit/DrainCredit)
+	autoSendFlow bool                    // automatically send flow frames as credit becomes available
+	batching     bool                    // enable batching of message dispositions
+	batchMaxAge  time.Duration           // maximum time between the start n batch and sending the batch to the server
+	dispositions chan messageDisposition // message dispositions are sent on this channel when batching is enabled
+	maxCredit    uint32                  // maximum allowed inflight messages
+	inFlight     inFlight                // used to track message disposition when rcv-settle-mode == second
+	creditor     creditor                // manages credits via calls to IssueCredit/DrainCredit
 }
 
 // IssueCredit adds credits to be requested in the next flow
 // request.
 func (r *Receiver) IssueCredit(credit uint32) error {
-	if r.manualCreditor == nil {
+	if r.autoSendFlow {
 		return errors.New("issueCredit can only be used with receiver links using manual credit management")
 	}
 
-	if err := r.manualCreditor.IssueCredit(credit); err != nil {
+	if err := r.creditor.IssueCredit(credit, r); err != nil {
 		return err
 	}
 
@@ -70,7 +71,7 @@ func (r *Receiver) IssueCredit(credit uint32) error {
 // DrainCredit sets the drain flag on the next flow frame and
 // waits for the drain to be acknowledged.
 func (r *Receiver) DrainCredit(ctx context.Context) error {
-	if r.manualCreditor == nil {
+	if r.autoSendFlow {
 		return errors.New("drain can only be used with receiver links using manual credit management")
 	}
 
@@ -80,7 +81,7 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 	default:
 	}
 
-	return r.manualCreditor.Drain(ctx, r)
+	return r.creditor.Drain(ctx, r)
 }
 
 // Prefetched returns the next message that is stored in the Receiver's
@@ -406,6 +407,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 			source:   &frames.Source{Address: source},
 			target:   new(frames.Target),
 		},
+		autoSendFlow:  true,
 		receiverReady: make(chan struct{}, 1),
 		batching:      defaultLinkBatching,
 		batchMaxAge:   defaultLinkBatchMaxAge,
@@ -425,6 +427,9 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	}
 	if opts.Credit > 0 {
 		r.maxCredit = opts.Credit
+	} else {
+		// TODO: larger default?
+		r.maxCredit = 1
 	}
 	if opts.Durability > DurabilityUnsettledState {
 		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)
@@ -448,7 +453,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		}
 	}
 	if opts.ManualCredits {
-		r.manualCreditor = &manualCreditor{}
+		r.autoSendFlow = false
 	}
 	if opts.MaxMessageSize > 0 {
 		r.l.maxMessageSize = opts.MaxMessageSize
@@ -496,13 +501,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (r *Receiver) attach(ctx context.Context) error {
-	// buffer rx to linkCredit so that conn.mux won't block
-	// attempting to send to a slow reader
-	if r.manualCreditor != nil {
-		r.l.rx = make(chan frames.FrameBody, r.maxCredit)
-	} else {
-		r.l.rx = make(chan frames.FrameBody, r.l.availableCredit)
-	}
+	r.l.rx = make(chan frames.FrameBody, 1)
 
 	if err := r.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleReceiver
@@ -541,36 +540,34 @@ func (r *Receiver) mux() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.err)
 
-		// unblock any pending drain requests
-		if r.manualCreditor != nil {
-			r.manualCreditor.EndDrain()
+		if !r.autoSendFlow {
+			// unblock any pending drain requests
+			r.creditor.EndDrain()
 		}
 	}, func(fr frames.PerformTransfer) {
 		_ = r.muxReceive(fr)
 	})
 
 	for {
-		switch {
-		case r.manualCreditor != nil:
-			drain, credits := r.manualCreditor.FlowBits(r.l.availableCredit)
-
-			if drain || credits > 0 {
-				debug.Log(1, "receiver (manual): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s",
-					r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
-
-				// send a flow frame.
-				r.l.err = r.muxFlow(credits, drain)
-			}
-
-		// if receiver && half maxCredits have been processed, send more credits
-		case r.l.availableCredit+uint32(r.countUnsettled()) <= r.maxCredit/2:
+		// if half maxCredits have been processed and auto-flow is enabled, send more credits
+		if available := r.l.availableCredit + uint32(r.countUnsettled()); available <= r.maxCredit/2 && r.autoSendFlow {
 			debug.Log(1, "receiver (half): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
-
-			linkCredit := r.maxCredit - uint32(r.countUnsettled())
-			r.l.err = r.muxFlow(linkCredit, false)
-
-		case r.l.availableCredit == 0:
+			r.l.err = r.creditor.IssueCredit(r.maxCredit-available, r)
+		} else if r.l.availableCredit == 0 {
 			debug.Log(1, "receiver (pause): inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+		}
+
+		if r.l.err != nil {
+			return
+		}
+
+		drain, credits := r.creditor.FlowBits(r.l.availableCredit)
+		if drain || credits > 0 {
+			debug.Log(1, "receiver: source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s",
+				r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+
+			// send a flow frame.
+			r.l.err = r.muxFlow(credits, drain)
 		}
 
 		if r.l.err != nil {
@@ -656,9 +653,9 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		if !fr.Echo {
 			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
 			// we signal whomever is waiting (the service has seen and acknowledged our drain)
-			if fr.Drain && r.manualCreditor != nil {
+			if fr.Drain && !r.autoSendFlow {
 				r.l.availableCredit = 0 // we have no active credits at this point.
-				r.manualCreditor.EndDrain()
+				r.creditor.EndDrain()
 			}
 			return nil
 		}

--- a/receiver.go
+++ b/receiver.go
@@ -500,7 +500,8 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (r *Receiver) attach(ctx context.Context) error {
-	r.l.rx = make(chan frames.FrameBody, 1)
+	// TODO: remove double-buffering
+	r.l.rx = make(chan frames.FrameBody, r.maxCredit)
 
 	if err := r.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleReceiver

--- a/receiver.go
+++ b/receiver.go
@@ -549,12 +549,13 @@ func (r *Receiver) mux() {
 
 	for {
 		// max - (availableCredit + countUnsettled) == pending credit (i.e. credit we can reclaim)
-		// once we have pending credits equal to or greater than our available credit, reclaim it.
-		if pendingCredit := r.maxCredit - (r.l.availableCredit + uint32(r.countUnsettled())); pendingCredit > 0 && pendingCredit >= r.l.availableCredit && r.autoSendFlow {
+		// once we have pending credit equal to or greater than half our max, reclaim it.  we do this
+		// instead of pending > 0 to prevent flow frames from being too chatty.
+		if pendingCredit := r.maxCredit - (r.l.availableCredit + uint32(r.countUnsettled())); pendingCredit >= r.maxCredit/2 && r.autoSendFlow {
 			debug.Log(1, "receiver (auto): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 			r.l.err = r.creditor.IssueCredit(pendingCredit, r)
 		} else if r.l.availableCredit == 0 {
-			debug.Log(1, "receiver (pause): inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "receiver (pause): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.err != nil {
@@ -563,7 +564,7 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.availableCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "receiver: source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
+			debug.Log(1, "receiver (flow): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
 				r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 
 			// send a flow frame.

--- a/receiver.go
+++ b/receiver.go
@@ -427,8 +427,6 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	}
 	if opts.Credit > 0 {
 		r.maxCredit = opts.Credit
-	} else {
-		r.maxCredit = defaultLinkCredit
 	}
 	if opts.Durability > DurabilityUnsettledState {
 		return nil, fmt.Errorf("invalid Durability %d", opts.Durability)


### PR DESCRIPTION
Auto link flow control is now built on the creditor. Renamed some types to clarify their usage.
Removed double buffering of incoming frames for receiver.

Fixes https://github.com/Azure/go-amqp/issues/73