### PR TITLE
Ensure outgoing delivery IDs are sequential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Fixed an issue that could cause `Conn.connReader()` to become blocked in rare circumstances.
 
+### Bugs Fixed
+
+* Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
+
 ### Other Changes
 
 * The connection mux goroutine has been removed, eliminating a potential source of deadlocks.

--- a/sender.go
+++ b/sender.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/Azure/go-amqp/internal/buffer"
 	"github.com/Azure/go-amqp/internal/debug"
@@ -110,7 +109,6 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 		maxPayloadSize = int64(s.l.session.conn.peerMaxFrameSize) - maxTransferFrameHeader
 		sndSettleMode  = s.l.senderSettleMode
 		senderSettled  = sndSettleMode != nil && (*sndSettleMode == SenderSettleModeSettled || (*sndSettleMode == SenderSettleModeMixed && msg.SendSettled))
-		deliveryID     = atomic.AddUint32(&s.l.session.nextDeliveryID, 1)
 	)
 
 	deliveryTag := msg.DeliveryTag
@@ -123,7 +121,7 @@ func (s *Sender) send(ctx context.Context, msg *Message) (chan encoding.Delivery
 
 	fr := frames.PerformTransfer{
 		Handle:        s.l.handle,
-		DeliveryID:    &deliveryID,
+		DeliveryID:    &needsDeliveryID,
 		DeliveryTag:   deliveryTag,
 		MessageFormat: &msg.Format,
 		More:          s.buf.Len() > 0,

--- a/sender_test.go
+++ b/sender_test.go
@@ -459,7 +459,7 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 			return mocks.SenderAttach(0, tt.Name, 0, SenderSettleModeUnsettled)
 		case *frames.PerformTransfer:
 			// reject first delivery
-			if *tt.DeliveryID == 1 {
+			if *tt.DeliveryID == 0 {
 				return mocks.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateRejected{
 					Error: &Error{
 						Condition:   "rejected",


### PR DESCRIPTION
Assign delivery IDs to outgoing transfers from the session mux to ensure the IDs are in sequence.
Fixed an off-by-one error to ensure that the outgoing transfer ID aligns with the value sent by the flow frame.

Fixes
- https://github.com/Azure/go-amqp/issues/135
- https://github.com/Azure/go-amqp/issues/183