### PR TITLE
Make frame type a typed constant

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -357,7 +357,7 @@ func TestKeepAlives(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			// specify small idle timeout so we receive a lot of keep-alives
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{ContainerID: "container", IdleTimeout: 100 * time.Millisecond})
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformOpen{ContainerID: "container", IdleTimeout: 100 * time.Millisecond})
 		case *mocks.KeepAlive:
 			keepAlives <- struct{}{}
 			return nil, nil
@@ -391,7 +391,7 @@ func TestKeepAlivesIdleTimeout(t *testing.T) {
 		case *mocks.AMQPProto:
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{ContainerID: "container", IdleTimeout: time.Minute})
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformOpen{ContainerID: "container", IdleTimeout: time.Minute})
 		case *mocks.KeepAlive:
 			return nil, nil
 		case *frames.PerformClose:
@@ -703,7 +703,7 @@ func TestClientTooManySessions(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			// return small number of max channels
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformOpen{
 				ChannelMax:   1,
 				ContainerID:  "test",
 				IdleTimeout:  time.Minute,
@@ -750,7 +750,7 @@ func TestClientNewSessionMissingRemoteChannel(t *testing.T) {
 			return mocks.PerformOpen("container")
 		case *frames.PerformBegin:
 			// return begin with nil RemoteChannel
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformBegin{
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformBegin{
 				NextOutgoingID: 1,
 				IncomingWindow: 5000,
 				OutgoingWindow: 1000,

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -17,7 +17,7 @@ func sendInitialFlowFrame(t *testing.T, netConn *mocks.NetConn, handle uint32, c
 	nextIncoming := uint32(0)
 	count := uint32(0)
 	available := uint32(0)
-	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
+	b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
 		NextIncomingID: &nextIncoming,
 		IncomingWindow: 1000,
 		OutgoingWindow: 1000,

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -10,10 +10,21 @@ import (
 	"github.com/Azure/go-amqp/internal/encoding"
 )
 
+// Type contains the values for a frame's type.
+type Type uint8
+
 const (
-	TypeAMQP = 0x0
-	TypeSASL = 0x1
+	TypeAMQP Type = 0x0
+	TypeSASL Type = 0x1
 )
+
+// String implements the fmt.Stringer interface for type Type.
+func (t Type) String() string {
+	if t == 0 {
+		return "AMQP"
+	}
+	return "SASL"
+}
 
 /*
 <type name="source" class="composite" source="list" provides="source">
@@ -339,12 +350,17 @@ func (t Target) String() string {
 
 // frame is the decoded representation of a frame
 type Frame struct {
-	Type    uint8     // AMQP/SASL
+	Type    Type      // AMQP/SASL
 	Channel uint16    // channel this frame is for
 	Body    FrameBody // body of the frame
 
 	// optional channel which will be closed after net transmit
 	Done chan encoding.DeliveryState
+}
+
+// String implements the fmt.Stringer interface for type Frame.
+func (f Frame) String() string {
+	return fmt.Sprintf("Frame{Type: %s, Channel: %d, Body: %s}", f.Type, f.Channel, f.Body)
 }
 
 // frameBody adds some type safety to frame encoding

--- a/internal/frames/parsing.go
+++ b/internal/frames/parsing.go
@@ -134,8 +134,8 @@ func Write(buf *buffer.Buffer, fr Frame) error {
 	// write header
 	buf.Append([]byte{
 		0, 0, 0, 0, // size, overwrite later
-		2,       // doff, see frameHeader.DataOffset comment
-		fr.Type, // frame type
+		2,              // doff, see frameHeader.DataOffset comment
+		uint8(fr.Type), // frame type
 	})
 	buf.AppendUint16(fr.Channel) // channel
 

--- a/link_test.go
+++ b/link_test.go
@@ -444,7 +444,7 @@ func TestSessionFlowDisablesTransfer(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
+	b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
 		NextIncomingID: &nextIncomingID,
 		IncomingWindow: 0,
 		OutgoingWindow: 100,

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -63,7 +63,7 @@ func TestFrameMarshalUnmarshal(t *testing.T) {
 			if header.Channel != want.Channel {
 				t.Errorf("Expected channel to be %d, but it is %d", want.Channel, header.Channel)
 			}
-			if header.FrameType != want.Type {
+			if header.FrameType != uint8(want.Type) {
 				t.Errorf("Expected channel to be %d, but it is %d", want.Type, header.FrameType)
 			}
 

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -314,7 +314,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 	}()
 
 	// missing DeliveryID
-	fr, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+	fr, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformTransfer{
 		Handle: linkHandle,
 	})
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 		msgChan <- msg
 		errChan <- err
 	}()
-	fr, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+	fr, err = mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformTransfer{
 		DeliveryID: &deliveryID,
 		Handle:     linkHandle,
 	})
@@ -363,7 +363,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 		msgChan <- msg
 		errChan <- err
 	}()
-	fr, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformTransfer{
+	fr, err = mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformTransfer{
 		DeliveryID:    &deliveryID,
 		Handle:        linkHandle,
 		MessageFormat: &format,

--- a/sender_test.go
+++ b/sender_test.go
@@ -258,14 +258,14 @@ func TestSenderAttachError(t *testing.T) {
 
 	enqueueFrames = func(n string) {
 		// send an invalid attach response
-		b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformAttach{
+		b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformAttach{
 			Name: n,
 			Role: encoding.RoleReceiver,
 		})
 		require.NoError(t, err)
 		netConn.SendFrame(b)
 		// now follow up with a detach frame
-		b, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformDetach{
+		b, err = mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformDetach{
 			Error: &encoding.Error{
 				Condition:   errcon,
 				Description: errdesc,
@@ -616,7 +616,7 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 			return mocks.PerformEnd(0, nil)
 		case *frames.PerformAttach:
 			mode := SenderSettleModeUnsettled
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformAttach{
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformAttach{
 				Name:   tt.Name,
 				Handle: 0,
 				Role:   encoding.RoleReceiver,
@@ -713,7 +713,7 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 		case *mocks.AMQPProto:
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
-			return mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformOpen{
+			return mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformOpen{
 				ChannelMax:   65535,
 				ContainerID:  "container",
 				IdleTimeout:  time.Minute,
@@ -896,7 +896,7 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 	require.NoError(t, err)
 
 	nextIncomingID := uint32(1)
-	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
+	b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
 		Handle:         &sender.l.handle,
 		NextIncomingID: &nextIncomingID,
 		IncomingWindow: 100,

--- a/session_test.go
+++ b/session_test.go
@@ -491,7 +491,7 @@ func TestSessionUnexpectedFrame(t *testing.T) {
 	require.NoError(t, err)
 
 	// this frame is swallowed
-	b, err := mocks.EncodeFrame(mocks.FrameSASL, 0, &frames.SASLMechanisms{})
+	b, err := mocks.EncodeFrame(frames.TypeSASL, 0, &frames.SASLMechanisms{})
 	require.NoError(t, err)
 	netConn.SendFrame(b)
 
@@ -516,7 +516,7 @@ func TestSessionInvalidFlowFrame(t *testing.T) {
 	require.NoError(t, err)
 
 	// NextIncomingID cannot be nil once the session has been established
-	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{})
+	b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{})
 	require.NoError(t, err)
 	netConn.SendFrame(b)
 
@@ -577,7 +577,7 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformFlow{
+	b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
 		NextIncomingID: &nextIncomingID,
 		IncomingWindow: 100,
 		OutgoingWindow: 100,
@@ -629,14 +629,14 @@ func TestSessionInvalidAttachDeadlock(t *testing.T) {
 
 	enqueueFrames = func(n string) {
 		// send an invalid attach response
-		b, err := mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformAttach{
+		b, err := mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformAttach{
 			Name: "mismatched",
 			Role: encoding.RoleReceiver,
 		})
 		require.NoError(t, err)
 		netConn.SendFrame(b)
 		// now follow up with a detach frame
-		b, err = mocks.EncodeFrame(mocks.FrameAMQP, 0, &frames.PerformDetach{
+		b, err = mocks.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformDetach{
 			Error: &encoding.Error{
 				Condition:   "boom",
 				Description: "failed",


### PR DESCRIPTION
Added fmt.Stringer support.
Removed duplicate definition from mocks package.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
