### PR TITLE
Remove DrainCredit API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * The `Credit` field in `ReceiverOptions` has been renamed to `MaxCredit` to better reflect its purpose.
 * Renamed fields in the `ReceiverOptions` for configuring options on the source.
 * Renamed `DetachError` to `LinkError` as "detach" has a specific meaning which doesn't equate to the returned link errors.
+* The `Receiver.DrainCredit()` API has been removed.
 
 ### Bugs Fixed
 

--- a/receiver.go
+++ b/receiver.go
@@ -70,16 +70,6 @@ func (r *Receiver) IssueCredit(credit uint32) error {
 	return nil
 }
 
-// DrainCredit sets the drain flag on the next flow frame and
-// waits for the drain to be acknowledged.
-func (r *Receiver) DrainCredit(ctx context.Context) error {
-	if r.autoSendFlow {
-		return errors.New("drain can only be used with receiver links using manual credit management")
-	}
-
-	return r.creditor.Drain(ctx, r)
-}
-
 // Prefetched returns the next message that is stored in the Receiver's
 // prefetch cache. It does NOT wait for the remote sender to send messages
 // and returns immediately if the prefetch cache is empty. To receive from the


### PR DESCRIPTION
There's lack of uniformity on handling of drain across brokers, leading to flakey behavior.

Fixes https://github.com/Azure/go-amqp/issues/255