### PR TITLE
Move detachError field to Receiver

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -38,6 +38,7 @@ type Receiver struct {
 	msgBuf                buffer.Buffer       // buffered bytes for current message
 	more                  bool                // if true, buf contains a partial message
 	msg                   Message             // current message being decoded
+	detachError           *Error              // error to send to peer on detach/close, set by closeWithError; NOT why link was terminated
 
 	autoSendFlow bool                    // automatically send flow frames as credit becomes available
 	batching     bool                    // enable batching of message dispositions
@@ -232,9 +233,7 @@ func (r *Receiver) Close(ctx context.Context) error {
 // returns the error passed in
 func (r *Receiver) closeWithError(de *Error) error {
 	r.l.closeOnce.Do(func() {
-		r.l.detachErrorMu.Lock()
-		r.l.detachError = de
-		r.l.detachErrorMu.Unlock()
+		r.detachError = de
 		close(r.l.close)
 	})
 	return &DetachError{inner: de}
@@ -542,7 +541,7 @@ func (r *Receiver) attach(ctx context.Context) error {
 }
 
 func (r *Receiver) mux() {
-	defer r.l.muxDetach(context.Background(), func() {
+	defer r.l.muxClose(context.Background(), r.detachError, func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
 

--- a/sender.go
+++ b/sender.go
@@ -281,7 +281,7 @@ func (s *Sender) attach(ctx context.Context) error {
 }
 
 func (s *Sender) mux() {
-	defer s.l.muxDetach(context.Background(), nil, nil)
+	defer s.l.muxClose(context.Background(), nil, nil, nil)
 
 	// used to track and send disposition frames.
 	// frames are sent in FIFO order.


### PR DESCRIPTION
It's only used by Receiver to send an error when detaching due to an error condition.
Renamed muxDetach to muxClose.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
