### PR TITLE
Don't swallow unexpected frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Refactored handling of incoming frames to eliminate potential deadlocks due to "mux pumping".
 * Disallow sending of frames once the end performative has been sent.
 * Clean up client-side state when a `context.Context` expires or is cancelled and document the potential side-effects.
+* Unexpected frames will now terminate a `Session`, `Receiver`, or `Sender` as required.
 
 ## 0.18.1 (2023-01-17)
 

--- a/link.go
+++ b/link.go
@@ -139,8 +139,10 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
-		// TODO: seems like more cleanup is in order
-		return fmt.Errorf("unexpected attach response: %#v", fr)
+		if err := l.session.conn.Close(); err != nil {
+			return err
+		}
+		return &ConnError{inner: fmt.Errorf("unexpected attach response: %#v", fr)}
 	}
 
 	// If the remote encounters an error during the attach it returns an Attach
@@ -162,7 +164,10 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 
 		detach, ok := fr.(*frames.PerformDetach)
 		if !ok {
-			return fmt.Errorf("unexpected frame while waiting for detach: %#v", fr)
+			if err := l.session.conn.Close(); err != nil {
+				return err
+			}
+			return &ConnError{inner: fmt.Errorf("unexpected frame while waiting for detach: %#v", fr)}
 		}
 
 		// send return detach

--- a/link.go
+++ b/link.go
@@ -248,11 +248,9 @@ func (l *link) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 		return &LinkError{RemoteErr: fr.Error}
 
 	default:
-		// TODO: evaluate
 		debug.Log(1, "RX (link): unexpected frame: %s", fr)
+		return &LinkError{inner: fmt.Errorf("internal error: unexpected frame %T", fr)}
 	}
-
-	return nil
 }
 
 // Close closes the Sender and AMQP link.

--- a/link_test.go
+++ b/link_test.go
@@ -168,7 +168,7 @@ func newTestLink(t *testing.T) *Receiver {
 				handles: bitmap.New(32),
 			},
 			rxQ:   queue.NewHolder(queue.New[frames.FrameBody](100)),
-			close: make(chan *Error),
+			close: make(chan struct{}),
 		},
 		autoSendFlow:  true,
 		inFlight:      inFlight{},

--- a/receiver.go
+++ b/receiver.go
@@ -473,8 +473,6 @@ func (r *Receiver) mux() {
 		r.l.doneErr = r.muxFlow(r.l.linkCredit, false)
 	}
 
-	var clientClosed bool // indicates a client-side close
-
 	for {
 		msgLen := r.messagesQ.Len()
 
@@ -518,7 +516,7 @@ func (r *Receiver) mux() {
 		}
 
 		closed := r.l.close
-		if clientClosed {
+		if r.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
 		}
@@ -533,15 +531,11 @@ func (r *Receiver) mux() {
 			// populated queue
 			fr := *q.Dequeue()
 			r.l.rxQ.Release(q)
-			if err := r.muxHandleFrame(fr, clientClosed); err != nil {
-				// if the error returned is an AMQP error it means a client-side close was
-				// initiated so we need to keep the mux running in order to send the close.
-				var amqpErr *Error
-				if errors.As(err, &amqpErr) {
-					continue
-				}
 
-				// some other error, exit
+			// if muxHandleFrame returns an error it means the mux must terminate.
+			// note that in the case of a client-side close due to an error, nil
+			// is returned in order to keep the mux running to ack the detach frame.
+			if err := r.muxHandleFrame(fr); err != nil {
 				r.l.doneErr = err
 				return
 			}
@@ -549,18 +543,20 @@ func (r *Receiver) mux() {
 		case <-r.receiverReady:
 			continue
 
-		case err := <-closed:
-			// receiver is being closed by the client (Close() or protocol error)
-			clientClosed = true
+		case <-closed:
+			if r.l.closeInProgress {
+				// a client-side close due to protocol error is in progress
+				continue
+			}
+			// receiver is being closed by the client
+			r.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: r.l.handle,
 				Closed: true,
-				Error:  err,
 			}
 			_ = r.l.session.txFrame(fr, nil)
 
 		case <-r.l.session.done:
-			// TODO: per spec, if the session has terminated, we're not allowed to send frames
 			r.l.doneErr = r.l.session.doneErr
 			return
 		}
@@ -597,19 +593,19 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 		debug.Log(2, "TX (Receiver): %s", fr)
 		return nil
 	case <-r.l.close:
-		return &LinkError{}
+		return nil
 	case <-r.l.session.done:
 		return r.l.session.doneErr
 	}
 }
 
 // muxHandleFrame processes fr based on type.
-func (r *Receiver) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
+func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 	debug.Log(2, "RX (Receiver): %s", fr)
 	switch fr := fr.(type) {
 	// message frame
 	case *frames.PerformTransfer:
-		return r.muxReceive(*fr)
+		r.muxReceive(*fr)
 
 	// flow control frame
 	case *frames.PerformFlow:
@@ -640,7 +636,7 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error 
 		case r.l.session.tx <- resp:
 			debug.Log(2, "TX (Sender): %s", resp)
 		case <-r.l.close:
-			return &LinkError{}
+			return nil
 		case <-r.l.session.done:
 			return r.l.session.doneErr
 		}
@@ -660,13 +656,13 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error 
 		r.inFlight.remove(fr.First, fr.Last, dispositionError)
 
 	default:
-		return r.l.muxHandleFrame(fr, clientClosed)
+		return r.l.muxHandleFrame(fr)
 	}
 
 	return nil
 }
 
-func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
+func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	if !r.more {
 		// this is the first transfer of a message,
 		// record the delivery ID, message format,
@@ -681,13 +677,16 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 
 		// these fields are required on first transfer of a message
 		if fr.DeliveryID == nil {
-			return r.l.closeWithError(ErrCondNotAllowed, "received message without a delivery-id")
+			r.l.closeWithError(ErrCondNotAllowed, "received message without a delivery-id")
+			return
 		}
 		if fr.MessageFormat == nil {
-			return r.l.closeWithError(ErrCondNotAllowed, "received message without a message-format")
+			r.l.closeWithError(ErrCondNotAllowed, "received message without a message-format")
+			return
 		}
 		if fr.DeliveryTag == nil {
-			return r.l.closeWithError(ErrCondNotAllowed, "received message without a delivery-tag")
+			r.l.closeWithError(ErrCondNotAllowed, "received message without a delivery-tag")
+			return
 		}
 	} else {
 		// this is a continuation of a multipart message
@@ -700,21 +699,24 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 				"received continuation transfer with inconsistent delivery-id: %d != %d",
 				*fr.DeliveryID, r.msg.deliveryID,
 			)
-			return r.l.closeWithError(ErrCondNotAllowed, msg)
+			r.l.closeWithError(ErrCondNotAllowed, msg)
+			return
 		}
 		if fr.MessageFormat != nil && *fr.MessageFormat != r.msg.Format {
 			msg := fmt.Sprintf(
 				"received continuation transfer with inconsistent message-format: %d != %d",
 				*fr.MessageFormat, r.msg.Format,
 			)
-			return r.l.closeWithError(ErrCondNotAllowed, msg)
+			r.l.closeWithError(ErrCondNotAllowed, msg)
+			return
 		}
 		if fr.DeliveryTag != nil && !bytes.Equal(fr.DeliveryTag, r.msg.DeliveryTag) {
 			msg := fmt.Sprintf(
 				"received continuation transfer with inconsistent delivery-tag: %q != %q",
 				fr.DeliveryTag, r.msg.DeliveryTag,
 			)
-			return r.l.closeWithError(ErrCondNotAllowed, msg)
+			r.l.closeWithError(ErrCondNotAllowed, msg)
+			return
 		}
 	}
 
@@ -723,12 +725,13 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 		r.msgBuf.Reset()
 		r.msg = Message{}
 		r.more = false
-		return nil
+		return
 	}
 
 	// ensure maxMessageSize will not be exceeded
 	if r.l.maxMessageSize != 0 && uint64(r.msgBuf.Len())+uint64(len(fr.Payload)) > r.l.maxMessageSize {
-		return r.l.closeWithError(ErrCondMessageSizeExceeded, fmt.Sprintf("received message larger than max size of %d", r.l.maxMessageSize))
+		r.l.closeWithError(ErrCondMessageSizeExceeded, fmt.Sprintf("received message larger than max size of %d", r.l.maxMessageSize))
+		return
 	}
 
 	// add the payload the the buffer
@@ -741,13 +744,14 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	r.more = fr.More
 
 	if fr.More {
-		return nil
+		return
 	}
 
 	// last frame in message
 	err := r.msg.Unmarshal(&r.msgBuf)
 	if err != nil {
-		return &LinkError{inner: err}
+		r.l.closeWithError(ErrCondInternalError, err.Error())
+		return
 	}
 
 	// send to receiver
@@ -769,7 +773,6 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) error {
 	r.l.deliveryCount++
 	r.l.linkCredit--
 	debug.Log(3, "RX (Receiver) link %s - deliveryCount: %d, linkCredit: %d, len(messages): %d", r.l.key.name, r.l.deliveryCount, r.l.linkCredit, msgLen)
-	return nil
 }
 
 // inFlight tracks in-flight message dispositions allowing receivers

--- a/sender.go
+++ b/sender.go
@@ -300,8 +300,6 @@ func (s *Sender) mux() {
 		close(s.l.done)
 	}()
 
-	var clientClosed bool // indicates a client-side close
-
 Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
@@ -313,7 +311,7 @@ Loop:
 		}
 
 		closed := s.l.close
-		if clientClosed {
+		if s.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
 		}
@@ -329,15 +327,11 @@ Loop:
 			// populated queue
 			fr := *q.Dequeue()
 			s.l.rxQ.Release(q)
-			if err := s.muxHandleFrame(fr, clientClosed); err != nil {
-				// if the error returned is an AMQP error it means a client-side close was
-				// initiated so we need to keep the mux running in order to send the close.
-				var amqpErr *Error
-				if errors.As(err, &amqpErr) {
-					continue
-				}
 
-				// some other error, exit
+			// if muxHandleFrame returns an error it means the mux must terminate.
+			// note that in the case of a client-side close due to an error, nil
+			// is returned in order to keep the mux running to ack the detach frame.
+			if err := s.muxHandleFrame(fr); err != nil {
 				s.l.doneErr = err
 				return
 			}
@@ -361,13 +355,16 @@ Loop:
 				continue Loop
 			}
 
-		case err := <-closed:
-			// sender is being closed by the client (Close() or protocol error)
-			clientClosed = true
+		case <-closed:
+			if s.l.closeInProgress {
+				// a client-side close due to protocol error is in progress
+				continue
+			}
+			// sender is being closed by the client
+			s.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: s.l.handle,
 				Closed: true,
-				Error:  err,
 			}
 			_ = s.l.session.txFrame(fr, nil)
 
@@ -381,7 +378,7 @@ Loop:
 
 // muxHandleFrame processes fr based on type.
 // depending on the peer's RSM, it might return a disposition frame for sending
-func (s *Sender) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
+func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 	debug.Log(2, "RX (Sender): %s", fr)
 	switch fr := fr.(type) {
 	// flow control frame
@@ -418,7 +415,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 		case s.l.session.tx <- resp:
 			debug.Log(2, "TX (Sender): %s", resp)
 		case <-s.l.close:
-			return &LinkError{}
+			return nil
 		case <-s.l.session.done:
 			return s.l.session.doneErr
 		}
@@ -442,7 +439,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 		case s.l.session.tx <- dr:
 			debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, dr)
 		case <-s.l.close:
-			return &LinkError{}
+			return nil
 		case <-s.l.session.done:
 			return s.l.session.doneErr
 		}
@@ -450,7 +447,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody, clientClosed bool) error {
 		return nil
 
 	default:
-		return s.l.muxHandleFrame(fr, clientClosed)
+		return s.l.muxHandleFrame(fr)
 	}
 
 	return nil

--- a/session.go
+++ b/session.go
@@ -550,7 +550,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				debug.Log(1, "RX (Session): unexpected frame: %s\n", body)
 				closeWithError(&Error{
 					Condition:   ErrCondInternalError,
-					Description: "received unexpected frame",
+					Description: "session received unexpected frame",
 				}, fmt.Errorf("internal error: unexpected frame %T", body))
 			}
 

--- a/session.go
+++ b/session.go
@@ -146,7 +146,11 @@ func (s *Session) begin(ctx context.Context) error {
 		// either swallow the frame or blow up in some other way, both causing this call to hang.
 		// deallocate session on error.  we can't call
 		// s.Close() as the session mux hasn't started yet.
-		return fmt.Errorf("unexpected begin response: %+v", fr)
+		s.conn.deleteSession(s)
+		if err := s.conn.Close(); err != nil {
+			return err
+		}
+		return &ConnError{inner: fmt.Errorf("unexpected begin response: %#v", fr)}
 	}
 
 	// start Session multiplexor

--- a/session_test.go
+++ b/session_test.go
@@ -399,6 +399,8 @@ func TestSessionUnexpectedFrame(t *testing.T) {
 	require.NoError(t, err)
 	netConn.SendFrame(b)
 
+	// sleep for a bit so that the session mux has time to process the invalid frame before we close
+	time.Sleep(50 * time.Millisecond)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	err = session.Close(ctx)
 	cancel()


### PR DESCRIPTION
Terminate a session/link on receiving an unexpected frame. The change uncovered a race introduced in #223 where it's possible to send an *Error to a closed s.close causing a panic.

Fixes https://github.com/Azure/go-amqp/issues/81