### PR TITLE
Clarify that Conn IdleTimeout is not in milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * The connection mux goroutine has been removed, eliminating a potential source of deadlocks.
 * Automatic link flow control is built on the manual creditor.
 * Clarified docs that messages received from a sender configured in a mode other than `SenderSettleModeSettled` must be acknowledged.
+* Clarified default value for `Conn.IdleTimeout` and removed unit prefix.
 
 ## 0.18.0 (2022-12-06)
 

--- a/conn.go
+++ b/conn.go
@@ -38,12 +38,12 @@ type ConnOptions struct {
 	// Open frame and TLS ServerName (if not otherwise set).
 	HostName string
 
-	// IdleTimeout specifies the maximum period in milliseconds between
+	// IdleTimeout specifies the maximum period between
 	// receiving frames from the peer.
 	//
 	// Specify a value less than zero to disable idle timeout.
 	//
-	// Default: 1 minute.
+	// Default: 1 minute (60000000000).
 	IdleTimeout time.Duration
 
 	// MaxFrameSize sets the maximum frame size that


### PR DESCRIPTION
With the default value for `Conn.IdleTimeout` being set as `1 * time.Minute`, that results in `60000000000` or `1 * 60 * 1000 * 1000 * 1000 * time.Nanosecond`, as opposed to `60000.` Caused me a tiny headache when I tried setting it to actual millisecond values as I could not establish a connection.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [-] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [-] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
