### PR TITLE
Refactor link termination handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 * Enabled support for senders in an at-most-once configuration.
+* Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Don't discard incoming frames while closing a Session.
 * Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
+* Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
 
 ## 0.18.1 (2023-01-17)
 
@@ -20,7 +21,6 @@
 * Fixed an issue that could cause outgoing transfers to be rejected by some brokers due to out-of-sequence delivery IDs.
 * Fixed an issue that could cause senders and receivers within the same session to deadlock if the receiver was configured with `ReceiverSettleModeFirst`.
 * Enabled support for senders in an at-most-once configuration.
-* Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
 
 ### Other Changes
 

--- a/creditor.go
+++ b/creditor.go
@@ -88,8 +88,8 @@ func (mc *creditor) Drain(ctx context.Context, r *Receiver) error {
 	select {
 	case <-drained:
 		return nil
-	case <-r.l.detached:
-		return r.l.detachError
+	case <-r.l.done:
+		return r.l.doneErr
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/creditor_test.go
+++ b/creditor_test.go
@@ -132,8 +132,8 @@ func TestCreditorDrainReturnsProperError(t *testing.T) {
 			mc := creditor{}
 			link := newTestLink(t)
 
-			link.l.detachError = err
-			close(link.l.detached)
+			link.l.doneErr = err
+			close(link.l.done)
 
 			detachErr := mc.Drain(ctx, link)
 			require.Equal(t, err, detachErr)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -123,8 +123,8 @@ func waitForReceiver(r *Receiver, paused bool) error {
 			return err
 		}
 		select {
-		case <-r.l.detached:
-			return fmt.Errorf("link detached: detachErr %v, error %v", r.l.detachError, r.l.err)
+		case <-r.l.done:
+			return fmt.Errorf("link terminated:  %v", r.l.doneErr)
 		case <-time.After(50 * time.Millisecond):
 			// try again
 		}

--- a/link_test.go
+++ b/link_test.go
@@ -235,7 +235,7 @@ func newTestLink(t *testing.T) *Receiver {
 			source: &frames.Source{},
 			// adding just enough so the debug() print will still work...
 			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.l.availableCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
-			detached: make(chan struct{}),
+			done: make(chan struct{}),
 			session: &Session{
 				tx:   make(chan frames.FrameBody, 100),
 				done: make(chan struct{}),

--- a/session.go
+++ b/session.go
@@ -637,9 +637,9 @@ func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	select {
 	case l.rx <- fr:
 		// frame successfully sent to link
-	case <-l.detached:
+	case <-l.done:
 		// link is closed
-		// this should be impossible to hit as the link has been removed from the session once Detached is closed
+		// this should be impossible to hit as the link has been removed from the session once done is closed
 	case <-s.conn.done:
 		// conn is closed
 	}


### PR DESCRIPTION
Mostly this renamed internal fields to be consistent with the patterns established in Conn and Session.
Fixed a bug in Drain() that could return the wrong error.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
