### PR TITLE
Fix potential deadlock in connReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.18.1 (Unreleased)
 
+### Bugs Fixed
+
+* Fixed an issue that could cause `Conn.connReader()` to become blocked in rare circumstances.
+
 ### Other Changes
 
 * The connection mux goroutine has been removed, eliminating a potential source of deadlocks.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,14 +61,14 @@ jobs:
           pushd $(Pipeline.Workspace)/azure-amqp/test/TestAmqpBroker
           dotnet restore
           dotnet build
-          chmod +x $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net461/TestAmqpBroker.exe
+          chmod +x $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net462/TestAmqpBroker.exe
         displayName: 'Clone and Build Broker'
 
       - script: |
           set -e
           export TEST_CORPUS=1
           echo '##[command]Starting broker at $(AMQP_BROKER_ADDR)'
-          $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net461/TestAmqpBroker.exe $AMQP_BROKER_ADDR /headless &
+          $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net462/TestAmqpBroker.exe $AMQP_BROKER_ADDR /headless &
           brokerPID=$!
           echo '##[section]Starting tests'
           go test -tags -race -v -coverprofile=coverage.txt -covermode atomic ./... 2>&1 | tee gotestoutput.log 

--- a/conn.go
+++ b/conn.go
@@ -150,7 +150,7 @@ type Conn struct {
 
 	// conn state
 	done    chan struct{} // indicates the connection has terminated
-	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of conn.go until Done has been closed!
+	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of conn.go until done has been closed!
 
 	// connReader and connWriter management
 	rxtxExit  chan struct{} // signals connReader and connWriter to exit
@@ -515,6 +515,10 @@ func (c *Conn) connReader() {
 
 		select {
 		case session.rx <- fr:
+			// sent to session
+		case <-session.done:
+			// the session has terminated (or at least its mux has)
+			// we should only hit this if a session's mux abnormally terminated
 		case <-c.rxtxExit:
 			return
 		}

--- a/link.go
+++ b/link.go
@@ -111,7 +111,7 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		return ctx.Err()
 	case <-l.session.done:
 		// session has terminated, no need to deallocate in this case
-		return l.session.err
+		return l.session.doneErr
 	case fr = <-l.rx:
 	}
 	debug.Log(3, "RX (attachLink): %s", fr)
@@ -141,7 +141,7 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			}()
 			return ctx.Err()
 		case <-l.session.done:
-			return l.session.err
+			return l.session.doneErr
 		case fr = <-l.rx:
 			l.session.deallocateHandle(l)
 		}
@@ -314,7 +314,7 @@ Loop:
 			}
 		case <-l.session.done:
 			if l.err == nil {
-				l.err = l.session.err
+				l.err = l.session.doneErr
 			}
 			return
 		}
@@ -346,7 +346,7 @@ Loop:
 		// connection has ended
 		case <-l.session.done:
 			if l.err == nil {
-				l.err = l.session.err
+				l.err = l.session.doneErr
 			}
 			return
 		}

--- a/receiver.go
+++ b/receiver.go
@@ -588,7 +588,7 @@ func (r *Receiver) mux() {
 			r.l.err = &DetachError{}
 			return
 		case <-r.l.session.done:
-			r.l.err = r.l.session.err
+			r.l.err = r.l.session.doneErr
 			return
 		}
 	}
@@ -635,7 +635,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 		case <-r.l.close:
 			return &DetachError{}
 		case <-r.l.session.done:
-			return r.l.session.err
+			return r.l.session.doneErr
 		}
 	}
 }

--- a/sender.go
+++ b/sender.go
@@ -332,7 +332,7 @@ Loop:
 					s.l.err = &DetachError{}
 					return
 				case <-s.l.session.done:
-					s.l.err = s.l.session.err
+					s.l.err = s.l.session.doneErr
 					return
 				}
 			}
@@ -341,7 +341,7 @@ Loop:
 			s.l.err = &DetachError{}
 			return
 		case <-s.l.session.done:
-			s.l.err = s.l.session.err
+			s.l.err = s.l.session.doneErr
 			return
 		}
 	}


### PR DESCRIPTION
If a session's mux terminates before connReader attempts to send it a frame, connReader will become blocked.
Renamed Session.err to follow pattern used in other places.

Inspired by https://github.com/Azure/go-amqp/issues/216