### PR TITLE
Added some additional benchmarks

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,235 @@
+package amqp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-amqp/internal/encoding"
+	"github.com/Azure/go-amqp/internal/fake"
+	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(SenderSettleModeUnsettled)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch tt := req.(type) {
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			return nil, nil
+		case *frames.PerformTransfer:
+			return fake.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	sndr, err := session.NewSender(ctx, "target", &SenderOptions{
+		SettlementMode: SenderSettleModeUnsettled.Ptr(),
+	})
+	cancel()
+	require.NoError(b, err)
+	sendInitialFlowFrame(b, conn, 0, 1000000)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	msg := NewMessage([]byte("test"))
+	for i := 0; i < b.N; i++ {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		err = sndr.Send(ctx, msg, nil)
+		cancel()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkSenderSendSSMSettled(b *testing.B) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(SenderSettleModeSettled)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			return nil, nil
+		case *frames.PerformTransfer:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	sndr, err := session.NewSender(ctx, "target", &SenderOptions{
+		SettlementMode: SenderSettleModeSettled.Ptr(),
+	})
+	cancel()
+	require.NoError(b, err)
+	sendInitialFlowFrame(b, conn, 0, 1000000)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	msg := NewMessage([]byte("test"))
+	for i := 0; i < b.N; i++ {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		err = sndr.Send(ctx, msg, nil)
+		cancel()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ReceiverSettleModeFirst)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	rcvr, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeFirst.Ptr(),
+	})
+	cancel()
+	require.NoError(b, err)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
+		require.NoError(b, err)
+		conn.SendFrame(fr)
+		b.StartTimer()
+
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		_, err = rcvr.Receive(ctx, nil)
+		cancel()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ReceiverSettleModeSecond)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	rcvr, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeSecond.Ptr(),
+	})
+	cancel()
+	require.NoError(b, err)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
+		require.NoError(b, err)
+		conn.SendFrame(fr)
+		b.StartTimer()
+
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		_, err = rcvr.Receive(ctx, nil)
+		cancel()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkReceiverSettleMessage(b *testing.B) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(ReceiverSettleModeFirst)(req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow:
+			return nil, nil
+		case *frames.PerformDisposition:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(b, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	rcvr, err := session.NewReceiver(ctx, "source", nil)
+	cancel()
+	require.NoError(b, err)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		require.NoError(b, rcvr.AcceptMessage(ctx, &Message{deliveryID: 0}))
+		cancel()
+	}
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -132,15 +132,19 @@ func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
 	})
 	cancel()
 	require.NoError(b, err)
+
+	transfers := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
+		require.NoError(b, err)
+		transfers[i] = fr
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
-		require.NoError(b, err)
-		conn.SendFrame(fr)
-		b.StartTimer()
+		conn.SendFrame(transfers[i])
 
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		_, err = rcvr.Receive(ctx, nil)
@@ -179,15 +183,19 @@ func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
 	})
 	cancel()
 	require.NoError(b, err)
+
+	transfers := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
+		require.NoError(b, err)
+		transfers[i] = fr
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		fr, err := fake.PerformTransfer(0, 0, uint32(i), []byte{})
-		require.NoError(b, err)
-		conn.SendFrame(fr)
-		b.StartTimer()
+		conn.SendFrame(transfers[i])
 
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		_, err = rcvr.Receive(ctx, nil)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/Azure/go-amqp/internal/encoding"
@@ -13,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func sendInitialFlowFrame(t *testing.T, netConn *fake.NetConn, handle uint32, credit uint32) {
+func sendInitialFlowFrame(t require.TestingT, netConn *fake.NetConn, handle uint32, credit uint32) {
 	nextIncoming := uint32(0)
 	count := uint32(0)
 	available := uint32(0)
 	b, err := fake.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
 		NextIncomingID: &nextIncoming,
-		IncomingWindow: 1000,
-		OutgoingWindow: 1000,
+		IncomingWindow: 1000000,
+		OutgoingWindow: 1000000,
 		NextOutgoingID: nextIncoming + 1,
 		Handle:         &handle,
 		DeliveryCount:  &count,

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -148,6 +148,9 @@ func BenchmarkMarshal(b *testing.B) {
 
 func BenchmarkUnmarshal(b *testing.B) {
 	for _, type_ := range allTypes {
+		if type_ == nil {
+			continue
+		}
 		b.Run(fmt.Sprintf("%T", type_), func(b *testing.B) {
 			var buf buffer.Buffer
 			err := encoding.Marshal(&buf, type_)


### PR DESCRIPTION
Includes measurments for sending, receiving, and settling messages. Bumped up test session window to avoid flow control. Fixed a panic in the unmarshalling benchmark.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
