### PR TITLE
Drain prefetched messages when Receiver is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Don't discard incoming frames while closing a Session.
 * Client-side termination of a Session due to invalid state will wait for the peer to acknowledge the Session's end.
 * Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
+* Ensure that `Receiver.Receive()` drains prefetched messages when the link closed.
 
 ## 0.18.1 (2023-01-17)
 


### PR DESCRIPTION
There's a small window where messages might arrive and the link being closed before selecting on these conditions.  Drain any messages that might have arrived.

Fixes https://github.com/Azure/go-amqp/issues/125