### PR TITLE
Fix potential hang when closing a receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
 * Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
 * Ensure that `Receiver.Receive()` drains prefetched messages when the link closed.
+* Fixed an issue that could cause closing a `Receiver` to hang under certain circumstances.
 
 ## 0.18.1 (2023-01-17)
 

--- a/link.go
+++ b/link.go
@@ -37,7 +37,7 @@ type link struct {
 	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
 	closeOnce sync.Once     // closeOnce protects close from being closed multiple times
 
-	done    chan struct{} // closed when the link has terminated
+	done    chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
 	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of link.go until done has been closed!
 
 	session    *Session                // parent session

--- a/receiver.go
+++ b/receiver.go
@@ -833,12 +833,8 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	if !r.msg.settled {
 		r.addUnsettled(&r.msg)
 	}
-	select {
-	case r.messages <- r.msg:
-		// message received
-	case <-r.l.done:
-		// link has terminated
-		return r.l.doneErr
+	if !r.muxMsg() {
+		return nil
 	}
 
 	debug.Log(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.l.deliveryCount, r.l.availableCredit, len(r.messages), r.inFlight.len())

--- a/receiver.go
+++ b/receiver.go
@@ -51,7 +51,7 @@ type Receiver struct {
 
 // IssueCredit adds credits to be requested in the next flow request.
 // Attempting to issue more credit than the receiver's max credit as
-// specified in ReceiverOptions.Credit will result in an error.
+// specified in ReceiverOptions.MaxCredit will result in an error.
 func (r *Receiver) IssueCredit(credit uint32) error {
 	if r.autoSendFlow {
 		return errors.New("issueCredit can only be used with receiver links using manual credit management")

--- a/receiver.go
+++ b/receiver.go
@@ -49,8 +49,9 @@ type Receiver struct {
 	creditor     creditor                // manages credits via calls to IssueCredit/DrainCredit
 }
 
-// IssueCredit adds credits to be requested in the next flow
-// request.
+// IssueCredit adds credits to be requested in the next flow request.
+// Attempting to issue more credit than the receiver's max credit as
+// specified in ReceiverOptions.Credit will result in an error.
 func (r *Receiver) IssueCredit(credit uint32) error {
 	if r.autoSendFlow {
 		return errors.New("issueCredit can only be used with receiver links using manual credit management")

--- a/receiver_debug.go
+++ b/receiver_debug.go
@@ -1,0 +1,21 @@
+//go:build debug
+// +build debug
+
+package amqp
+
+func (r *Receiver) muxMsg() bool {
+	select {
+	case r.messages <- r.msg:
+		// message received
+		// NOTE: writing to this should NEVER block.
+		// if it does, it means we have a flow control
+		// bug so our peer sent a message exceeding
+		// the link credit
+		return true
+	case <-r.l.close:
+		// client-side close
+		return false
+	default:
+		panic("writing to r.messages should not block")
+	}
+}

--- a/receiver_prod.go
+++ b/receiver_prod.go
@@ -1,0 +1,21 @@
+//go:build !debug
+// +build !debug
+
+package amqp
+
+// muxMsg sends the current decoded message to the channel of incoming messages.
+// it returns false if a client-side close has been initiated.
+func (r *Receiver) muxMsg() bool {
+	select {
+	case r.messages <- r.msg:
+		// message received
+		// NOTE: writing to this should NEVER block.
+		// if it does, it means we have a flow control
+		// bug so our peer sent a message exceeding
+		// the link credit
+		return true
+	case <-r.l.close:
+		// client-side close
+		return false
+	}
+}

--- a/session.go
+++ b/session.go
@@ -65,7 +65,7 @@ type Session struct {
 	closeOnce sync.Once
 
 	// part of internal public surface area
-	done    chan struct{} // closed when the session has terminated
+	done    chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
 	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of session.go until done has been closed!
 }
 


### PR DESCRIPTION
Select on r.l.close in muxReceive instead of r.l.done.  The latter is only closed when the mux exits, and since muxReceive is called from the mux, this case will never trigger.
Add a debug build for selecting on r.messages that will panic if it's full.  This indicates a flow control bug.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
