### PR TITLE
Clean up debug log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 * Ensure that `Receiver.Receive()` drains prefetched messages when the link closed.
 * Fixed an issue that could cause closing a `Receiver` to hang under certain circumstances.
 
+### Other Changes
+
+* Debug logging has been cleaned up to reduce the number of redundant entries and consolidate the entry format.
+  * DEBUG_LEVEL 1 now captures all sent/received frames along with basic flow control information.
+  * Higher debug levels add entries when a frame transitions across mux boundaries and other diagnostics info.
+
 ## 0.18.1 (2023-01-17)
 
 ### Bugs Fixed

--- a/link.go
+++ b/link.go
@@ -85,9 +85,6 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// link-specific configuration of the attach frame
 	beforeAttach(attach)
 
-	// send Attach frame
-	debug.Log(1, "TX (attachLink): %s", attach)
-
 	_ = l.session.txFrame(attach, nil)
 
 	// wait for response
@@ -107,7 +104,6 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		return l.session.doneErr
 	case fr = <-l.rx:
 	}
-	debug.Log(3, "RX (attachLink): %s", fr)
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
 		return fmt.Errorf("unexpected attach response: %#v", fr)
@@ -149,7 +145,6 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			Handle: l.handle,
 			Closed: true,
 		}
-		debug.Log(1, "TX (attachLink): %s", fr)
 		_ = l.session.txFrame(fr, nil)
 
 		if detach.Error == nil {
@@ -204,7 +199,6 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 	switch fr := fr.(type) {
 	// remote side is closing links
 	case *frames.PerformDetach:
-		debug.Log(1, "RX (muxHandleFrame): %s", fr)
 		// don't currently support link detach and reattach
 		if !fr.Closed {
 			return &LinkError{inner: fmt.Errorf("non-closing detach not supported: %+v", fr)}
@@ -220,7 +214,7 @@ func (l *link) muxHandleFrame(fr frames.FrameBody) error {
 
 	default:
 		// TODO: evaluate
-		debug.Log(1, "muxHandleFrame: unexpected frame: %s\n", fr)
+		debug.Log(1, "RX (link): unexpected frame: %s", fr)
 	}
 
 	return nil

--- a/receiver.go
+++ b/receiver.go
@@ -104,7 +104,7 @@ func (r *Receiver) Prefetched() *Message {
 	// delivered regardless of whether the link has been closed.
 	select {
 	case msg := <-r.messages:
-		debug.Log(3, "Receive() non blocking %d", msg.deliveryID)
+		debug.Log(3, "RX (Receiver): prefetched delivery ID %d", msg.deliveryID)
 		msg.rcvr = r
 		return &msg
 	default:
@@ -132,7 +132,7 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 	// wait for the next message
 	select {
 	case msg := <-r.messages:
-		debug.Log(3, "Receive() blocking %d", msg.deliveryID)
+		debug.Log(3, "RX (Receiver): received delivery ID %d", msg.deliveryID)
 		msg.rcvr = r
 		return &msg, nil
 	case <-r.l.done:
@@ -351,7 +351,6 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 		return r.l.doneErr
 	default:
 		// TODO: this is racy
-		debug.Log(1, "TX (sendDisposition): %s", fr)
 		return r.l.session.txFrame(fr, nil)
 	}
 }
@@ -359,13 +358,14 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state encoding.DeliveryState) error {
 	var wait chan error
 	if r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond {
-		debug.Log(3, "RX (messageDisposition): add %d to inflight", msg.deliveryID)
+		debug.Log(3, "TX (Receiver): delivery ID %d is in flight", msg.deliveryID)
 		wait = r.inFlight.add(msg.deliveryID)
 	}
 
 	if r.batching {
 		select {
 		case r.dispositions <- messageDisposition{id: msg.deliveryID, state: state}:
+			// disposition sent to batcher
 		case <-r.l.done:
 			return r.l.doneErr
 		}
@@ -389,6 +389,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	select {
 	case err := <-wait:
+		debug.Log(3, "RX (Receiver): delivery ID %d has been settled", msg.deliveryID)
 		// we've received confirmation of disposition
 		r.deleteUnsettled(msg)
 		msg.settled = true
@@ -576,10 +577,10 @@ func (r *Receiver) mux() {
 		// this ensures that any pending credit can be reclaimed if the number of unsettled messages
 		// remains greater than half the link's max credit.
 		if pendingCredit := r.maxCredit - (r.l.availableCredit + uint32(r.countUnsettled())); pendingCredit > 0 && pendingCredit >= r.l.availableCredit && r.autoSendFlow {
-			debug.Log(1, "receiver (auto): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (auto): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 			r.l.doneErr = r.creditor.IssueCredit(pendingCredit, r)
 		} else if r.l.availableCredit == 0 {
-			debug.Log(1, "receiver (pause): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (pause): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.doneErr != nil {
@@ -588,7 +589,7 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.availableCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "receiver (flow): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
+			debug.Log(1, "RX (Receiver) (flow): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
 				r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 
 			// send a flow frame.
@@ -627,15 +628,12 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 		deliveryCount = r.l.deliveryCount
 	)
 
-	debug.Log(3, "muxFlow: len(l.Messages):%d - linkCredit: %d - deliveryCount: %d, inFlight: %d", len(r.messages), linkCredit, deliveryCount, r.inFlight.len())
-
 	fr := &frames.PerformFlow{
 		Handle:        &r.l.handle,
 		DeliveryCount: &deliveryCount,
 		LinkCredit:    &linkCredit, // max number of messages,
 		Drain:         drain,
 	}
-	debug.Log(3, "TX (muxFlow): %s", fr)
 
 	// Update credit. This must happen before entering loop below
 	// because incoming messages handled while waiting to transmit
@@ -652,6 +650,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 	for {
 		select {
 		case r.l.session.tx <- fr:
+			debug.Log(2, "TX (Receiver): %s", fr)
 			return nil
 		case fr := <-r.l.rx:
 			err := r.muxHandleFrame(fr)
@@ -668,6 +667,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 
 // muxHandleFrame processes fr based on type.
 func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
+	debug.Log(2, "RX (Receiver): %s", fr)
 	switch fr := fr.(type) {
 	// message frame
 	case *frames.PerformTransfer:
@@ -675,7 +675,6 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 
 	// flow control frame
 	case *frames.PerformFlow:
-		debug.Log(3, "RX (receiver): %s", fr)
 		if !fr.Echo {
 			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
 			// we signal whomever is waiting (the service has seen and acknowledged our drain)
@@ -699,12 +698,9 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 			DeliveryCount: &deliveryCount,
 			LinkCredit:    &linkCredit, // max number of messages
 		}
-		debug.Log(1, "TX (receiver): %s", resp)
 		_ = r.l.session.txFrame(resp, nil)
 
 	case *frames.PerformDisposition:
-		debug.Log(3, "RX (receiver): %s", fr)
-
 		// Unblock receivers waiting for message disposition
 		// bubble disposition error up to the receiver
 		var dispositionError error
@@ -829,16 +825,15 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	if err != nil {
 		return &LinkError{inner: err}
 	}
-	debug.Log(1, "deliveryID %d before push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.l.deliveryCount, r.l.availableCredit, len(r.messages), r.inFlight.len())
+
 	// send to receiver
 	if !r.msg.settled {
 		r.addUnsettled(&r.msg)
+		debug.Log(3, "RX (Receiver): add unsettled delivery ID %d", r.msg.deliveryID)
 	}
-	if !r.muxMsg() {
+	if !r.muxMsg(&fr) {
 		return nil
 	}
-
-	debug.Log(1, "deliveryID %d after push to receiver - deliveryCount : %d - linkCredit: %d, len(messages): %d, len(inflight): %d", r.msg.deliveryID, r.l.deliveryCount, r.l.availableCredit, len(r.messages), r.inFlight.len())
 
 	// reset progress
 	r.msgBuf.Reset()
@@ -847,7 +842,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	// decrement link-credit after entire message received
 	r.l.deliveryCount++
 	r.l.availableCredit--
-	debug.Log(1, "deliveryID %d before exit - deliveryCount : %d - linkCredit: %d, len(messages): %d", r.msg.deliveryID, r.l.deliveryCount, r.l.availableCredit, len(r.messages))
+	debug.Log(3, "RX (Receiver) link %s - deliveryCount: %d, availableCredit: %d, len(messages): %d", r.l.key.name, r.l.deliveryCount, r.l.availableCredit, len(r.messages))
 	return nil
 }
 

--- a/receiver.go
+++ b/receiver.go
@@ -577,10 +577,10 @@ func (r *Receiver) mux() {
 		// this ensures that any pending credit can be reclaimed if the number of unsettled messages
 		// remains greater than half the link's max credit.
 		if pendingCredit := r.maxCredit - (r.l.availableCredit + uint32(r.countUnsettled())); pendingCredit > 0 && pendingCredit >= r.l.availableCredit && r.autoSendFlow {
-			debug.Log(1, "RX (Receiver) (auto): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (auto): source: \"%s\", inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 			r.l.doneErr = r.creditor.IssueCredit(pendingCredit, r)
 		} else if r.l.availableCredit == 0 {
-			debug.Log(1, "RX (Receiver) (pause): source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (pause): source: \"%s\", inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.doneErr != nil {
@@ -589,7 +589,7 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.availableCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver) (flow): source: %s, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
+			debug.Log(1, "RX (Receiver) (flow): source: \"%s\", inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
 				r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 
 			// send a flow frame.

--- a/receiver.go
+++ b/receiver.go
@@ -577,10 +577,10 @@ func (r *Receiver) mux() {
 		// this ensures that any pending credit can be reclaimed if the number of unsettled messages
 		// remains greater than half the link's max credit.
 		if pendingCredit := r.maxCredit - (r.l.availableCredit + uint32(r.countUnsettled())); pendingCredit > 0 && pendingCredit >= r.l.availableCredit && r.autoSendFlow {
-			debug.Log(1, "RX (Receiver) (auto): source: \"%s\", inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (auto): source: %q, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 			r.l.doneErr = r.creditor.IssueCredit(pendingCredit, r)
 		} else if r.l.availableCredit == 0 {
-			debug.Log(1, "RX (Receiver) (pause): source: \"%s\", inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver) (pause): source: %q, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s", r.l.source.Address, r.inFlight.len(), r.l.availableCredit, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 		}
 
 		if r.l.doneErr != nil {
@@ -589,7 +589,7 @@ func (r *Receiver) mux() {
 
 		drain, credits := r.creditor.FlowBits(r.l.availableCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver) (flow): source: \"%s\", inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
+			debug.Log(1, "RX (Receiver) (flow): source: %q, inflight: %d, credit: %d, creditsToAdd: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit: %d, settleMode: %s",
 				r.l.source.Address, r.inFlight.len(), r.l.availableCredit, credits, drain, r.l.deliveryCount, len(r.messages), r.countUnsettled(), r.maxCredit, r.l.receiverSettleMode.String())
 
 			// send a flow frame.

--- a/receiver_debug.go
+++ b/receiver_debug.go
@@ -3,10 +3,17 @@
 
 package amqp
 
-func (r *Receiver) muxMsg() bool {
+import (
+	"github.com/Azure/go-amqp/internal/debug"
+	"github.com/Azure/go-amqp/internal/frames"
+)
+
+// muxMsg sends the current decoded message to the channel of incoming messages.
+// it returns false if a client-side close has been initiated.
+func (r *Receiver) muxMsg(fr *frames.PerformTransfer) bool {
 	select {
 	case r.messages <- r.msg:
-		// message received
+		debug.Log(2, "RX (Receiver): mux transfer: %s", fr)
 		// NOTE: writing to this should NEVER block.
 		// if it does, it means we have a flow control
 		// bug so our peer sent a message exceeding

--- a/receiver_prod.go
+++ b/receiver_prod.go
@@ -3,11 +3,17 @@
 
 package amqp
 
+import (
+	"github.com/Azure/go-amqp/internal/debug"
+	"github.com/Azure/go-amqp/internal/frames"
+)
+
 // muxMsg sends the current decoded message to the channel of incoming messages.
 // it returns false if a client-side close has been initiated.
-func (r *Receiver) muxMsg() bool {
+func (r *Receiver) muxMsg(fr *frames.PerformTransfer) bool {
 	select {
 	case r.messages <- r.msg:
+		debug.Log(2, "RX (Receiver): mux transfer: %s", fr)
 		// message received
 		// NOTE: writing to this should NEVER block.
 		// if it does, it means we have a flow control

--- a/sasl.go
+++ b/sasl.go
@@ -39,11 +39,12 @@ func SASLTypePlain(username, password string) SASLType {
 				InitialResponse: []byte("\x00" + username + "\x00" + password),
 				Hostname:        "",
 			}
-			debug.Log(1, "TX (ConnSASLPlain): %s", init)
-			err := c.writeFrame(frames.Frame{
+			fr := frames.Frame{
 				Type: frames.TypeSASL,
 				Body: init,
-			})
+			}
+			debug.Log(1, "TX (ConnSASLPlain): %s", fr)
+			err := c.writeFrame(fr)
 			if err != nil {
 				return nil, err
 			}
@@ -69,11 +70,12 @@ func SASLTypeAnonymous() SASLType {
 				Mechanism:       saslMechanismANONYMOUS,
 				InitialResponse: []byte("anonymous"),
 			}
-			debug.Log(1, "TX (ConnSASLAnonymous): %s", init)
-			err := c.writeFrame(frames.Frame{
+			fr := frames.Frame{
 				Type: frames.TypeSASL,
 				Body: init,
-			})
+			}
+			debug.Log(1, "TX (ConnSASLAnonymous): %s", fr)
+			err := c.writeFrame(fr)
 			if err != nil {
 				return nil, err
 			}
@@ -101,11 +103,12 @@ func SASLTypeExternal(resp string) SASLType {
 				Mechanism:       saslMechanismEXTERNAL,
 				InitialResponse: []byte(resp),
 			}
-			debug.Log(1, "TX (ConnSASLExternal): %s", init)
-			err := c.writeFrame(frames.Frame{
+			fr := frames.Frame{
 				Type: frames.TypeSASL,
 				Body: init,
-			})
+			}
+			debug.Log(1, "TX (ConnSASLExternal): %s", fr)
+			err := c.writeFrame(fr)
 			if err != nil {
 				return nil, err
 			}

--- a/sender.go
+++ b/sender.go
@@ -297,8 +297,10 @@ Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
 		if s.l.availableCredit > 0 {
-			debug.Log(3, "TX (Sender): credit: %d, deliveryCount: %d", s.l.availableCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender) (enable): target: \"%s\", available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
+		} else {
+			debug.Log(1, "TX (Sender) (pause): target: \"%s\", available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
 		}
 
 		if len(outgoingDisps) > 0 && len(outgoingDisp) == 0 {

--- a/sender.go
+++ b/sender.go
@@ -297,7 +297,7 @@ Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
 		if s.l.availableCredit > 0 {
-			debug.Log(1, "sender: credit: %d, deliveryCount: %d", s.l.availableCredit, s.l.deliveryCount)
+			debug.Log(3, "TX (Sender): credit: %d, deliveryCount: %d", s.l.availableCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
 		}
 
@@ -320,12 +320,11 @@ Loop:
 
 		select {
 		case dr := <-outgoingDisp:
-			debug.Log(3, "TX (sender): %s", dr)
-
 			// Ensure the session mux is not blocked
 			for {
 				select {
 				case s.l.session.tx <- dr:
+					debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, dr)
 					continue Loop
 				case fr := <-s.l.rx:
 					if err := handleFrame(fr); err != nil {
@@ -346,18 +345,17 @@ Loop:
 
 		// send data
 		case tr := <-outgoingTransfers:
-			debug.Log(3, "TX (sender): %s", tr)
-
 			// Ensure the session mux is not blocked
 			for {
 				select {
 				case s.l.session.txTransfer <- &tr:
+					debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
 					// decrement link-credit after entire message transferred
 					if !tr.More {
 						s.l.deliveryCount++
 						s.l.availableCredit--
 						// we are the sender and we keep track of the peer's link credit
-						debug.Log(3, "TX (sender): key:%s, decremented linkCredit: %d", s.l.key.name, s.l.availableCredit)
+						debug.Log(3, "TX (Sender): link: %s, available credit: %d", s.l.key.name, s.l.availableCredit)
 					}
 					continue Loop
 				case fr := <-s.l.rx:
@@ -385,10 +383,10 @@ Loop:
 // muxHandleFrame processes fr based on type.
 // depending on the peer's RSM, it might return a disposition frame for sending
 func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition, error) {
+	debug.Log(2, "RX (Sender): %s", fr)
 	switch fr := fr.(type) {
 	// flow control frame
 	case *frames.PerformFlow:
-		debug.Log(3, "RX (sender): %s", fr)
 		linkCredit := *fr.LinkCredit - s.l.deliveryCount
 		if fr.DeliveryCount != nil {
 			// DeliveryCount can be nil if the receiver hasn't processed
@@ -414,11 +412,9 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition
 			DeliveryCount: &deliveryCount,
 			LinkCredit:    &linkCredit, // max number of messages
 		}
-		debug.Log(1, "TX (sender): %s", resp)
 		_ = s.l.session.txFrame(resp, nil)
 
 	case *frames.PerformDisposition:
-		debug.Log(3, "RX (sender): %s", fr)
 		// If sending async and a message is rejected, cause a link error.
 		//
 		// This isn't ideal, but there isn't a clear better way to handle it.

--- a/sender.go
+++ b/sender.go
@@ -297,10 +297,10 @@ Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
 		if s.l.availableCredit > 0 {
-			debug.Log(1, "TX (Sender) (enable): target: \"%s\", available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender) (enable): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
 		} else {
-			debug.Log(1, "TX (Sender) (pause): target: \"%s\", available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender) (pause): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
 		}
 
 		if len(outgoingDisps) > 0 && len(outgoingDisp) == 0 {


### PR DESCRIPTION
Centralized logging of incoming and outgoing frames at Conn and removed all redundant entries.
Log transfering of frames across mux at DEBUG_LEVEL 2. Frame entries now include the full frames.Frame info.

Fixes https://github.com/Azure/go-amqp/issues/187