### PR TITLE
Remove concept of "max credit" from Receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 * `Dial()` and `NewConn()` now require a `context.Context` as their first parameter.
   * As a result, the `ConnOptions.Timeout` field has been removed.
 * Methods `Sender.Send()` and `Receiver.Receive()` now take their respective options-type as the final argument.
-* The `Credit` field in `ReceiverOptions` has been renamed to `MaxCredit` to better reflect its purpose.
+* The `ManualCredits` field in `ReceiverOptions` has been consolidated into field `Credit`.
 * Renamed fields in the `ReceiverOptions` for configuring options on the source.
 * Renamed `DetachError` to `LinkError` as "detach" has a specific meaning which doesn't equate to the returned link errors.
+* The `Batching` field in `ReceiverOptions` has been renamed to `BatchSize` and its type changed to `uint32`.
+* Received messages must now be acknowledged regardless of the sender settlement mode.
 
 ### Bugs Fixed
 

--- a/creditor.go
+++ b/creditor.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -103,14 +102,12 @@ func (mc *creditor) Drain(ctx context.Context, r *Receiver) error {
 
 // IssueCredit queues up additional credits to be requested at the next
 // call of FlowBits()
-func (mc *creditor) IssueCredit(credits uint32, r *Receiver) error {
+func (mc *creditor) IssueCredit(credits uint32) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
 	if mc.drained != nil {
 		return errLinkDraining
-	} else if unsettled := uint32(r.countUnsettled()); credits+unsettled+r.l.linkCredit > r.maxCredit {
-		return fmt.Errorf("link credit exceeded: requested %d, available %d, max %d, %d unsettled messages", credits, r.l.linkCredit, r.maxCredit, unsettled)
 	}
 
 	mc.creditsToAdd += credits

--- a/creditor_test.go
+++ b/creditor_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestCreditorIssueCredits(t *testing.T) {
 	r := newTestLink(t)
-	r.maxCredit = 100
-	require.NoError(t, r.creditor.IssueCredit(3, r))
+	require.NoError(t, r.creditor.IssueCredit(3))
 
 	drain, credits := r.creditor.FlowBits(1)
 	require.False(t, drain)
@@ -31,8 +30,7 @@ func TestCreditorDrain(t *testing.T) {
 	defer cancel()
 
 	r := newTestLink(t)
-	r.maxCredit = 100
-	require.NoError(t, r.creditor.IssueCredit(3, r))
+	require.NoError(t, r.creditor.IssueCredit(3))
 
 	// only one drain allowed at a time.
 	drainRoutines := sync.WaitGroup{}
@@ -80,8 +78,7 @@ func TestCreditorIssueCreditsWhileDrainingFails(t *testing.T) {
 	defer cancel()
 
 	r := newTestLink(t)
-	r.maxCredit = 100
-	require.NoError(t, r.creditor.IssueCredit(3, r))
+	require.NoError(t, r.creditor.IssueCredit(3))
 
 	// only one drain allowed at a time.
 	drainRoutines := sync.WaitGroup{}
@@ -99,7 +96,7 @@ func TestCreditorIssueCreditsWhileDrainingFails(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// drain is still active, so...
-	require.Error(t, r.creditor.IssueCredit(1, r), errLinkDraining.Error())
+	require.Error(t, r.creditor.IssueCredit(1), errLinkDraining.Error())
 
 	r.creditor.EndDrain()
 	wg.Wait()

--- a/example_test.go
+++ b/example_test.go
@@ -52,7 +52,7 @@ func Example() {
 	{
 		// create a receiver
 		receiver, err := session.NewReceiver(ctx, "/queue-name", &amqp.ReceiverOptions{
-			MaxCredit: 10,
+			Credit: 10,
 		})
 		if err != nil {
 			log.Fatal("Creating receiver link:", err)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -35,7 +35,7 @@ func fuzzConn(data []byte) int {
 	}
 
 	r, err := s.NewReceiver(context.Background(), "source", &ReceiverOptions{
-		MaxCredit: 2,
+		Credit: 2,
 	})
 	if err != nil {
 		return 0

--- a/integration_test.go
+++ b/integration_test.go
@@ -1049,7 +1049,7 @@ func TestReceivingLotsOfSettledMessages(t *testing.T) {
 	require.EqualValues(t, linkCredit, receivedCount)
 
 	for _, msg := range unsettledMsgs {
-		receiver.AcceptMessage(context.Background(), msg)
+		require.NoError(t, receiver.AcceptMessage(context.Background(), msg))
 	}
 
 	// should have more credit now

--- a/integration_test.go
+++ b/integration_test.go
@@ -157,7 +157,7 @@ func TestIntegrationRoundTrip(t *testing.T) {
 					// Create a receiver
 					ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 					receiver, err := session.NewReceiver(ctx, targetName, &amqp.ReceiverOptions{
-						MaxCredit: 10,
+						Credit: 10,
 					})
 					cancel()
 					if err != nil {
@@ -284,7 +284,7 @@ func TestIntegrationRoundTrip_Buffered(t *testing.T) {
 			// Create a receiver
 			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			receiver, err := session.NewReceiver(ctx, targetName, &amqp.ReceiverOptions{
-				MaxCredit:                 uint32(len(tt.data)),
+				Credit:                    int32(len(tt.data)),
 				RequestedSenderSettleMode: amqp.SenderSettleModeSettled.Ptr(),
 			})
 			cancel()
@@ -902,7 +902,7 @@ func TestReceiverModeFirst(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	recv, err := session.NewReceiver(ctx, "TestReceiverModeFirst", &amqp.ReceiverOptions{
-		MaxCredit: linkCredit,
+		Credit: linkCredit,
 	})
 	cancel()
 	require.NoError(t, err)
@@ -984,6 +984,92 @@ func TestSenderExactlyOnce(t *testing.T) {
 	require.Equal(t, "hello!", string(msg.GetData()))
 	client.Close()
 	checkLeaks()
+}
+
+func TestReceivingLotsOfSettledMessages(t *testing.T) {
+	if localBrokerAddr == "" {
+		t.Skip()
+	}
+
+	// Create client
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	cancel()
+	require.NoError(t, err)
+
+	// Open a session
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+
+	// Create a sender
+	// add a random suffix to the link name so the test broker always creates a new node
+	targetName := fmt.Sprintf("TestReceivingLotsOfSettledMessages %d", rng.Uint64())
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	sender, err := session.NewSender(ctx, targetName, nil)
+	cancel()
+	require.NoError(t, err)
+
+	const linkCredit = 10
+
+	// send more messages than the receiver's link credit
+	const msgCount = linkCredit * 2
+	for i := 0; i < msgCount; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		err = sender.Send(ctx, amqp.NewMessage([]byte(fmt.Sprintf("TestReceivingLotsOfSettledMessages %d", i))), nil)
+		cancel()
+		require.NoError(t, err)
+	}
+	testClose(t, sender.Close)
+
+	// Create a receiver
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	receiver, err := session.NewReceiver(ctx, targetName, &amqp.ReceiverOptions{
+		Credit:                    linkCredit,
+		RequestedSenderSettleMode: amqp.SenderSettleModeSettled.Ptr(),
+	})
+	cancel()
+	require.NoError(t, err)
+
+	unsettledMsgs := []*amqp.Message{}
+	var receivedCount int
+	for i := 0; i < msgCount; i++ {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := receiver.Receive(ctx, nil)
+		cancel()
+		if errors.Is(err, context.DeadlineExceeded) {
+			break
+		}
+		receivedCount++
+		unsettledMsgs = append(unsettledMsgs, msg)
+	}
+
+	// shouldn't receive more than linkCredit
+	require.EqualValues(t, linkCredit, receivedCount)
+
+	for _, msg := range unsettledMsgs {
+		receiver.AcceptMessage(context.Background(), msg)
+	}
+
+	// should have more credit now
+	for i := 0; i < linkCredit; i++ {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := receiver.Receive(ctx, nil)
+		cancel()
+		if errors.Is(err, context.DeadlineExceeded) {
+			break
+		}
+		receivedCount++
+		unsettledMsgs = append(unsettledMsgs, msg)
+	}
+
+	// now we received all the messages
+	require.EqualValues(t, msgCount, receivedCount)
+
+	testClose(t, receiver.Close)
+
+	client.Close()
 }
 
 func repeatStrings(count int, strs ...string) []string {

--- a/link_options.go
+++ b/link_options.go
@@ -86,14 +86,14 @@ type SenderOptions struct {
 }
 
 type ReceiverOptions struct {
-	// LinkBatching toggles batching of message disposition.
+	// BatchSize toggles batching of message disposition.
 	//
 	// When enabled, accepting a message does not send the disposition
-	// to the server until the batch is equal to link credit or the
+	// to the server until the batch is equal to BatchSize or the
 	// batch max age expires.
 	//
-	// Default: false.
-	Batching bool
+	// Default: 0.
+	BatchSize uint32
 
 	// BatchMaxAge sets the maximum time between the start
 	// of a disposition batch and sending the batch to the server.
@@ -106,11 +106,20 @@ type ReceiverOptions struct {
 	// Capabilities is the list of extension capabilities the receiver supports.
 	Capabilities []string
 
-	// MaxCredit specifies the maximum number of unacknowledged messages
-	// the sender can transmit.
+	// Credit specifies the maximum number of unacknowledged messages
+	// the sender can transmit.  Once this limit is reached, no more messages
+	// will arrive until messages are acknowledged and settled.
+	//
+	// As messages are settled, any available credit will automatically be issued.
+	//
+	// Setting this to -1 requires manual management of link credit.
+	// Credits can be added with IssueCredit(), and links can also be
+	// drained with DrainCredit().
+	// This should only be enabled when complete control of the link's
+	// flow control is required.
 	//
 	// Default: 1.
-	MaxCredit uint32
+	Credit int32
 
 	// Durability indicates what state of the receiver will be retained durably.
 	//
@@ -138,13 +147,6 @@ type ReceiverOptions struct {
 	// Filters contains the desired filters for this receiver.
 	// If the peer cannot fulfill the filters the link will be detached.
 	Filters []LinkFilter
-
-	// ManualCredits enables manual credit management for this link.
-	// Credits can be added with IssueCredit(), and links can also be
-	// drained with DrainCredit().
-	// This should only be enabled when complete control of the link's
-	// flow control is required.
-	ManualCredits bool
 
 	// MaxMessageSize sets the maximum message size that can
 	// be received on the link.

--- a/link_test.go
+++ b/link_test.go
@@ -30,7 +30,7 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 		l.l.linkCredit = 1
 		l.unsettledMessages = map[string]struct{}{}
 
-		require.NoError(t, l.onSettlement(1))
+		l.onSettlement(1)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	Loop:
@@ -223,10 +223,9 @@ func newTestLink(t *testing.T) *Receiver {
 			rx:    make(chan frames.FrameBody, 100),
 			close: make(chan struct{}),
 		},
-		autoSendFlow:    true,
-		inFlight:        inFlight{},
-		settlementCount: make(chan uint32),
-		receiverReady:   make(chan struct{}, 1),
+		autoSendFlow:  true,
+		inFlight:      inFlight{},
+		receiverReady: make(chan struct{}, 1),
 	}
 
 	l.messagesQ = queue.NewHolder(queue.New[Message](100))

--- a/message.go
+++ b/message.go
@@ -144,10 +144,6 @@ func (m *Message) MarshalBinary() ([]byte, error) {
 	return buf.Detach(), err
 }
 
-func (m *Message) shouldSendDisposition() bool {
-	return !m.settled
-}
-
 func (m *Message) Marshal(wr *buffer.Buffer) error {
 	if m.Header != nil {
 		err := m.Header.Marshal(wr)

--- a/receiver.go
+++ b/receiver.go
@@ -703,14 +703,13 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 
 	// flow control frame
 	case *frames.PerformFlow:
-		// if the 'drain' flag has been set in the frame sent to the _receiver_ then
-		// we signal whomever is waiting (the service has seen and acknowledged our drain)
-		if fr.Drain && !r.autoSendFlow {
-			r.l.linkCredit = 0 // we have no active credits at this point.
-			r.creditor.EndDrain()
-		}
-
 		if !fr.Echo {
+			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
+			// we signal whomever is waiting (the service has seen and acknowledged our drain)
+			if fr.Drain && !r.autoSendFlow {
+				r.l.linkCredit = 0 // we have no active credits at this point.
+				r.creditor.EndDrain()
+			}
 			return nil
 		}
 

--- a/receiver.go
+++ b/receiver.go
@@ -536,8 +536,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (r *Receiver) attach(ctx context.Context) error {
-	// TODO: remove double-buffering
-	r.l.rx = make(chan frames.FrameBody, r.l.linkCredit)
+	r.l.rx = make(chan frames.FrameBody)
 
 	if err := r.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleReceiver

--- a/receiver.go
+++ b/receiver.go
@@ -531,7 +531,8 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (r *Receiver) attach(ctx context.Context) error {
-	r.l.rx = make(chan frames.FrameBody)
+	// TODO: remove double-buffering
+	r.l.rx = make(chan frames.FrameBody, r.l.linkCredit)
 
 	if err := r.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleReceiver

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1283,9 +1283,9 @@ func TestReceiverDispositionBatcherTimer(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching:       true,
+		BatchSize:      2,
 		BatchMaxAge:    time.Second,
-		MaxCredit:      2,
+		Credit:         2,
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	})
 	cancel()
@@ -1351,9 +1351,9 @@ func TestReceiverDispositionBatcherFull(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching:       true,
+		BatchSize:      credit,
 		BatchMaxAge:    time.Second,
-		MaxCredit:      credit,
+		Credit:         credit,
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	})
 	cancel()
@@ -1427,9 +1427,9 @@ func TestReceiverDispositionBatcherRelease(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching:       true,
+		BatchSize:      credit,
 		BatchMaxAge:    time.Second,
-		MaxCredit:      credit,
+		Credit:         credit,
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	})
 	cancel()

--- a/session.go
+++ b/session.go
@@ -209,15 +209,16 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 		return nil, err
 	}
 
-	// batching is just extra overhead when maxCredits == 1
-	if r.maxCredit == 1 {
-		r.batching = false
+	// batching is just extra overhead when linkCredit == 1
+	// TODO: probably extra overhead for some small values of linkCredit?
+	if r.autoSendFlow && r.l.linkCredit == 1 {
+		r.batchSize = 0
 	}
 
 	// create dispositions channel and start dispositionBatcher if batching enabled
-	if r.batching {
+	if r.batchSize > 0 {
 		// buffer dispositions chan to prevent disposition sends from blocking
-		r.dispositions = make(chan messageDisposition, r.maxCredit)
+		r.dispositions = make(chan messageDisposition, r.batchSize)
 		go r.dispositionBatcher()
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -235,12 +235,12 @@ func TestSessionNewReceiverBatchingOneCredit(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching: true,
+		BatchSize: 5,
 	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, recv)
-	require.Equal(t, false, recv.batching, "expected batching disabled with one link credit")
+	require.EqualValues(t, 0, recv.batchSize, "expected batching disabled with one link credit")
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = session.Close(ctx)
 	cancel()
@@ -282,13 +282,13 @@ func TestSessionNewReceiverBatchingEnabled(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching:  true,
-		MaxCredit: 10,
+		BatchSize: 10,
+		Credit:    10,
 	})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, recv)
-	require.Equal(t, true, recv.batching, "expected batching enabled with multiple link credits")
+	require.EqualValues(t, 10, recv.batchSize, "expected batching enabled with multiple link credits")
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = session.Close(ctx)
 	cancel()
@@ -328,8 +328,8 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	recv, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
-		Batching:  true,
-		MaxCredit: 10,
+		BatchSize: 10,
+		Credit:    10,
 	})
 	cancel()
 	require.Error(t, err)


### PR DESCRIPTION
This exposed an implementation detail of how Receivers worked.  With the removal of the Message channel, this is no longer required and never really made sense anyways.
The MaxCredit and ManualCredits options have been consolidated into a single Credit option.  This is used to set the total credit for a Receiver in auto-flow mode, or to disable auto-flow. Disposition batching needed some slight refactoring.  Now you can directly specify the batch size instead of it being tied to link credit.
Received messages that are sender-settled now correctly count towards a Receiver's credit and must be settled to reclaim it.

Fixes
- https://github.com/Azure/go-amqp/issues/217
- https://github.com/Azure/go-amqp/issues/240
- https://github.com/Azure/go-amqp/issues/249