### PR TITLE
Add context.Context param to Dial and NewConn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.19.0 (Unreleased)
+
+### Breaking Changes
+
+* `Dial()` and `NewConn()` now require a `context.Context` as their first parameter.
+  * As a result, the `ConnOptions.Timeout` field has been removed.
+
 ## 0.18.1 (2023-01-17)
 
 ### Bugs Fixed

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -14,13 +14,15 @@ func BenchmarkSimple(b *testing.B) {
 	if localBrokerAddr == "" {
 		b.Skip()
 	}
-	client, err := amqp.Dial(localBrokerAddr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -66,15 +66,6 @@ type ConnOptions struct {
 	// SASLType contains the specified SASL authentication mechanism.
 	SASLType SASLType
 
-	// Timeout configures how long to wait for the
-	// server during connection establishment.
-	//
-	// Once the connection has been established, IdleTimeout
-	// applies. If duration is zero, no timeout will be applied.
-	//
-	// Default: 0.
-	Timeout time.Duration
-
 	// TLSConfig sets the tls.Config to be used during
 	// TLS negotiation.
 	//
@@ -95,12 +86,13 @@ type ConnOptions struct {
 // credentials, equal to passing ConnSASLPlain option.
 //
 // opts: pass nil to accept the default values.
-func Dial(addr string, opts *ConnOptions) (*Conn, error) {
-	c, err := dialConn(addr, opts)
+func Dial(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
+	deadline, _ := ctx.Deadline()
+	c, err := dialConn(deadline, addr, opts)
 	if err != nil {
 		return nil, err
 	}
-	err = c.start()
+	err = c.start(deadline)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +101,13 @@ func Dial(addr string, opts *ConnOptions) (*Conn, error) {
 
 // NewConn establishes a new AMQP client connection over conn.
 // opts: pass nil to accept the default values.
-func NewConn(conn net.Conn, opts *ConnOptions) (*Conn, error) {
+func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, error) {
 	c, err := newConn(conn, opts)
 	if err != nil {
 		return nil, err
 	}
-	err = c.start()
+	deadline, _ := ctx.Deadline()
+	err = c.start(deadline)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +116,8 @@ func NewConn(conn net.Conn, opts *ConnOptions) (*Conn, error) {
 
 // Conn is an AMQP connection.
 type Conn struct {
-	net            net.Conn      // underlying connection
-	connectTimeout time.Duration // time to wait for reads/writes during conn establishment
-	dialer         dialer        // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	net    net.Conn // underlying connection
+	dialer dialer   // used for testing purposes, it allows faking dialing TCP/TLS endpoints
 
 	// TLS
 	tlsNegotiation bool        // negotiate TLS
@@ -175,26 +167,26 @@ type Conn struct {
 
 // used to abstract the underlying dialer for testing purposes
 type dialer interface {
-	NetDialerDial(c *Conn, host, port string) error
-	TLSDialWithDialer(c *Conn, host, port string) error
+	NetDialerDial(deadline time.Time, c *Conn, host, port string) error
+	TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) error
 }
 
 // implements the dialer interface
 type defaultDialer struct{}
 
-func (defaultDialer) NetDialerDial(c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Timeout: c.connectTimeout}
+func (defaultDialer) NetDialerDial(deadline time.Time, c *Conn, host, port string) (err error) {
+	dialer := &net.Dialer{Deadline: deadline}
 	c.net, err = dialer.Dial("tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func (defaultDialer) TLSDialWithDialer(c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Timeout: c.connectTimeout}
+func (defaultDialer) TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) (err error) {
+	dialer := &net.Dialer{Deadline: deadline}
 	c.net, err = tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, port), c.tlsConfig)
 	return
 }
 
-func dialConn(addr string, opts *ConnOptions) (*Conn, error) {
+func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -229,11 +221,11 @@ func dialConn(addr string, opts *ConnOptions) (*Conn, error) {
 
 	switch u.Scheme {
 	case "amqp", "":
-		err = c.dialer.NetDialerDial(c, host, port)
+		err = c.dialer.NetDialerDial(deadline, c, host, port)
 	case "amqps", "amqp+ssl":
 		c.initTLSConfig()
 		c.tlsNegotiation = false
-		err = c.dialer.TLSDialWithDialer(c, host, port)
+		err = c.dialer.TLSDialWithDialer(deadline, c, host, port)
 	default:
 		err = fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
@@ -290,9 +282,6 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 			return nil, err
 		}
 	}
-	if opts.Timeout > 0 {
-		c.connectTimeout = opts.Timeout
-	}
 	if opts.Properties != nil {
 		c.properties = make(map[encoding.Symbol]any)
 		for key, val := range opts.Properties {
@@ -322,7 +311,12 @@ func (c *Conn) initTLSConfig() {
 
 // start establishes the connection and begins multiplexing network IO.
 // It is an error to call Start() on a connection that's been closed.
-func (c *Conn) start() error {
+func (c *Conn) start(deadline time.Time) error {
+	if !deadline.IsZero() {
+		// set connection establishment deadline
+		_ = c.net.SetDeadline(deadline)
+	}
+
 	// run connection establishment state machine
 	for state := c.negotiateProto; state != nil; {
 		var err error
@@ -334,6 +328,11 @@ func (c *Conn) start() error {
 			_ = c.Close()
 			return err
 		}
+	}
+
+	if !deadline.IsZero() {
+		// remove connection establishment deadline
+		_ = c.net.SetDeadline(time.Time{})
 	}
 
 	// we can't create the channel bitmap until the connection has been established.
@@ -614,12 +613,6 @@ func (c *Conn) connWriter() {
 		c.close()
 	}()
 
-	// disable write timeout
-	if c.connectTimeout != 0 {
-		c.connectTimeout = 0
-		_ = c.net.SetWriteDeadline(time.Time{})
-	}
-
 	var (
 		// keepalives are sent at a rate of 1/2 idle timeout
 		keepaliveInterval = c.peerIdleTimeout / 2
@@ -683,10 +676,6 @@ func (c *Conn) connWriter() {
 // writeFrame writes a frame to the network.
 // used externally by SASL only.
 func (c *Conn) writeFrame(fr frames.Frame) error {
-	if c.connectTimeout != 0 {
-		_ = c.net.SetWriteDeadline(time.Now().Add(c.connectTimeout))
-	}
-
 	// writeFrame into txBuf
 	c.txBuf.Reset()
 	err := frames.Write(&c.txBuf, fr)
@@ -711,9 +700,6 @@ func (c *Conn) writeFrame(fr frames.Frame) error {
 // writeProtoHeader writes an AMQP protocol header to the
 // network
 func (c *Conn) writeProtoHeader(pID protoID) error {
-	if c.connectTimeout != 0 {
-		_ = c.net.SetWriteDeadline(time.Now().Add(c.connectTimeout))
-	}
 	_, err := c.net.Write([]byte{'A', 'M', 'Q', 'P', byte(pID), 1, 0, 0})
 	return err
 }
@@ -802,10 +788,6 @@ func (c *Conn) readProtoHeader() (protoHeader, error) {
 	// protocol doesn't actually work this way.
 	if c.rxBuf.Len() == 0 {
 		for {
-			if c.connectTimeout != 0 {
-				_ = c.net.SetReadDeadline(time.Now().Add(c.connectTimeout))
-			}
-
 			err := c.rxBuf.ReadFromOnce(c.net)
 			if err != nil {
 				return protoHeader{}, err
@@ -815,11 +797,6 @@ func (c *Conn) readProtoHeader() (protoHeader, error) {
 			if c.rxBuf.Len() >= protoHeaderSize {
 				break
 			}
-		}
-
-		// reset outside the loop
-		if c.connectTimeout != 0 {
-			_ = c.net.SetReadDeadline(time.Time{})
 		}
 	}
 
@@ -973,11 +950,6 @@ func (c *Conn) saslOutcome() (stateFunc, error) {
 //
 // After setup, conn.connReader handles incoming frames.
 func (c *Conn) readSingleFrame() (frames.Frame, error) {
-	if c.connectTimeout != 0 {
-		_ = c.net.SetDeadline(time.Now().Add(c.connectTimeout))
-		defer func() { _ = c.net.SetDeadline(time.Time{}) }()
-	}
-
 	fr, err := c.readFrame()
 	if err != nil {
 		return frames.Frame{}, err

--- a/conn.go
+++ b/conn.go
@@ -312,10 +312,8 @@ func (c *Conn) initTLSConfig() {
 // start establishes the connection and begins multiplexing network IO.
 // It is an error to call Start() on a connection that's been closed.
 func (c *Conn) start(deadline time.Time) error {
-	if !deadline.IsZero() {
-		// set connection establishment deadline
-		_ = c.net.SetDeadline(deadline)
-	}
+	// set connection establishment deadline
+	_ = c.net.SetDeadline(deadline)
 
 	// run connection establishment state machine
 	for state := c.negotiateProto; state != nil; {
@@ -330,10 +328,8 @@ func (c *Conn) start(deadline time.Time) error {
 		}
 	}
 
-	if !deadline.IsZero() {
-		// remove connection establishment deadline
-		_ = c.net.SetDeadline(time.Time{})
-	}
+	// remove connection establishment deadline
+	_ = c.net.SetDeadline(time.Time{})
 
 	// we can't create the channel bitmap until the connection has been established.
 	// this is because our peer can tell us the max channels they support.

--- a/example_test.go
+++ b/example_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 func Example() {
+	ctx := context.TODO()
+
 	// create connection
-	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+	conn, err := amqp.Dial(ctx, "amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
 		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
 	})
 	if err != nil {
 		log.Fatal("Dialing AMQP server:", err)
 	}
 	defer conn.Close()
-
-	ctx := context.TODO()
 
 	// open a session
 	session, err := conn.NewSession(ctx, nil)
@@ -84,15 +84,15 @@ func ExampleConnError() {
 	// *ConnErrors are returned when the underlying connection has been closed.
 	// this error is propagated to all child Session, Sender, and Receiver instances.
 
+	ctx := context.TODO()
+
 	// create connection
-	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+	conn, err := amqp.Dial(ctx, "amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
 		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
 	})
 	if err != nil {
 		log.Fatal("Dialing AMQP server:", err)
 	}
-
-	ctx := context.TODO()
 
 	// open a session
 	session, err := conn.NewSession(ctx, nil)
@@ -134,16 +134,16 @@ func ExampleSessionError() {
 	// *SessionErrors are returned when a session has been closed.
 	// this error is propagated to all child Sender and Receiver instances.
 
+	ctx := context.TODO()
+
 	// create connection
-	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+	conn, err := amqp.Dial(ctx, "amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
 		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
 	})
 	if err != nil {
 		log.Fatal("Dialing AMQP server:", err)
 	}
 	defer conn.Close()
-
-	ctx := context.TODO()
 
 	// open a session
 	session, err := conn.NewSession(ctx, nil)
@@ -180,16 +180,16 @@ func ExampleDetachError() {
 	// it can also be returned if the peer has detached from the link. in this case, the *RemoteErr
 	// field should contain additional information about why the peer detached.
 
+	ctx := context.TODO()
+
 	// create connection
-	conn, err := amqp.Dial("amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+	conn, err := amqp.Dial(ctx, "amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
 		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
 	})
 	if err != nil {
 		log.Fatal("Dialing AMQP server:", err)
 	}
 	defer conn.Close()
-
-	ctx := context.TODO()
 
 	// open a session
 	session, err := conn.NewSession(ctx, nil)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -18,11 +18,12 @@ import (
 
 func fuzzConn(data []byte) int {
 	// Receive
-	client, err := NewConn(testconn.New(data), &ConnOptions{
-		Timeout:     10 * time.Millisecond,
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	client, err := NewConn(ctx, testconn.New(data), &ConnOptions{
 		IdleTimeout: 10 * time.Millisecond,
 		SASLType:    SASLTypePlain("listen", "3aCXZYFcuZA89xe6lZkfYJvOPnTGipA3ap7NvPruBhI="),
 	})
+	cancel()
 	if err != nil {
 		return 0
 	}
@@ -57,10 +58,12 @@ func fuzzConn(data []byte) int {
 	s.Close(ctx)
 
 	// Send
-	client, err = NewConn(testconn.New(data), &ConnOptions{
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	client, err = NewConn(ctx, testconn.New(data), &ConnOptions{
 		IdleTimeout: 10 * time.Millisecond,
 		SASLType:    SASLTypePlain("listen", "3aCXZYFcuZA89xe6lZkfYJvOPnTGipA3ap7NvPruBhI="),
 	})
+	cancel()
 	if err != nil {
 		return 0
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -89,9 +89,11 @@ func TestIntegrationRoundTrip(t *testing.T) {
 			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 			// Create client
-			client, err := amqp.Dial(localBrokerAddr, &amqp.ConnOptions{
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, &amqp.ConnOptions{
 				MaxSessions: tt.sessions,
 			})
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -242,14 +244,16 @@ func TestIntegrationRoundTrip_Buffered(t *testing.T) {
 			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 			// Create client
-			client, err := amqp.Dial(localBrokerAddr, nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer client.Close()
 
 			// Open a session
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			session, err := client.NewSession(ctx, nil)
 			cancel()
 			if err != nil {
@@ -353,7 +357,9 @@ func TestIntegrationReceiverModeSecond(t *testing.T) {
 			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 			// Create client
-			client, err := amqp.Dial(localBrokerAddr, nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -502,14 +508,16 @@ func TestIntegrationSessionHandleMax(t *testing.T) {
 			// checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 			// Create client
-			client, err := amqp.Dial(localBrokerAddr, nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer client.Close()
 
 			// Open a session
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			session, err := client.NewSession(ctx, &amqp.SessionOptions{
 				MaxLinks: tt.maxLinks,
 			})
@@ -573,14 +581,16 @@ func TestIntegrationLinkName(t *testing.T) {
 		label := fmt.Sprintf("name %v", tt.name)
 		t.Run(label, func(t *testing.T) {
 			// Create client
-			client, err := amqp.Dial(localBrokerAddr, nil)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer client.Close()
 
 			// Open a session
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			session, err := client.NewSession(ctx, nil)
 			cancel()
 			if err != nil {
@@ -629,14 +639,16 @@ func TestIntegrationClose(t *testing.T) {
 		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 		// Create client
-		client, err := amqp.Dial(localBrokerAddr, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+		cancel()
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer client.Close()
 
 		// Open a session
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		session, err := client.NewSession(ctx, nil)
 		cancel()
 		if err != nil {
@@ -670,14 +682,16 @@ func TestIntegrationClose(t *testing.T) {
 		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 		// Create client
-		client, err := amqp.Dial(localBrokerAddr, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+		cancel()
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer client.Close()
 
 		// Open a session
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		session, err := client.NewSession(ctx, nil)
 		cancel()
 		if err != nil {
@@ -714,14 +728,16 @@ func TestIntegrationClose(t *testing.T) {
 		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
 		// Create client
-		client, err := amqp.Dial(localBrokerAddr, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+		cancel()
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer client.Close()
 
 		// Open a session
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		session, err := client.NewSession(ctx, nil)
 		cancel()
 		if err != nil {
@@ -763,7 +779,9 @@ func TestMultipleSessionsOpenClose(t *testing.T) {
 	checkLeaks := leaktest.Check(t)
 
 	// Create client
-	client, err := amqp.Dial(localBrokerAddr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,7 +820,9 @@ func TestConcurrentSessionsOpenClose(t *testing.T) {
 	checkLeaks := leaktest.Check(t)
 
 	// Create client
-	client, err := amqp.Dial(localBrokerAddr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,10 +860,12 @@ func TestReceiverModeFirst(t *testing.T) {
 
 	checkLeaks := leaktest.Check(t)
 
-	client, err := amqp.Dial(localBrokerAddr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -923,10 +945,12 @@ func TestSenderExactlyOnce(t *testing.T) {
 	checkLeaks := leaktest.Check(t)
 
 	// Create client
-	client, err := amqp.Dial(localBrokerAddr, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)

--- a/link_test.go
+++ b/link_test.go
@@ -434,10 +434,12 @@ func TestSessionFlowDisablesTransfer(t *testing.T) {
 	nextIncomingID := uint32(0)
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -16,9 +16,12 @@ import (
 
 func TestReceiverInvalidOptions(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -69,9 +72,11 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -95,9 +100,11 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 
 func TestReceiverLinkSourceFilter(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -122,9 +129,11 @@ func TestReceiverLinkSourceFilter(t *testing.T) {
 
 func TestReceiverOnClosed(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -153,9 +162,11 @@ func TestReceiverOnClosed(t *testing.T) {
 
 func TestReceiverOnSessionClosed(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -181,9 +192,11 @@ func TestReceiverOnSessionClosed(t *testing.T) {
 
 func TestReceiverOnConnClosed(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -212,9 +225,11 @@ func TestReceiverOnConnClosed(t *testing.T) {
 
 func TestReceiverOnDetached(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -265,9 +280,11 @@ func TestReceiveInvalidMessage(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -375,9 +392,11 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -445,9 +464,11 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -525,9 +546,11 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptOnClosedLink(t *testing.T) 
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -586,9 +609,11 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -660,9 +685,11 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -739,9 +766,11 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -839,9 +868,11 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -918,9 +949,11 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1028,9 +1061,11 @@ func TestReceiveMultiFrameMessageAborted(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1089,9 +1124,11 @@ func TestReceiveMessageTooBig(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1133,9 +1170,11 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1198,9 +1237,11 @@ func TestReceiverDispositionBatcherTimer(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1264,9 +1305,11 @@ func TestReceiverDispositionBatcherFull(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1338,9 +1381,11 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 		}
 	}
 	conn := mocks.NewNetConn(responder)
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1389,9 +1434,11 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 
 func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1416,9 +1463,11 @@ func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
 
 func TestReceiverConnReaderError(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1450,9 +1499,11 @@ func TestReceiverConnReaderError(t *testing.T) {
 
 func TestReceiverConnWriterError(t *testing.T) {
 	conn := mocks.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
-	client, err := NewConn(conn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -104,10 +105,12 @@ func TestConnSASLXOAUTH2AuthSuccess(t *testing.T) {
 	}
 
 	c := testconn.New(buf)
-	client, err := NewConn(c, &ConnOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	client, err := NewConn(ctx, c, &ConnOptions{
 		IdleTimeout: 10 * time.Minute,
 		SASLType:    SASLTypeXOAUTH2("someuser@example.com", "ya29.vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg", 512),
 	})
+	cancel()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,10 +137,12 @@ func TestConnSASLXOAUTH2AuthFail(t *testing.T) {
 	}
 
 	c := testconn.New(buf)
-	client, err := NewConn(c, &ConnOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	client, err := NewConn(ctx, c, &ConnOptions{
 		IdleTimeout: 10 * time.Minute,
 		SASLType:    SASLTypeXOAUTH2("someuser@example.com", "ya29.vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg", 512),
 	})
+	cancel()
 	if err == nil {
 		defer client.Close()
 	}
@@ -174,10 +179,12 @@ func TestConnSASLXOAUTH2AuthFailWithErrorResponse(t *testing.T) {
 	}
 
 	c := testconn.New(buf)
-	client, err := NewConn(c, &ConnOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	client, err := NewConn(ctx, c, &ConnOptions{
 		IdleTimeout: 10 * time.Minute,
 		SASLType:    SASLTypeXOAUTH2("someuser@example.com", "ya29.vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg", 512),
 	})
+	cancel()
 	if err == nil {
 		defer client.Close()
 	}
@@ -214,10 +221,12 @@ func TestConnSASLXOAUTH2AuthFailsAdditionalErrorResponse(t *testing.T) {
 	}
 
 	c := testconn.New(buf)
-	client, err := NewConn(c, &ConnOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	client, err := NewConn(ctx, c, &ConnOptions{
 		IdleTimeout: 10 * time.Minute,
 		SASLType:    SASLTypeXOAUTH2("someuser@example.com", "ya29.vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg", 512),
 	})
+	cancel()
 	if err == nil {
 		defer client.Close()
 	}
@@ -255,10 +264,12 @@ func TestConnSASLExternal(t *testing.T) {
 	}
 
 	c := testconn.New(buf)
-	client, err := NewConn(c, &ConnOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	client, err := NewConn(ctx, c, &ConnOptions{
 		IdleTimeout: 10 * time.Minute,
 		SASLType:    SASLTypeExternal(""),
 	})
+	cancel()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sender_test.go
+++ b/sender_test.go
@@ -17,10 +17,12 @@ import (
 func TestSenderInvalidOptions(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -60,10 +62,12 @@ func TestSenderMethodsNoSend(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -92,10 +96,12 @@ func TestSenderMethodsNoSend(t *testing.T) {
 func TestSenderSendOnClosed(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -118,10 +124,12 @@ func TestSenderSendOnClosed(t *testing.T) {
 func TestSenderSendOnSessionClosed(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -147,10 +155,12 @@ func TestSenderSendOnSessionClosed(t *testing.T) {
 func TestSenderSendOnConnClosed(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -173,10 +183,12 @@ func TestSenderSendOnConnClosed(t *testing.T) {
 func TestSenderSendOnDetached(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -205,7 +217,7 @@ func TestSenderSendOnDetached(t *testing.T) {
 }
 
 func TestSenderAttachError(t *testing.T) {
-	detachAck := make(chan bool)
+	detachAck := make(chan bool, 1)
 	var enqueueFrames func(string)
 	responder := func(req frames.FrameBody) ([]byte, error) {
 		switch tt := req.(type) {
@@ -231,10 +243,12 @@ func TestSenderAttachError(t *testing.T) {
 		}
 	}
 	netConn := mocks.NewNetConn(responder)
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -279,10 +293,12 @@ func TestSenderAttachError(t *testing.T) {
 func TestSenderSendMismatchedModes(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -324,10 +340,12 @@ func TestSenderSendSuccess(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -369,10 +387,12 @@ func TestSenderSendSettled(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -412,10 +432,12 @@ func TestSenderSendRejected(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -478,10 +500,12 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -529,10 +553,12 @@ func TestSenderSendDetached(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -559,10 +585,12 @@ func TestSenderSendDetached(t *testing.T) {
 func TestSenderSendTimeout(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -616,10 +644,12 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -652,10 +682,12 @@ func TestSenderSendTagTooBig(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -726,10 +758,12 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -757,10 +791,12 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 func TestSenderConnReaderError(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -790,10 +826,12 @@ func TestSenderConnReaderError(t *testing.T) {
 func TestSenderConnWriterError(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -846,10 +884,12 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -902,9 +942,11 @@ func TestNewSenderTimedOut(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -945,9 +987,11 @@ func TestNewSenderWriteError(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
-	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -992,10 +1036,12 @@ func TestNewSenderTimedOutAckTimedOut(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 	// fisrt session succeeds
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -1040,10 +1086,12 @@ func TestNewSenderContextCancelled(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)

--- a/session_test.go
+++ b/session_test.go
@@ -43,7 +43,9 @@ func TestSessionClose(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 	for i := 0; i < 4; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -79,10 +81,12 @@ func TestSessionServerClose(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -125,10 +129,12 @@ func TestSessionCloseTimeout(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -142,10 +148,12 @@ func TestSessionCloseTimeout(t *testing.T) {
 func TestConnCloseSessionClose(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -168,10 +176,12 @@ func TestConnCloseSessionClose(t *testing.T) {
 func TestSessionNewReceiverBadOptionFails(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -214,10 +224,12 @@ func TestSessionNewReceiverBatchingOneCredit(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -259,10 +271,12 @@ func TestSessionNewReceiverBatchingEnabled(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -303,10 +317,12 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -328,10 +344,12 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 func TestSessionNewSenderBadOptionFails(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -372,10 +390,12 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -394,10 +414,12 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 func TestSessionNewSenderDuplicateLinks(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -425,10 +447,12 @@ func TestSessionNewSenderDuplicateLinks(t *testing.T) {
 func TestSessionNewSenderMaxHandles(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, &SessionOptions{MaxLinks: 1})
 	cancel()
 	require.NoError(t, err)
@@ -456,10 +480,12 @@ func TestSessionNewSenderMaxHandles(t *testing.T) {
 func TestSessionUnexpectedFrame(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -479,10 +505,12 @@ func TestSessionUnexpectedFrame(t *testing.T) {
 func TestSessionInvalidFlowFrame(t *testing.T) {
 	netConn := mocks.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -539,10 +567,12 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -586,10 +616,13 @@ func TestSessionInvalidAttachDeadlock(t *testing.T) {
 		}
 	}
 	netConn := mocks.NewNetConn(responder)
-	client, err := NewConn(netConn, nil)
-	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
@@ -635,13 +668,17 @@ func TestNewSessionContextCancelled(t *testing.T) {
 			return nil, nil
 		case *frames.PerformEnd:
 			return mocks.PerformEnd(0, nil)
+		case *mocks.KeepAlive:
+			return nil, nil
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	netConn := mocks.NewNetConn(responder)
 
-	client, err := NewConn(netConn, nil)
+	newCtx, newCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(newCtx, netConn, nil)
+	newCancel()
 	require.NoError(t, err)
 
 	session, err := client.NewSession(ctx, nil)


### PR DESCRIPTION
Removed ConnOptions.Timeout as it's no longer required.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
