### PR TITLE
Separate link credit variables for sender and receiver

### DIFF
--- a/creditor.go
+++ b/creditor.go
@@ -109,8 +109,8 @@ func (mc *creditor) IssueCredit(credits uint32, r *Receiver) error {
 
 	if mc.drained != nil {
 		return errLinkDraining
-	} else if unsettled := uint32(r.countUnsettled()); credits+unsettled+r.l.availableCredit > r.maxCredit {
-		return fmt.Errorf("link credit exceeded: requested %d, available %d, max %d, %d unsettled messages", credits, r.l.availableCredit, r.maxCredit, unsettled)
+	} else if unsettled := uint32(r.countUnsettled()); credits+unsettled+r.linkCredit > r.maxCredit {
+		return fmt.Errorf("link credit exceeded: requested %d, available %d, max %d, %d unsettled messages", credits, r.linkCredit, r.maxCredit, unsettled)
 	}
 
 	mc.creditsToAdd += credits

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -115,7 +115,7 @@ func waitForReceiver(r *Receiver, paused bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	for {
-		credit := atomic.LoadUint32(&r.l.availableCredit)
+		credit := atomic.LoadUint32(&r.linkCredit)
 		// waiting for the link to pause means its credit has been consumed
 		if (paused && credit == 0) || (!paused && credit > 0) {
 			return nil

--- a/link.go
+++ b/link.go
@@ -53,11 +53,6 @@ type link struct {
 	// initialized at an arbitrary point by the sender."
 	deliveryCount uint32
 
-	// the currently available credit on the link.
-	// for senders, this is the peer's receiving credit.
-	// for receivers, this is our receiving credit.
-	availableCredit uint32
-
 	senderSettleMode   *SenderSettleMode
 	receiverSettleMode *ReceiverSettleMode
 	maxMessageSize     uint64

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -426,7 +426,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 		t.Fatalf("unexpected unsettled count %d", c)
 	}
 	// link credit should be 0
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -439,7 +439,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -500,7 +500,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -521,7 +521,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// subsequent dispositions should have no effect
@@ -582,7 +582,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptOnClosedLink(t *testing.T) 
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 
@@ -645,7 +645,7 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -665,7 +665,7 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -721,7 +721,7 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -741,7 +741,7 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -802,7 +802,7 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -827,7 +827,7 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -918,7 +918,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
@@ -939,7 +939,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	// wait for the link to unpause as credit should now be available
 	require.NoError(t, waitForReceiver(r, false))
 	// link credit should be back to 1
-	if c := r.l.availableCredit; c != 1 {
+	if c := r.linkCredit; c != 1 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	require.NoError(t, client.Close())
@@ -1220,7 +1220,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	// wait for the link to pause as we've consumed all available credit
 	require.NoError(t, waitForReceiver(r, true))
 	// link credit must be zero since we only started with 1
-	if c := r.l.availableCredit; c != 0 {
+	if c := r.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
 	// close client before accepting the message

--- a/sender.go
+++ b/sender.go
@@ -28,6 +28,10 @@ type Sender struct {
 	mu              sync.Mutex // protects buf and nextDeliveryTag
 	buf             buffer.Buffer
 	nextDeliveryTag uint64
+
+	// The number of messages awaiting credit at the link sender endpoint. Only the sender can independently
+	// set this value. The receiver sets this to the last known value seen from the sender.
+	availableCredit uint32
 }
 
 // LinkName() is the name of the link used for this Sender.
@@ -296,11 +300,11 @@ func (s *Sender) mux() {
 Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
-		if s.l.availableCredit > 0 {
-			debug.Log(1, "TX (Sender) (enable): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
+		if s.availableCredit > 0 {
+			debug.Log(1, "TX (Sender) (enable): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.availableCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
 		} else {
-			debug.Log(1, "TX (Sender) (pause): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
+			debug.Log(1, "TX (Sender) (pause): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.availableCredit, s.l.deliveryCount)
 		}
 
 		if len(outgoingDisps) > 0 && len(outgoingDisp) == 0 {
@@ -355,9 +359,9 @@ Loop:
 					// decrement link-credit after entire message transferred
 					if !tr.More {
 						s.l.deliveryCount++
-						s.l.availableCredit--
+						s.availableCredit--
 						// we are the sender and we keep track of the peer's link credit
-						debug.Log(3, "TX (Sender): link: %s, available credit: %d", s.l.key.name, s.l.availableCredit)
+						debug.Log(3, "TX (Sender): link: %s, available credit: %d", s.l.key.name, s.availableCredit)
 					}
 					continue Loop
 				case fr := <-s.l.rx:
@@ -396,7 +400,8 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition
 			// what ActiveMQ does.
 			linkCredit += *fr.DeliveryCount
 		}
-		s.l.availableCredit = linkCredit
+		// TODO: clean up as part of flow control fixes
+		s.availableCredit = linkCredit
 
 		if !fr.Echo {
 			return nil, nil


### PR DESCRIPTION
Moved to their respective types.  No functional changes.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
