### PR TITLE
Enable at-most-once for senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed an issue that could cause `Conn.connReader()` to become blocked in rare circumstances.
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
+* Enabled support for senders in an at-most-once configuration.
 
 ### Other Changes
 

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -185,7 +185,7 @@ func (s *Source) Unmarshal(r *buffer.Buffer) error {
 
 func (s Source) String() string {
 	return fmt.Sprintf("source{Address: %s, Durable: %d, ExpiryPolicy: %s, Timeout: %d, "+
-		"Dynamic: %t, DynamicNodeProperties: %v, DistributionMode: %s, Filter: %v, DefaultOutcome: %v"+
+		"Dynamic: %t, DynamicNodeProperties: %v, DistributionMode: %s, Filter: %v, DefaultOutcome: %v "+
 		"Outcomes: %v, Capabilities: %v}",
 		s.Address,
 		s.Durable,
@@ -1210,7 +1210,7 @@ type PerformDisposition struct {
 func (d *PerformDisposition) frameBody() {}
 
 func (d PerformDisposition) String() string {
-	return fmt.Sprintf("Disposition{Role: %s, First: %d, Last: %s, Settled: %t, State: %s, Batchable: %t}",
+	return fmt.Sprintf("Disposition{Role: %s, First: %d, Last: %s, Settled: %t, State: %v, Batchable: %t}",
 		d.Role,
 		d.First,
 		formatUint32Ptr(d.Last),

--- a/link_test.go
+++ b/link_test.go
@@ -459,26 +459,4 @@ func TestSessionFlowDisablesTransfer(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
-func TestExactlyOnceDoesntWork(t *testing.T) {
-	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
-
-	client, err := NewConn(netConn, nil)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	session, err := client.NewSession(ctx, nil)
-	cancel()
-	require.NoError(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := session.NewSender(ctx, "doesntwork", &SenderOptions{
-		SettlementMode:              SenderSettleModeMixed.Ptr(),
-		RequestedReceiverSettleMode: ReceiverSettleModeSecond.Ptr(),
-	})
-	cancel()
-	require.Error(t, err)
-	require.Nil(t, snd)
-	require.NoError(t, client.Close())
-}
-
 // TODO: echo flow frame

--- a/session.go
+++ b/session.go
@@ -545,6 +545,26 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 		case fr := <-s.tx:
 			switch fr := fr.(type) {
+			case *frames.PerformDisposition:
+				if fr.Settled && fr.Role == encoding.RoleSender {
+					// sender with a peer that's in mode second; sending confirmation of disposition
+					start := fr.First
+					end := start
+					if fr.Last != nil {
+						end = *fr.Last
+					}
+					for deliveryID := start; deliveryID <= end; deliveryID++ {
+						if done, ok := settlementByDeliveryID[deliveryID]; ok {
+							delete(settlementByDeliveryID, deliveryID)
+							select {
+							case done <- fr.State:
+							default:
+							}
+							close(done)
+						}
+					}
+				}
+				_ = s.txFrame(fr, nil)
 			case *frames.PerformFlow:
 				niID := nextIncomingID
 				fr.NextIncomingID = &niID


### PR DESCRIPTION
When a sender's peer is in mode second, the disposition confirmation must be sent through the session so that the in-flight disposition tracker can be closed.

Fixes https://github.com/Azure/go-amqp/issues/85