### PR TITLE
Rename DetachError to LinkError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Methods `Sender.Send()` and `Receiver.Receive()` now take their respective options-type as the final argument.
 * The `Credit` field in `ReceiverOptions` has been renamed to `MaxCredit` to better reflect its purpose.
 * Renamed fields in the `ReceiverOptions` for configuring options on the source.
+* Renamed `DetachError` to `LinkError` as "detach" has a specific meaning which doesn't equate to the returned link errors.
 
 ### Bugs Fixed
 

--- a/errors.go
+++ b/errors.go
@@ -47,16 +47,16 @@ const (
 // Error is an AMQP error.
 type Error = encoding.Error
 
-// DetachError is returned by methods on Sender/Receiver when the link has become detached/closed.
-type DetachError struct {
+// LinkError is returned by methods on Sender/Receiver when the link has closed.
+type LinkError struct {
 	// RemoteErr contains any error information provided by the peer if the peer detached the link.
 	RemoteErr *Error
 
 	inner error
 }
 
-// Error implements the error interface for DetachError.
-func (e *DetachError) Error() string {
+// Error implements the error interface for LinkError.
+func (e *LinkError) Error() string {
 	if e.RemoteErr == nil && e.inner == nil {
 		return "amqp: link closed"
 	} else if e.RemoteErr != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -175,10 +175,10 @@ func ExampleSessionError() {
 	}
 }
 
-func ExampleDetachError() {
-	// *DetachErrors are returned by methods on Senders/Receivers after Close() has been called.
-	// it can also be returned if the peer has detached from the link. in this case, the *RemoteErr
-	// field should contain additional information about why the peer detached.
+func ExampleLinkError() {
+	// *LinkError are returned by methods on Senders/Receivers after Close() has been called.
+	// it can also be returned if the peer has closed the link. in this case, the *RemoteErr
+	// field should contain additional information about why the peer closed the link.
 
 	ctx := context.TODO()
 
@@ -215,8 +215,8 @@ func ExampleDetachError() {
 	// attempt to send a message after close
 	err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")), nil)
 
-	var detachErr *amqp.DetachError
-	if !errors.As(err, &detachErr) {
+	var linkErr *amqp.LinkError
+	if !errors.As(err, &linkErr) {
 		log.Fatalf("unexpected error type %T", err)
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -666,8 +666,8 @@ func TestIntegrationClose(t *testing.T) {
 		testClose(t, receiver.Close)
 
 		_, err = receiver.Receive(context.Background(), nil)
-		var detachErr *amqp.DetachError
-		require.ErrorAs(t, err, &detachErr)
+		var linkErr *amqp.LinkError
+		require.ErrorAs(t, err, &linkErr)
 
 		err = client.Close() // close before leak check
 		if err != nil {

--- a/link.go
+++ b/link.go
@@ -207,16 +207,16 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 		debug.Log(1, "RX (muxHandleFrame): %s", fr)
 		// don't currently support link detach and reattach
 		if !fr.Closed {
-			return &DetachError{inner: fmt.Errorf("non-closing detach not supported: %+v", fr)}
+			return &LinkError{inner: fmt.Errorf("non-closing detach not supported: %+v", fr)}
 		}
 
 		// set detach received and close link
 		l.detachReceived = true
 
 		if fr.Error != nil {
-			return &DetachError{RemoteErr: fr.Error}
+			return &LinkError{RemoteErr: fr.Error}
 		}
-		return &DetachError{}
+		return &LinkError{}
 
 	default:
 		// TODO: evaluate
@@ -237,9 +237,9 @@ func (l *link) closeLink(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	var detachErr *DetachError
-	if errors.As(l.doneErr, &detachErr) && detachErr.inner == nil {
-		// an empty DetachError means the link was closed by the caller
+	var linkErr *LinkError
+	if errors.As(l.doneErr, &linkErr) && linkErr.inner == nil {
+		// an empty LinkError means the link was closed by the caller
 		return nil
 	}
 	return l.doneErr

--- a/link_options.go
+++ b/link_options.go
@@ -33,7 +33,7 @@ type SenderOptions struct {
 	// Default: 0.
 	ExpiryTimeout uint32
 
-	// IgnoreDispositionErrors controls automatic detach on disposition errors.
+	// IgnoreDispositionErrors controls automatic close on disposition errors.
 	//
 	// Default: false.
 	IgnoreDispositionErrors bool

--- a/link_test.go
+++ b/link_test.go
@@ -269,7 +269,7 @@ func TestNewSendingLink(t *testing.T) {
 				require.False(t, l.l.dynamicAddr)
 				require.Empty(t, l.l.source.ExpiryPolicy)
 				require.Zero(t, l.l.source.Timeout)
-				require.True(t, l.detachOnDispositionError)
+				require.True(t, l.closeOnDispositionError)
 				require.NotEmpty(t, l.l.key.name)
 				require.Empty(t, l.l.properties)
 				require.Nil(t, l.l.senderSettleMode)
@@ -299,7 +299,7 @@ func TestNewSendingLink(t *testing.T) {
 				require.True(t, l.l.dynamicAddr)
 				require.Equal(t, ExpiryPolicyLinkDetach, l.l.source.ExpiryPolicy)
 				require.Equal(t, uint32(5), l.l.source.Timeout)
-				require.False(t, l.detachOnDispositionError)
+				require.False(t, l.closeOnDispositionError)
 				require.Equal(t, name, l.l.key.name)
 				require.Equal(t, map[encoding.Symbol]any{
 					"property": 123,

--- a/receiver.go
+++ b/receiver.go
@@ -241,7 +241,7 @@ func (r *Receiver) closeWithError(de *Error) error {
 		r.detachError = de
 		close(r.l.close)
 	})
-	return &DetachError{inner: de}
+	return &LinkError{inner: de}
 }
 
 func (r *Receiver) dispositionBatcher() {
@@ -602,7 +602,7 @@ func (r *Receiver) mux() {
 		case <-r.receiverReady:
 			continue
 		case <-r.l.close:
-			r.l.doneErr = &DetachError{}
+			r.l.doneErr = &LinkError{}
 			return
 		case <-r.l.session.done:
 			// TODO: per spec, if the session has terminated, we're not allowed to send frames
@@ -651,7 +651,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 				return err
 			}
 		case <-r.l.close:
-			return &DetachError{}
+			return &LinkError{}
 		case <-r.l.session.done:
 			return r.l.session.doneErr
 		}
@@ -819,7 +819,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	// last frame in message
 	err := r.msg.Unmarshal(&r.msgBuf)
 	if err != nil {
-		return &DetachError{inner: err}
+		return &LinkError{inner: err}
 	}
 	debug.Log(1, "deliveryID %d before push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.l.deliveryCount, r.l.availableCredit, len(r.messages), r.inFlight.len())
 	// send to receiver


### PR DESCRIPTION
Detach has a specific meaning in AMQP and since we don't support link detach/reattach the error type name is misleading. Cleaned up any misused detach verbage.

Fixes https://github.com/Azure/go-amqp/issues/224