### PR TITLE
Don't discard incoming frames while closing a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 * Enabled support for senders in an at-most-once configuration.
 * Don't discard incoming frames while closing a Session.
+* Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * `Dial()` and `NewConn()` now require a `context.Context` as their first parameter.
   * As a result, the `ConnOptions.Timeout` field has been removed.
 
+### Bugs Fixed
+
+* Don't discard incoming frames while closing a Session.
+* Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
+
 ## 0.18.1 (2023-01-17)
 
 ### Bugs Fixed
@@ -15,8 +20,6 @@
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 * Enabled support for senders in an at-most-once configuration.
-* Don't discard incoming frames while closing a Session.
-* Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 * Enabled support for senders in an at-most-once configuration.
+* Don't discard incoming frames while closing a Session.
 
 ### Other Changes
 

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -1310,6 +1310,10 @@ type PerformEnd struct {
 
 func (e *PerformEnd) frameBody() {}
 
+func (d PerformEnd) String() string {
+	return fmt.Sprintf("End{Error: %v}", d.Error)
+}
+
 func (e *PerformEnd) Marshal(wr *buffer.Buffer) error {
 	return encoding.MarshalComposite(wr, encoding.TypeCodeEnd, []encoding.MarshalField{
 		{Value: e.Error, Omit: e.Error == nil},

--- a/session.go
+++ b/session.go
@@ -417,6 +417,12 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				link, linkOk := s.linksByKey[linkKey{name: body.Name, role: !body.Role}]
 				s.linksMu.RUnlock()
 				if !linkOk {
+					_ = s.txFrame(&frames.PerformEnd{
+						Error: &Error{
+							Condition:   ErrCondNotAllowed,
+							Description: "received mismatched attach frame",
+						},
+					}, nil)
 					s.doneErr = fmt.Errorf("protocol error: received mismatched attach frame %+v", body)
 					return
 				}

--- a/session.go
+++ b/session.go
@@ -60,11 +60,13 @@ type Session struct {
 	linksByKey map[linkKey]*link // mapping of name+role link
 	handles    *bitmap.Bitmap    // allocated handles
 
-	// used for gracefully closing link
+	// used for gracefully closing session
 	close     chan struct{}
 	closeOnce sync.Once
-	done      chan struct{} // part of internal public surface area
-	doneErr   error         // contains the error state returned from Close(); DO NOT TOUCH outside of session.go until done has been closed!
+
+	// part of internal public surface area
+	done    chan struct{} // closed when the session has terminated
+	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of session.go until done has been closed!
 }
 
 func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
@@ -167,11 +169,14 @@ func (s *Session) begin(ctx context.Context) error {
 // The session will continue to wait for the response until the Client is closed.
 func (s *Session) Close(ctx context.Context) error {
 	s.closeOnce.Do(func() { close(s.close) })
+
 	select {
 	case <-s.done:
+		// mux has exited
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
 	var sessionErr *SessionError
 	if errors.As(s.doneErr, &sessionErr) && sessionErr.RemoteErr == nil && sessionErr.inner == nil {
 		// an empty SessionError means the session was closed by the caller
@@ -264,6 +269,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		nextIncomingID       = remoteBegin.NextOutgoingID
 		remoteIncomingWindow = remoteBegin.IncomingWindow
 		remoteOutgoingWindow = remoteBegin.OutgoingWindow
+
+		clientClosed bool // indicates a client-side close
 	)
 
 	for {
@@ -276,6 +283,12 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			txTransfer = nil
 		}
 
+		closed := s.close
+		if clientClosed {
+			// swap out channel so it no longer triggers
+			closed = nil
+		}
+
 		select {
 		// conn has completed, exit
 		case <-s.conn.done:
@@ -283,28 +296,14 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			return
 
 		// session is being closed by user
-		case <-s.close:
-			_ = s.txFrame(&frames.PerformEnd{}, nil)
+		case <-closed:
+			clientClosed = true
+			fr := frames.PerformEnd{}
+			debug.Log(1, "TX(Session): %s", fr)
+			_ = s.txFrame(&fr, nil)
+			// TODO: per spec, after end has been sent, the session is no longer allowed to send frames
 
-			// wait for the ack that the session is closed.
-			// we can't exit the mux, which deletes the session,
-			// until we receive it.
-		EndLoop:
-			for {
-				select {
-				case fr := <-s.rx:
-					_, ok := fr.Body.(*frames.PerformEnd)
-					if ok {
-						break EndLoop
-					}
-				case <-s.conn.done:
-					s.doneErr = s.conn.doneErr
-					return
-				}
-			}
-			return
-
-		// incoming frame for link
+		// incoming frame
 		case fr := <-s.rx:
 			debug.Log(1, "RX(Session): %s", fr.Body)
 
@@ -488,10 +487,24 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				delete(deliveryIDByHandle, link.handle)
 
 			case *frames.PerformEnd:
-				_ = s.txFrame(&frames.PerformEnd{}, nil)
+				// there are two possibilities:
+				// - this is the ack to a client-side Close()
+				// - the peer is ending the session so we must ack
+
+				if clientClosed {
+					return
+				}
+
+				// TODO: per spec, when end is received, we're no longer allowed to receive frames
+
+				// peer detached us with an error, save it and send the ack
 				if body.Error != nil {
 					s.doneErr = body.Error
 				}
+
+				fr := frames.PerformEnd{}
+				debug.Log(1, "TX(Session): %s", fr)
+				_ = s.txFrame(&fr, nil)
 				return
 
 			default:


### PR DESCRIPTION
Keep the session mux running until the acknowledging end performative has been received.
Added fmt.Stringer implementation to PerformEnd.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
