### PR TITLE
Clean up state on context timeout/cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Document default values for incoming and outgoing windows.
 * Refactored handling of incoming frames to eliminate potential deadlocks due to "mux pumping".
 * Disallow sending of frames once the end performative has been sent.
+* Clean up client-side state when a `context.Context` expires or is cancelled and document the potential side-effects.
 
 ## 0.18.1 (2023-01-17)
 

--- a/creditor.go
+++ b/creditor.go
@@ -68,6 +68,8 @@ func (mc *creditor) FlowBits(currentCredits uint32) (bool, uint32) {
 }
 
 // Drain initiates a drain and blocks until EndDrain is called.
+// If the context's deadline expires or is cancelled before the operation
+// completes, the drain might not have happened.
 func (mc *creditor) Drain(ctx context.Context, r *Receiver) error {
 	mc.mu.Lock()
 

--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,6 @@
 package amqp
 
 import (
-	"context"
-	"errors"
-
 	"github.com/Azure/go-amqp/internal/encoding"
 )
 
@@ -104,8 +101,4 @@ func (e *SessionError) Error() string {
 		return e.RemoteErr.Error()
 	}
 	return e.inner.Error()
-}
-
-func isContextErr(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/link.go
+++ b/link.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
@@ -38,8 +37,9 @@ type link struct {
 	rxQ *queue.Holder[frames.FrameBody]
 
 	// used for gracefully closing link
-	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
-	closeOnce *sync.Once    // closeOnce protects close from being closed multiple times
+	close      chan *Error   // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
+	forceClose chan struct{} // used for forcibly terminate a link if Close() times out/is cancelled
+	closeOnce  *sync.Once    // closeOnce protects close from being closed multiple times
 
 	done    chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
 	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of link.go until done has been closed!
@@ -64,16 +64,16 @@ type link struct {
 	senderSettleMode   *SenderSettleMode
 	receiverSettleMode *ReceiverSettleMode
 	maxMessageSize     uint64
-	detachReceived     bool // set to true when the peer initiates link detach/close
 }
 
 func newLink(s *Session, r encoding.Role) link {
 	l := link{
-		key:       linkKey{shared.RandString(40), r},
-		session:   s,
-		close:     make(chan struct{}),
-		closeOnce: &sync.Once{},
-		done:      make(chan struct{}),
+		key:        linkKey{shared.RandString(40), r},
+		session:    s,
+		close:      make(chan *Error, 1), // buffered so we can queue up an error from the mux
+		forceClose: make(chan struct{}),
+		closeOnce:  &sync.Once{},
+		done:       make(chan struct{}),
 	}
 
 	// set the segment size relative to respective window
@@ -132,16 +132,8 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 
 	// wait for response
 	fr, err := l.waitForFrame(ctx)
-	if isContextErr(err) {
-		// attach was written to the network. assume it was received
-		// and that the ctx was too short to wait for the ack.
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			l.muxClose(ctx, nil, nil, nil)
-		}()
-		return ctx.Err()
-	} else if err != nil {
+	if err != nil {
+		l.session.deallocateHandle(l)
 		return err
 	}
 
@@ -163,15 +155,8 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	if resp.Source == nil && resp.Target == nil {
 		// wait for detach
 		fr, err := l.waitForFrame(ctx)
-		if isContextErr(err) {
-			// if we don't send an ack then we're in violation of the protocol
-			go func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				l.muxClose(ctx, nil, nil, nil)
-			}()
-			return ctx.Err()
-		} else if err != nil {
+		if err != nil {
+			l.session.deallocateHandle(l)
 			return err
 		}
 
@@ -201,7 +186,12 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	afterAttach(resp)
 
 	if err := l.setSettleModes(resp); err != nil {
-		l.muxClose(ctx, nil, nil, nil)
+		// close the link as there's a mismatch on requested/supported settlement modes
+		dr := &frames.PerformDetach{
+			Handle: l.handle,
+			Closed: true,
+		}
+		_ = l.session.txFrame(dr, nil)
 		return err
 	}
 
@@ -235,22 +225,27 @@ func (l *link) setSettleModes(resp *frames.PerformAttach) error {
 }
 
 // muxHandleFrame processes fr based on type.
-func (l *link) muxHandleFrame(fr frames.FrameBody) error {
+func (l *link) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 	switch fr := fr.(type) {
-	// remote side is closing links
 	case *frames.PerformDetach:
-		// don't currently support link detach and reattach
 		if !fr.Closed {
 			return &LinkError{inner: fmt.Errorf("non-closing detach not supported: %+v", fr)}
 		}
 
-		// set detach received and close link
-		l.detachReceived = true
+		// there are two possibilities:
+		// - this is the ack to a client-side Close()
+		// - the peer is closing the link so we must ack
 
-		if fr.Error != nil {
-			return &LinkError{RemoteErr: fr.Error}
+		if clientClosed {
+			return &LinkError{}
 		}
-		return &LinkError{}
+
+		dr := &frames.PerformDetach{
+			Handle: l.handle,
+			Closed: true,
+		}
+		_ = l.session.txFrame(dr, nil)
+		return &LinkError{RemoteErr: fr.Error}
 
 	default:
 		// TODO: evaluate
@@ -268,6 +263,7 @@ func (l *link) closeLink(ctx context.Context) error {
 	case <-l.done:
 		// mux exited
 	case <-ctx.Done():
+		close(l.forceClose)
 		return ctx.Err()
 	}
 
@@ -277,90 +273,4 @@ func (l *link) closeLink(ctx context.Context) error {
 		return nil
 	}
 	return l.doneErr
-}
-
-// muxClose closes the link
-//   - err is the error sent to the peer if we're closing the link with an error
-//   - deferred is executed during the final phase of shutdown (can be nil)
-//   - onRXTransfer handles incoming transfer frames during shutdown (can be nil)
-func (l *link) muxClose(ctx context.Context, err *Error, deferred func(), onRXTransfer func(frames.PerformTransfer)) {
-	defer func() {
-		// final cleanup and signaling
-
-		// if the context timed out or was cancelled we don't really know
-		// if the link has been properly terminated.  in this case, it might
-		// not be safe to reuse the handle as it might still be associated
-		// with an existing link.
-		if ctx.Err() == nil {
-			// deallocate handle
-			l.session.deallocateHandle(l)
-		}
-
-		if deferred != nil {
-			deferred()
-		}
-
-		// signal that the link mux has exited
-		close(l.done)
-	}()
-
-	// "A peer closes a link by sending the detach frame with the
-	// handle for the specified link, and the closed flag set to
-	// true. The partner will destroy the corresponding link
-	// endpoint, and reply with its own detach frame with the
-	// closed flag set to true.
-	//
-	// Note that one peer MAY send a closing detach while its
-	// partner is sending a non-closing detach. In this case,
-	// the partner MUST signal that it has closed the link by
-	// reattaching and then sending a closing detach."
-
-	fr := &frames.PerformDetach{
-		Handle: l.handle,
-		Closed: true,
-		Error:  err,
-	}
-
-	select {
-	case <-ctx.Done():
-		// TODO: expired context
-		return
-	case l.session.tx <- fr:
-		// frame sent to our session mux
-	case <-l.session.done:
-		if l.doneErr == nil {
-			l.doneErr = l.session.doneErr
-		}
-		return
-	}
-
-	// if the peer initiated the close then we just sent the ack so we're done
-	if l.detachReceived {
-		return
-	}
-
-	// wait for the ack
-	for {
-		fr, err := l.waitForFrame(ctx)
-		if isContextErr(err) {
-			// TODO: expired context
-			return
-		} else if err != nil {
-			if l.doneErr == nil {
-				l.doneErr = err
-			}
-			return
-		}
-
-		switch fr := fr.(type) {
-		case *frames.PerformDetach:
-			if fr.Closed {
-				return
-			}
-		case *frames.PerformTransfer:
-			if onRXTransfer != nil {
-				onRXTransfer(*fr)
-			}
-		}
-	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -405,7 +405,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		msg.settled = true
 		return err
 	case <-ctx.Done():
-		// TODO: if we don't receive the confirmation, should the message be considered settled?
+		// didn't receive the ack in the time allotted, leave message as unsettled
 		return ctx.Err()
 	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -40,7 +40,6 @@ type Receiver struct {
 	msgBuf                buffer.Buffer       // buffered bytes for current message
 	more                  bool                // if true, buf contains a partial message
 	msg                   Message             // current message being decoded
-	detachError           *Error              // error to send to peer on detach/close, set by closeWithError; NOT why link was terminated
 
 	settlementCount   uint32     // the count of settled messages
 	settlementCountMu sync.Mutex // must be held when accessing settlementCount
@@ -150,26 +149,44 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 	}
 }
 
-// Accept notifies the server that the message has been
-// accepted and does not require redelivery.
+// Accept notifies the server that the message has been accepted and does not require redelivery.
+//   - ctx controls waiting for the peer to acknowledge the disposition
+//   - msg is the message to accept
+//
+// If the context's deadline expires or is cancelled before the operation
+// completes, the message's disposition is in an unknown state.
 func (r *Receiver) AcceptMessage(ctx context.Context, msg *Message) error {
 	return r.messageDisposition(ctx, msg, &encoding.StateAccepted{})
 }
 
 // Reject notifies the server that the message is invalid.
+//   - ctx controls waiting for the peer to acknowledge the disposition
+//   - msg is the message to reject
+//   - e is an optional rejection error
 //
-// Rejection error is optional.
+// If the context's deadline expires or is cancelled before the operation
+// completes, the message's disposition is in an unknown state.
 func (r *Receiver) RejectMessage(ctx context.Context, msg *Message, e *Error) error {
 	return r.messageDisposition(ctx, msg, &encoding.StateRejected{Error: e})
 }
 
-// Release releases the message back to the server. The message
-// may be redelivered to this or another consumer.
+// Release releases the message back to the server. The message may be redelivered to this or another consumer.
+//   - ctx controls waiting for the peer to acknowledge the disposition
+//   - msg is the message to release
+//
+// If the context's deadline expires or is cancelled before the operation
+// completes, the message's disposition is in an unknown state.
 func (r *Receiver) ReleaseMessage(ctx context.Context, msg *Message) error {
 	return r.messageDisposition(ctx, msg, &encoding.StateReleased{})
 }
 
 // Modify notifies the server that the message was not acted upon and should be modifed.
+//   - ctx controls waiting for the peer to acknowledge the disposition
+//   - msg is the message to modify
+//   - options contains the optional settings to modify
+//
+// If the context's deadline expires or is cancelled before the operation
+// completes, the message's disposition is in an unknown state.
 func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, options *ModifyMessageOptions) error {
 	if options == nil {
 		options = &ModifyMessageOptions{}
@@ -224,20 +241,23 @@ func (r *Receiver) LinkSourceFilterValue(name string) any {
 }
 
 // Close closes the Receiver and AMQP link.
+//   - ctx controls waiting for the peer to acknowledge the close
 //
-// If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Session or Client
-// is closed.
+// If the context's deadline expires or is cancelled before the operation
+// completes, the application can be left in an unknown state, potentially
+// resulting in connection errors.
 func (r *Receiver) Close(ctx context.Context) error {
 	return r.l.closeLink(ctx)
 }
 
 // returns the error passed in
 func (r *Receiver) closeWithError(de *Error) error {
-	r.l.closeOnce.Do(func() {
-		r.detachError = de
-		close(r.l.close)
-	})
+	select {
+	case r.l.close <- de:
+		// close error queued
+	default:
+		// close error already pending
+	}
 	return &LinkError{inner: de}
 }
 
@@ -385,6 +405,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		msg.settled = true
 		return err
 	case <-ctx.Done():
+		// TODO: if we don't receive the confirmation, should the message be considered settled?
 		return ctx.Err()
 	}
 }
@@ -558,22 +579,23 @@ func (r *Receiver) attach(ctx context.Context) error {
 
 func (r *Receiver) mux() {
 	defer func() {
-		r.l.muxClose(context.Background(), r.detachError, func() {
-			// unblock any in flight message dispositions
-			r.inFlight.clear(r.l.doneErr)
+		// unblock any in flight message dispositions
+		r.inFlight.clear(r.l.doneErr)
 
-			if !r.autoSendFlow {
-				// unblock any pending drain requests
-				r.creditor.EndDrain()
-			}
-		}, func(fr frames.PerformTransfer) {
-			_ = r.muxReceive(fr)
-		})
+		if !r.autoSendFlow {
+			// unblock any pending drain requests
+			r.creditor.EndDrain()
+		}
+
+		r.l.session.deallocateHandle(&r.l)
+		close(r.l.done)
 	}()
 
 	if r.autoSendFlow {
 		r.l.doneErr = r.muxFlow(r.l.linkCredit, false)
 	}
+
+	var clientClosed bool // indicates a client-side close
 
 	for {
 		msgLen := r.messagesQ.Len()
@@ -617,21 +639,41 @@ func (r *Receiver) mux() {
 			return
 		}
 
+		closed := r.l.close
+		if clientClosed {
+			// swap out channel so it no longer triggers
+			closed = nil
+		}
+
 		select {
+		case <-r.l.forceClose:
+			// the call to r.Close() timed out waiting for the ack
+			r.l.doneErr = &LinkError{inner: errors.New("the receiver was forcibly closed")}
+			return
+
 		case q := <-r.l.rxQ.Wait():
 			// populated queue
 			fr := *q.Dequeue()
 			r.l.rxQ.Release(q)
 
-			r.l.doneErr = r.muxHandleFrame(fr)
+			r.l.doneErr = r.muxHandleFrame(fr, clientClosed)
 			if r.l.doneErr != nil {
 				return
 			}
+
 		case <-r.receiverReady:
 			continue
-		case <-r.l.close:
-			r.l.doneErr = &LinkError{}
-			return
+
+		case err := <-closed:
+			// receiver is being closed by the client (Close() or protocol error)
+			clientClosed = true
+			fr := &frames.PerformDetach{
+				Handle: r.l.handle,
+				Closed: true,
+				Error:  err,
+			}
+			_ = r.l.session.txFrame(fr, nil)
+
 		case <-r.l.session.done:
 			// TODO: per spec, if the session has terminated, we're not allowed to send frames
 			r.l.doneErr = r.l.session.doneErr
@@ -677,7 +719,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 }
 
 // muxHandleFrame processes fr based on type.
-func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
+func (r *Receiver) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 	debug.Log(2, "RX (Receiver): %s", fr)
 	switch fr := fr.(type) {
 	// message frame
@@ -733,7 +775,7 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		r.inFlight.remove(fr.First, fr.Last, dispositionError)
 
 	default:
-		return r.l.muxHandleFrame(fr)
+		return r.l.muxHandleFrame(fr, clientClosed)
 	}
 
 	return nil

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -67,6 +67,8 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 			return fake.ReceiverAttach(0, linkName, 0, ReceiverSettleModeFirst, nil)
 		case *frames.PerformFlow, *fake.KeepAlive:
 			return nil, nil
+		case *frames.PerformDetach:
+			return fake.PerformDetach(0, ff.Handle, nil)
 		default:
 			return nil, fmt.Errorf("unhandled frame %T", req)
 		}

--- a/session.go
+++ b/session.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/Azure/go-amqp/internal/bitmap"
 	"github.com/Azure/go-amqp/internal/debug"
@@ -56,8 +55,9 @@ type Session struct {
 	handles    *bitmap.Bitmap    // allocated handles
 
 	// used for gracefully closing session
-	close     chan *Error
-	closeOnce sync.Once
+	close      chan *Error
+	forceClose chan struct{}
+	closeOnce  sync.Once
 
 	// part of internal public surface area
 	done    chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
@@ -76,6 +76,7 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 		linksMu:        sync.RWMutex{},
 		linksByKey:     make(map[linkKey]*link),
 		close:          make(chan *Error, 1), // buffered so we can queue up an error from the mux
+		forceClose:     make(chan struct{}),
 		done:           make(chan struct{}),
 	}
 
@@ -130,34 +131,10 @@ func (s *Session) begin(ctx context.Context) error {
 
 	// wait for response
 	fr, err := s.waitForFrame(ctx)
-	if isContextErr(err) {
-		// begin was written to the network.  assume it was
-		// received and that the ctx was too short to wait for
-		// the ack.
-		go func() {
-			_ = s.txFrame(&frames.PerformEnd{}, nil)
-
-			// wait for the ack
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			for {
-				if fr, err := s.waitForFrame(ctx); isContextErr(err) {
-					// don't delete the session in this case. this is to avoid recylcing
-					// a channel number for a session that might not have terminated
-					debug.Log(3, "session.begin clean-up timed out waiting for PerformEnd ack")
-					return
-				} else if err != nil {
-					return
-				} else if _, ok := fr.(*frames.PerformEnd); ok {
-					// received ack that session was closed, safe to delete session
-					s.conn.deleteSession(s)
-					return
-				}
-			}
-		}()
-		return ctx.Err()
-	} else if err != nil {
+	if err != nil {
+		// if we exit before receiving the ack, our caller will clean up the channel.
+		// however, it does mean that the peer will now have assigned an outgoing
+		// channel ID that's not in use.
 		return err
 	}
 
@@ -169,7 +146,6 @@ func (s *Session) begin(ctx context.Context) error {
 		// either swallow the frame or blow up in some other way, both causing this call to hang.
 		// deallocate session on error.  we can't call
 		// s.Close() as the session mux hasn't started yet.
-		s.conn.deleteSession(s)
 		return fmt.Errorf("unexpected begin response: %+v", fr)
 	}
 
@@ -179,10 +155,12 @@ func (s *Session) begin(ctx context.Context) error {
 	return nil
 }
 
-// Close gracefully closes the session.
+// Close closes the session.
+//   - ctx controls waiting for the peer to acknowledge the session is closed
 //
-// If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Client is closed.
+// If the context's deadline expires or is cancelled before the operation
+// completes, the application can be left in an unknown state, potentially
+// resulting in connection errors.
 func (s *Session) Close(ctx context.Context) error {
 	s.closeOnce.Do(func() { close(s.close) })
 
@@ -190,6 +168,7 @@ func (s *Session) Close(ctx context.Context) error {
 	case <-s.done:
 		// mux has exited
 	case <-ctx.Done():
+		close(s.forceClose)
 		return ctx.Err()
 	}
 
@@ -213,7 +192,13 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 }
 
 // NewReceiver opens a new receiver link on the session.
-// opts: pass nil to accept the default values.
+//   - ctx controls waiting for the peer to create a sending terminus
+//   - source is the name of the peer's sending terminus
+//   - opts contains optional values, pass nil to accept the defaults
+//
+// If the context's deadline expires or is cancelled before the operation
+// completes, the application can be left in an unknown state, potentially
+// resulting in connection errors.
 func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
 	r, err := newReceiver(source, s, opts)
 	if err != nil {
@@ -240,7 +225,13 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 }
 
 // NewSender opens a new sender link on the session.
-// opts: pass nil to accept the default values.
+//   - ctx controls waiting for the peer to create a receiver terminus
+//   - target is the name of the peer's receiver terminus
+//   - opts contains optional values, pass nil to accept the defaults
+//
+// If the context's deadline expires or is cancelled before the operation
+// completes, the application can be left in an unknown state, potentially
+// resulting in connection errors.
 func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
 	l, err := newSender(target, s, opts)
 	if err != nil {
@@ -259,7 +250,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		if s.doneErr == nil {
 			s.doneErr = &SessionError{}
 		} else if connErr := (&ConnError{}); !errors.As(s.doneErr, &connErr) {
-			// only wrap non-ConnectionError error types
+			// only wrap non-ConnError error types
 			var amqpErr *Error
 			if errors.As(s.doneErr, &amqpErr) {
 				s.doneErr = &SessionError{RemoteErr: amqpErr}
@@ -321,8 +312,13 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			s.doneErr = s.conn.doneErr
 			return
 
-		// session is being closed by user
+		case <-s.forceClose:
+			// the call to s.Close() timed out waiting for the ack
+			s.doneErr = errors.New("the session was forcibly closed")
+			return
+
 		case err := <-closed:
+			// session is being closed by the client (Close() or protocol error)
 			clientClosed = true
 			fr := frames.PerformEnd{Error: err}
 			_ = s.txFrame(&fr, nil)

--- a/session_test.go
+++ b/session_test.go
@@ -141,7 +141,7 @@ func TestSessionCloseTimeout(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = session.Close(ctx)
 	cancel()
-	require.Equal(t, context.DeadlineExceeded, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.NoError(t, client.Close())
 }
 
@@ -662,12 +662,12 @@ func TestNewSessionContextCancelled(t *testing.T) {
 			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
 		case *frames.PerformOpen:
 			return fake.PerformOpen("container")
+		case *frames.PerformClose:
+			return fake.PerformClose(nil)
 		case *frames.PerformBegin:
 			cancel()
 			// swallow frame to prevent non-determinism of cancellation
 			return nil, nil
-		case *frames.PerformEnd:
-			return fake.PerformEnd(0, nil)
 		case *fake.KeepAlive:
 			return nil, nil
 		default:


### PR DESCRIPTION
Document the potential for connection errors.
This required refactoring the link closing code.  It now follows the
same pattern as Session.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
