### PR TITLE
Renamed fields in ReceiverOptions for configuring source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * As a result, the `ConnOptions.Timeout` field has been removed.
 * Methods `Sender.Send()` and `Receiver.Receive()` now take their respective options-type as the final argument.
 * The `Credit` field in `ReceiverOptions` has been renamed to `MaxCredit` to better reflect its purpose.
+* Renamed fields in the `ReceiverOptions` for configuring options on the source.
 
 ### Bugs Fixed
 

--- a/link_options.go
+++ b/link_options.go
@@ -79,7 +79,7 @@ type SenderOptions struct {
 	// Default: ExpirySessionEnd.
 	TargetExpiryPolicy ExpiryPolicy
 
-	// ExpiryTimeout is the duration in seconds that the peer will be retained.
+	// TargetExpiryTimeout is the duration in seconds that the peer will be retained.
 	//
 	// Default: 0.
 	TargetExpiryTimeout uint32
@@ -180,25 +180,25 @@ type ReceiverOptions struct {
 	// TargetAddress specifies the target address for this receiver.
 	TargetAddress string
 
-	// SenderCapabilities is the list of extension capabilities the receiver desires.
-	SenderCapabilities []string
+	// SourceCapabilities is the list of extension capabilities the receiver desires.
+	SourceCapabilities []string
 
-	// SenderDurability indicates what state of the peer will be retained durably.
+	// SourceDurability indicates what state of the peer will be retained durably.
 	//
 	// Default: DurabilityNone.
-	SenderDurability Durability
+	SourceDurability Durability
 
-	// SenderExpiryPolicy determines when the expiry timer of the peer starts counting
+	// SourceExpiryPolicy determines when the expiry timer of the peer starts counting
 	// down from the timeout value.  If the link is subsequently re-attached before
 	// the timeout is reached, the count down is aborted.
 	//
 	// Default: ExpirySessionEnd.
-	SenderExpiryPolicy ExpiryPolicy
+	SourceExpiryPolicy ExpiryPolicy
 
-	// SenderExpiryTimeout is the duration in seconds that the peer will be retained.
+	// SourceExpiryTimeout is the duration in seconds that the peer will be retained.
 	//
 	// Default: 0.
-	SenderExpiryTimeout uint32
+	SourceExpiryTimeout uint32
 }
 
 // LinkFilter is an advanced API for setting non-standard source filters.

--- a/receiver.go
+++ b/receiver.go
@@ -492,17 +492,17 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		r.l.receiverSettleMode = opts.SettlementMode
 	}
 	r.l.target.Address = opts.TargetAddress
-	for _, v := range opts.SenderCapabilities {
+	for _, v := range opts.SourceCapabilities {
 		r.l.source.Capabilities = append(r.l.source.Capabilities, encoding.Symbol(v))
 	}
-	if opts.SenderDurability != DurabilityNone {
-		r.l.source.Durable = opts.SenderDurability
+	if opts.SourceDurability != DurabilityNone {
+		r.l.source.Durable = opts.SourceDurability
 	}
-	if opts.SenderExpiryPolicy != ExpiryPolicySessionEnd {
-		r.l.source.ExpiryPolicy = opts.SenderExpiryPolicy
+	if opts.SourceExpiryPolicy != ExpiryPolicySessionEnd {
+		r.l.source.ExpiryPolicy = opts.SourceExpiryPolicy
 	}
-	if opts.SenderExpiryTimeout != 0 {
-		r.l.source.Timeout = opts.SenderExpiryTimeout
+	if opts.SourceExpiryTimeout != 0 {
+		r.l.source.Timeout = opts.SourceExpiryTimeout
 	}
 	return r, nil
 }


### PR DESCRIPTION
Use the prefix Source instead of Sender as this matches the protocol terminology and aligns with the field names in SenderOptions.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
