### PR TITLE
Replace incoming frame channels with queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   * DEBUG_LEVEL 1 now captures all sent/received frames along with basic flow control information.
   * Higher debug levels add entries when a frame transitions across mux boundaries and other diagnostics info.
 * Document default values for incoming and outgoing windows.
+* Refactored handling of incoming frames to eliminate potential deadlocks due to "mux pumping".
 
 ## 0.18.1 (2023-01-17)
 

--- a/conn.go
+++ b/conn.go
@@ -509,16 +509,10 @@ func (c *Conn) connReader() {
 			}
 		}
 
-		select {
-		case session.rx <- fr.Body:
-			// sent to session
-			debug.Log(2, "RX (connReader): mux frame to session: %s", fr)
-		case <-session.done:
-			// the session has terminated (or at least its mux has)
-			// we should only hit this if a session's mux abnormally terminated
-		case <-c.rxtxExit:
-			return
-		}
+		q := session.rxQ.Acquire()
+		q.Enqueue(fr.Body)
+		session.rxQ.Release(q)
+		debug.Log(2, "RX (connReader): mux frame to session: %s", fr)
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package amqp
 
 import (
+	"context"
+	"errors"
+
 	"github.com/Azure/go-amqp/internal/encoding"
 )
 
@@ -101,4 +104,8 @@ func (e *SessionError) Error() string {
 		return e.RemoteErr.Error()
 	}
 	return e.inner.Error()
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/link.go
+++ b/link.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/queue"
+	"github.com/Azure/go-amqp/internal/shared"
 )
 
 // linkKey uniquely identifies a link on a connection by name and direction.
@@ -27,15 +29,17 @@ type linkKey struct {
 
 // link contains the common state and methods for sending and receiving links
 type link struct {
-	key          linkKey               // Name and direction
-	handle       uint32                // our handle
-	remoteHandle uint32                // remote's handle
-	dynamicAddr  bool                  // request a dynamic link address from the server
-	rx           chan frames.FrameBody // sessions sends frames for this link on this channel
+	key          linkKey // Name and direction
+	handle       uint32  // our handle
+	remoteHandle uint32  // remote's handle
+	dynamicAddr  bool    // request a dynamic link address from the server
+
+	// frames destined for this link are added to this queue by Session.muxFrameToLink
+	rxQ *queue.Holder[frames.FrameBody]
 
 	// used for gracefully closing link
 	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
-	closeOnce sync.Once     // closeOnce protects close from being closed multiple times
+	closeOnce *sync.Once    // closeOnce protects close from being closed multiple times
 
 	done    chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
 	doneErr error         // contains the error state returned from Close(); DO NOT TOUCH outside of link.go until done has been closed!
@@ -67,6 +71,49 @@ type link struct {
 	detachReceived     bool // set to true when the peer initiates link detach/close
 }
 
+func newLink(s *Session, r encoding.Role) link {
+	l := link{
+		key:       linkKey{shared.RandString(40), r},
+		session:   s,
+		close:     make(chan struct{}),
+		closeOnce: &sync.Once{},
+		done:      make(chan struct{}),
+	}
+
+	// set the segment size relative to respective window
+	var segmentSize int
+	if r == encoding.RoleReceiver {
+		segmentSize = int(s.incomingWindow)
+	} else {
+		segmentSize = int(s.outgoingWindow)
+	}
+
+	l.rxQ = queue.NewHolder(queue.New[frames.FrameBody](int(segmentSize)))
+	return l
+}
+
+// waitForFrame waits for an incoming frame to be queued.
+// it returns the next frame from the queue, or an error.
+// the error is either from the context or session.doneErr.
+// not meant for consumption outside of link.go.
+func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
+	var q *queue.Queue[frames.FrameBody]
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.session.done:
+		// session has terminated, no need to deallocate in this case
+		return nil, l.session.doneErr
+	case q = <-l.rxQ.Wait():
+		// frame received
+	}
+
+	fr := q.Dequeue()
+	l.rxQ.Release(q)
+
+	return *fr, nil
+}
+
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
@@ -91,9 +138,8 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	_ = l.session.txFrame(attach, nil)
 
 	// wait for response
-	var fr frames.FrameBody
-	select {
-	case <-ctx.Done():
+	fr, err := l.waitForFrame(ctx)
+	if isContextErr(err) {
 		// attach was written to the network. assume it was received
 		// and that the ctx was too short to wait for the ack.
 		go func() {
@@ -102,13 +148,13 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			l.muxClose(ctx, nil, nil, nil)
 		}()
 		return ctx.Err()
-	case <-l.session.done:
-		// session has terminated, no need to deallocate in this case
-		return l.session.doneErr
-	case fr = <-l.rx:
+	} else if err != nil {
+		return err
 	}
+
 	resp, ok := fr.(*frames.PerformAttach)
 	if !ok {
+		// TODO: seems like more cleanup is in order
 		return fmt.Errorf("unexpected attach response: %#v", fr)
 	}
 
@@ -123,8 +169,8 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-transport-v1.0-csprd01.html#doc-idp386144
 	if resp.Source == nil && resp.Target == nil {
 		// wait for detach
-		select {
-		case <-ctx.Done():
+		fr, err := l.waitForFrame(ctx)
+		if isContextErr(err) {
 			// if we don't send an ack then we're in violation of the protocol
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -132,10 +178,8 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 				l.muxClose(ctx, nil, nil, nil)
 			}()
 			return ctx.Err()
-		case <-l.session.done:
-			return l.session.doneErr
-		case fr = <-l.rx:
-			l.session.deallocateHandle(l)
+		} else if err != nil {
+			return err
 		}
 
 		detach, ok := fr.(*frames.PerformDetach)
@@ -284,63 +328,45 @@ func (l *link) muxClose(ctx context.Context, err *Error, deferred func(), onRXTr
 		Error:  err,
 	}
 
-Loop:
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case l.session.tx <- fr:
-			// after sending the detach frame, break the read loop
-			break Loop
-		case fr := <-l.rx:
-			// read from link to avoid blocking session.mux
-			switch fr := fr.(type) {
-			case *frames.PerformDetach:
-				if fr.Closed {
-					l.detachReceived = true
-				}
-			case *frames.PerformTransfer:
-				if onRXTransfer != nil {
-					onRXTransfer(*fr)
-				}
-			}
-		case <-l.session.done:
-			if l.doneErr == nil {
-				l.doneErr = l.session.doneErr
-			}
-			return
+	select {
+	case <-ctx.Done():
+		return
+	case l.session.tx <- fr:
+		// frame sent to our session mux
+	case <-l.session.done:
+		if l.doneErr == nil {
+			l.doneErr = l.session.doneErr
 		}
+		return
 	}
 
-	// don't wait for remote to detach when already received
+	// if the peer initiated the close then we just sent the ack so we're done
 	if l.detachReceived {
 		return
 	}
 
+	// wait for the ack
 	for {
-		select {
-		case <-ctx.Done():
+		fr, err := l.waitForFrame(ctx)
+		if isContextErr(err) {
+			// TODO: expired context
 			return
-
-		// read from link until detach with Close == true is received
-		case fr := <-l.rx:
-			switch fr := fr.(type) {
-			case *frames.PerformDetach:
-				if fr.Closed {
-					return
-				}
-			case *frames.PerformTransfer:
-				if onRXTransfer != nil {
-					onRXTransfer(*fr)
-				}
-			}
-
-		// connection has ended
-		case <-l.session.done:
+		} else if err != nil {
 			if l.doneErr == nil {
-				l.doneErr = l.session.doneErr
+				l.doneErr = err
 			}
 			return
+		}
+
+		switch fr := fr.(type) {
+		case *frames.PerformDetach:
+			if fr.Closed {
+				return
+			}
+		case *frames.PerformTransfer:
+			if onRXTransfer != nil {
+				onRXTransfer(*fr)
+			}
 		}
 	}
 }

--- a/link_test.go
+++ b/link_test.go
@@ -220,7 +220,7 @@ func newTestLink(t *testing.T) *Receiver {
 				tx:   make(chan frames.FrameBody, 100),
 				done: make(chan struct{}),
 			},
-			rx:    make(chan frames.FrameBody, 100),
+			rxQ:   queue.NewHolder(queue.New[frames.FrameBody](100)),
 			close: make(chan struct{}),
 		},
 		autoSendFlow:  true,
@@ -297,7 +297,7 @@ func TestNewSendingLink(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			got, err := newSender(targetAddr, nil, &tt.opts)
+			got, err := newSender(targetAddr, &Session{}, &tt.opts)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			tt.validate(t, got)

--- a/sender.go
+++ b/sender.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
-	"github.com/Azure/go-amqp/internal/shared"
 )
 
 // Sender sends messages on a single AMQP link.
@@ -181,15 +180,11 @@ func (s *Sender) Close(ctx context.Context) error {
 
 // newSendingLink creates a new sending link and attaches it to the session
 func newSender(target string, session *Session, opts *SenderOptions) (*Sender, error) {
+	l := newLink(session, encoding.RoleSender)
+	l.target = &frames.Target{Address: target}
+	l.source = new(frames.Source)
 	s := &Sender{
-		l: link{
-			key:     linkKey{shared.RandString(40), encoding.RoleSender},
-			session: session,
-			close:   make(chan struct{}),
-			done:    make(chan struct{}),
-			target:  &frames.Target{Address: target},
-			source:  new(frames.Source),
-		},
+		l:                       l,
 		closeOnDispositionError: true,
 	}
 
@@ -257,8 +252,6 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 }
 
 func (s *Sender) attach(ctx context.Context) error {
-	s.l.rx = make(chan frames.FrameBody, 1)
-
 	if err := s.l.attach(ctx, func(pa *frames.PerformAttach) {
 		pa.Role = encoding.RoleSender
 		if pa.Target == nil {
@@ -288,11 +281,6 @@ func (s *Sender) attach(ctx context.Context) error {
 func (s *Sender) mux() {
 	defer s.l.muxClose(context.Background(), nil, nil, nil)
 
-	// used to track and send disposition frames.
-	// frames are sent in FIFO order.
-	outgoingDisp := make(chan *frames.PerformDisposition, 1)
-	outgoingDisps := []*frames.PerformDisposition{}
-
 Loop:
 	for {
 		var outgoingTransfers chan frames.PerformTransfer
@@ -303,72 +291,34 @@ Loop:
 			debug.Log(1, "TX (Sender) (pause): target: %q, available credit: %d, deliveryCount: %d", s.l.target.Address, s.l.availableCredit, s.l.deliveryCount)
 		}
 
-		if len(outgoingDisps) > 0 && len(outgoingDisp) == 0 {
-			// queue up the next outgoing frame and remove it from the slice
-			outgoingDisp <- outgoingDisps[0]
-			outgoingDisps = outgoingDisps[1:]
-		}
-
-		handleFrame := func(fr frames.FrameBody) error {
-			var disp *frames.PerformDisposition
-			disp, s.l.doneErr = s.muxHandleFrame(fr)
-			if s.l.doneErr != nil {
-				return s.l.doneErr
-			} else if disp != nil {
-				outgoingDisps = append(outgoingDisps, disp)
-			}
-			return nil
-		}
-
 		select {
-		case dr := <-outgoingDisp:
-			// Ensure the session mux is not blocked
-			for {
-				select {
-				case s.l.session.tx <- dr:
-					debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, dr)
-					continue Loop
-				case fr := <-s.l.rx:
-					if err := handleFrame(fr); err != nil {
-						return
-					}
-				case <-s.l.close:
-					continue Loop
-				case <-s.l.session.done:
-					continue Loop
-				}
-			}
-
 		// received frame
-		case fr := <-s.l.rx:
-			if err := handleFrame(fr); err != nil {
+		case q := <-s.l.rxQ.Wait():
+			// populated queue
+			fr := *q.Dequeue()
+			s.l.rxQ.Release(q)
+			s.l.doneErr = s.muxHandleFrame(fr)
+			if s.l.doneErr != nil {
 				return
 			}
 
 		// send data
 		case tr := <-outgoingTransfers:
-			// Ensure the session mux is not blocked
-			for {
-				select {
-				case s.l.session.txTransfer <- &tr:
-					debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
-					// decrement link-credit after entire message transferred
-					if !tr.More {
-						s.l.deliveryCount++
-						s.l.availableCredit--
-						// we are the sender and we keep track of the peer's link credit
-						debug.Log(3, "TX (Sender): link: %s, available credit: %d", s.l.key.name, s.l.availableCredit)
-					}
-					continue Loop
-				case fr := <-s.l.rx:
-					if err := handleFrame(fr); err != nil {
-						return
-					}
-				case <-s.l.close:
-					continue Loop
-				case <-s.l.session.done:
-					continue Loop
+			select {
+			case s.l.session.txTransfer <- &tr:
+				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
+				// decrement link-credit after entire message transferred
+				if !tr.More {
+					s.l.deliveryCount++
+					s.l.availableCredit--
+					// we are the sender and we keep track of the peer's link credit
+					debug.Log(3, "TX (Sender): link: %s, available credit: %d", s.l.key.name, s.l.availableCredit)
 				}
+				continue Loop
+			case <-s.l.close:
+				continue Loop
+			case <-s.l.session.done:
+				continue Loop
 			}
 
 		case <-s.l.close:
@@ -384,7 +334,7 @@ Loop:
 
 // muxHandleFrame processes fr based on type.
 // depending on the peer's RSM, it might return a disposition frame for sending
-func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition, error) {
+func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 	debug.Log(2, "RX (Sender): %s", fr)
 	switch fr := fr.(type) {
 	// flow control frame
@@ -400,7 +350,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition
 		s.l.availableCredit = linkCredit
 
 		if !fr.Echo {
-			return nil, nil
+			return nil
 		}
 
 		var (
@@ -409,41 +359,60 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) (*frames.PerformDisposition
 		)
 
 		// send flow
-		// TODO: missing Available and session info
+		// TODO: missing Available
 		resp := &frames.PerformFlow{
 			Handle:        &s.l.handle,
 			DeliveryCount: &deliveryCount,
 			LinkCredit:    &linkCredit, // max number of messages
 		}
-		_ = s.l.session.txFrame(resp, nil)
+
+		select {
+		case s.l.session.tx <- resp:
+			debug.Log(2, "TX (Sender): %s", resp)
+		case <-s.l.close:
+			return &LinkError{}
+		case <-s.l.session.done:
+			return s.l.session.doneErr
+		}
 
 	case *frames.PerformDisposition:
 		// If sending async and a message is rejected, cause a link error.
 		//
 		// This isn't ideal, but there isn't a clear better way to handle it.
 		if fr, ok := fr.State.(*encoding.StateRejected); ok && s.detachOnRejectDisp() {
-			return nil, &LinkError{RemoteErr: fr.Error}
+			return &LinkError{RemoteErr: fr.Error}
 		}
 
 		if fr.Settled {
-			return nil, nil
+			return nil
 		}
 
 		// peer is in mode second, so we must send confirmation of disposition.
 		// NOTE: the ack must be sent through the session so it can close out
 		// the in-flight disposition.
-		return &frames.PerformDisposition{
+		dr := &frames.PerformDisposition{
 			Role:    encoding.RoleSender,
 			First:   fr.First,
 			Last:    fr.Last,
 			Settled: true,
-		}, nil
+		}
+
+		select {
+		case s.l.session.tx <- dr:
+			debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, dr)
+		case <-s.l.close:
+			return &LinkError{}
+		case <-s.l.session.done:
+			return s.l.session.doneErr
+		}
+
+		return nil
 
 	default:
-		return nil, s.l.muxHandleFrame(fr)
+		return s.l.muxHandleFrame(fr)
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (s *Sender) detachOnRejectDisp() bool {

--- a/sender_test.go
+++ b/sender_test.go
@@ -862,6 +862,7 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 		}
 		switch tt := req.(type) {
 		case *frames.PerformFlow:
+			require.False(t, tt.Echo)
 			defer func() { close(echo) }()
 			// here we receive the echo.  verify state
 			if id := *tt.Handle; id != 0 {

--- a/session.go
+++ b/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-amqp/internal/debug"
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/queue"
 )
 
 // Default session options
@@ -48,9 +49,11 @@ type Session struct {
 	channel       uint16                       // session's local channel
 	remoteChannel uint16                       // session's remote channel, owned by conn.connReader
 	conn          *Conn                        // underlying conn
-	rx            chan frames.FrameBody        // frames destined for this session are sent on this chan by conn.connReader
 	tx            chan frames.FrameBody        // non-transfer frames to be sent; session must track disposition
 	txTransfer    chan *frames.PerformTransfer // transfer frames to be sent; session must track disposition
+
+	// frames destined for this session are added to this queue by conn.connReader
+	rxQ *queue.Holder[frames.FrameBody]
 
 	// flow control
 	incomingWindow uint32
@@ -77,7 +80,6 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 	s := &Session{
 		conn:           c,
 		channel:        channel,
-		rx:             make(chan frames.FrameBody),
 		tx:             make(chan frames.FrameBody),
 		txTransfer:     make(chan *frames.PerformTransfer),
 		incomingWindow: defaultWindow,
@@ -103,9 +105,34 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 			s.outgoingWindow = opts.OutgoingWindow
 		}
 	}
+
 	// create handle map after options have been applied
 	s.handles = bitmap.New(s.handleMax)
+
+	s.rxQ = queue.NewHolder(queue.New[frames.FrameBody](int(s.incomingWindow)))
+
 	return s
+}
+
+// waitForFrame waits for an incoming frame to be queued.
+// it returns the next frame from the queue, or an error.
+// the error is either from the context or conn.doneErr.
+// not meant for consumption outside of session.go.
+func (s *Session) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
+	var q *queue.Queue[frames.FrameBody]
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.conn.done:
+		return nil, s.conn.doneErr
+	case q = <-s.rxQ.Wait():
+		// populated queue
+	}
+
+	fr := q.Dequeue()
+	s.rxQ.Release(q)
+
+	return *fr, nil
 }
 
 func (s *Session) begin(ctx context.Context) error {
@@ -120,31 +147,36 @@ func (s *Session) begin(ctx context.Context) error {
 	_ = s.txFrame(begin, nil)
 
 	// wait for response
-	var fr frames.FrameBody
-	select {
-	case <-ctx.Done():
+	fr, err := s.waitForFrame(ctx)
+	if isContextErr(err) {
 		// begin was written to the network.  assume it was
 		// received and that the ctx was too short to wait for
 		// the ack.
 		go func() {
 			_ = s.txFrame(&frames.PerformEnd{}, nil)
-			select {
-			case <-s.conn.done:
-				// conn has terminated, no need to delete the session
-			case <-time.After(5 * time.Second):
-				// don't delete the session in this case. this is to avoid recylcing
-				// a channel number for a session that might not have terminated
-				debug.Log(3, "session.begin clean-up timed out waiting for PerformEnd ack")
-			case <-s.rx:
-				// received ack that session was closed, safe to delete session
-				s.conn.deleteSession(s)
+
+			// wait for the ack
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			for {
+				if fr, err := s.waitForFrame(ctx); isContextErr(err) {
+					// don't delete the session in this case. this is to avoid recylcing
+					// a channel number for a session that might not have terminated
+					debug.Log(3, "session.begin clean-up timed out waiting for PerformEnd ack")
+					return
+				} else if err != nil {
+					return
+				} else if _, ok := fr.(*frames.PerformEnd); ok {
+					// received ack that session was closed, safe to delete session
+					s.conn.deleteSession(s)
+					return
+				}
 			}
 		}()
 		return ctx.Err()
-	case <-s.conn.done:
-		return s.conn.doneErr
-	case fr = <-s.rx:
-		// received ack that session was created
+	} else if err != nil {
+		return err
 	}
 
 	begin, ok := fr.(*frames.PerformBegin)
@@ -306,8 +338,11 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			// TODO: per spec, after end has been sent, the session is no longer allowed to send frames
 
 		// incoming frame
-		case fr := <-s.rx:
+		case q := <-s.rxQ.Wait():
+			fr := *q.Dequeue()
+			s.rxQ.Release(q)
 			debug.Log(2, "RX (Session): %s", fr)
+
 			switch body := fr.(type) {
 			// Disposition frames can reference transfers from more than one
 			// link. Send this frame to all of them.
@@ -446,12 +481,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					continue
 				}
 
-				select {
-				case <-s.conn.done:
-					// conn terminated
-				case link.rx <- fr:
-					debug.Log(2, "RX (Session): mux transfer to link: %s", fr)
-				}
+				s.muxFrameToLink(link, fr)
+				debug.Log(2, "RX (Session): mux transfer to link: %s", fr)
 
 				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
 				if !body.Settled && body.DeliveryID != nil && link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond {
@@ -628,20 +659,13 @@ func (s *Session) deallocateHandle(l *link) {
 
 	delete(s.linksByKey, l.key)
 	s.handles.Remove(l.handle)
-	close(l.rx)
 }
 
 func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
-	select {
-	case l.rx <- fr:
-		debug.Log(2, "RX (Session): mux frame to link: %s, %s", l.key.name, fr)
-		// frame successfully sent to link
-	case <-l.done:
-		// link is closed
-		// this should be impossible to hit as the link has been removed from the session once done is closed
-	case <-s.conn.done:
-		// conn is closed
-	}
+	q := l.rxQ.Acquire()
+	q.Enqueue(fr)
+	l.rxQ.Release(q)
+	debug.Log(2, "RX (Session): mux frame to link: %s, %s", l.key.name, fr)
 }
 
 // the address of this var is a sentinel value indicating


### PR DESCRIPTION
The rx channel in Session and link has been replaced with a queue.  This
ensures that parents enqueueing frames to their children is always a non
blocking operation and removes the need to "pump the mux".
Consolidated some link creation code into newLink().
Links echoing a flow frame now correctly include session info.
Reverted workaround for sending disposition frames from senders as we
can now send directly from muxHandleFrame.