### PR TITLE
Document default values for incoming and outgoing windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Debug logging has been cleaned up to reduce the number of redundant entries and consolidate the entry format.
   * DEBUG_LEVEL 1 now captures all sent/received frames along with basic flow control information.
   * Higher debug levels add entries when a frame transitions across mux boundaries and other diagnostics info.
+* Document default values for incoming and outgoing windows.
 
 ## 0.18.1 (2023-01-17)
 

--- a/conn.go
+++ b/conn.go
@@ -510,7 +510,7 @@ func (c *Conn) connReader() {
 		}
 
 		select {
-		case session.rx <- fr:
+		case session.rx <- fr.Body:
 			// sent to session
 			debug.Log(2, "RX (connReader): mux frame to session: %s", fr)
 		case <-session.done:


### PR DESCRIPTION
Changed Session.rx to frames.FrameBody to remove extra level of indirection and passing data that isn't required.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
