### PR TITLE
Wake up receiver mux after setting the drain bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fixed an issue that could cause `creditor.Drain()` to return the wrong error when a link is terminated.
 * Ensure that `Receiver.Receive()` drains prefetched messages when the link closed.
 * Fixed an issue that could cause closing a `Receiver` to hang under certain circumstances.
+* In `Receiver.Drain()`, wake up `Receiver.mux()` after the drain bit has been set.
 
 ### Other Changes
 

--- a/creditor.go
+++ b/creditor.go
@@ -84,6 +84,12 @@ func (mc *creditor) Drain(ctx context.Context, r *Receiver) error {
 
 	mc.mu.Unlock()
 
+	// cause mux() to check our flow conditions.
+	select {
+	case r.receiverReady <- struct{}{}:
+	default:
+	}
+
 	// send drain, wait for responding flow frame
 	select {
 	case <-drained:

--- a/receiver.go
+++ b/receiver.go
@@ -77,12 +77,6 @@ func (r *Receiver) DrainCredit(ctx context.Context) error {
 		return errors.New("drain can only be used with receiver links using manual credit management")
 	}
 
-	// cause mux() to check our flow conditions.
-	select {
-	case r.receiverReady <- struct{}{}:
-	default:
-	}
-
 	return r.creditor.Drain(ctx, r)
 }
 


### PR DESCRIPTION
This ensures that when the mux wakes up it will see the bit is set.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
