### PR TITLE
Use 1ES pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,16 +9,20 @@ jobs:
     strategy:
       matrix:
         Linux_Go118:
+          pool.name: 'azsdk-pool-mms-ubuntu-2004-general'
           vm.image: 'ubuntu-20.04'
           go.version: '1.18.8'
         Linux_Go119:
+          pool.name: 'azsdk-pool-mms-ubuntu-2004-general'
           vm.image: 'ubuntu-20.04'
           go.version: '1.19.3'
         Linux_Go120:
+          pool.name: 'azsdk-pool-mms-ubuntu-2004-general'
           vm.image: 'ubuntu-20.04'
           go.version: '1.20'
 
     pool:
+      name: '$(pool.name)'
       vmImage: '$(vm.image)'
 
     steps:


### PR DESCRIPTION
All Windows and Linux pipelines should use 1ES pools by default, unless they need to run in the DevOps Pool for a specific reason.