### PR TITLE
Remove configuration of session window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Renamed `DetachError` to `LinkError` as "detach" has a specific meaning which doesn't equate to the returned link errors.
 * The `Batching` field in `ReceiverOptions` has been renamed to `BatchSize` and its type changed to `uint32`.
 * Received messages must now be acknowledged regardless of the sender settlement mode.
+* The `IncomingWindow` and `OutgoingWindow` fields in `SessionOptions` have been removed.
 
 ### Bugs Fixed
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -557,28 +557,6 @@ func TestSessionOptions(t *testing.T) {
 		verify func(t *testing.T, s *Session)
 	}{
 		{
-			label: "SessionIncomingWindow",
-			opt: SessionOptions{
-				IncomingWindow: 5000,
-			},
-			verify: func(t *testing.T, s *Session) {
-				if s.incomingWindow != 5000 {
-					t.Errorf("unexpected incoming window %d", s.incomingWindow)
-				}
-			},
-		},
-		{
-			label: "SessionOutgoingWindow",
-			opt: SessionOptions{
-				OutgoingWindow: 6000,
-			},
-			verify: func(t *testing.T, s *Session) {
-				if s.outgoingWindow != 6000 {
-					t.Errorf("unexpected outgoing window %d", s.outgoingWindow)
-				}
-			},
-		},
-		{
 			label: "SessionMaxLinks",
 			opt: SessionOptions{
 				MaxLinks: 4096,
@@ -601,8 +579,6 @@ func TestSessionOptions(t *testing.T) {
 
 func TestClientNewSession(t *testing.T) {
 	const channelNum = 0
-	const incomingWindow = 5000
-	const outgoingWindow = 6000
 	responder := func(req frames.FrameBody) ([]byte, error) {
 		switch tt := req.(type) {
 		case *fake.AMQPProto:
@@ -612,12 +588,6 @@ func TestClientNewSession(t *testing.T) {
 		case *frames.PerformBegin:
 			if tt.RemoteChannel != nil {
 				return nil, errors.New("expected nil remote channel")
-			}
-			if tt.IncomingWindow != incomingWindow {
-				return nil, fmt.Errorf("unexpected incoming window %d", tt.IncomingWindow)
-			}
-			if tt.OutgoingWindow != outgoingWindow {
-				return nil, fmt.Errorf("unexpected incoming window %d", tt.OutgoingWindow)
 			}
 			return fake.PerformBegin(channelNum)
 		case *frames.PerformClose:
@@ -633,10 +603,7 @@ func TestClientNewSession(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	session, err := client.NewSession(ctx, &SessionOptions{
-		IncomingWindow: incomingWindow,
-		OutgoingWindow: outgoingWindow,
-	})
+	session, err := client.NewSession(ctx, nil)
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, session)

--- a/link.go
+++ b/link.go
@@ -61,10 +61,6 @@ type link struct {
 	// can independently set this value. The sender endpoint sets this to the last known value seen from the receiver.
 	linkCredit uint32
 
-	// The number of messages awaiting credit at the link sender endpoint. Only the sender can independently
-	// set this value. The receiver sets this to the last known value seen from the sender.
-	availableCredit uint32
-
 	senderSettleMode   *SenderSettleMode
 	receiverSettleMode *ReceiverSettleMode
 	maxMessageSize     uint64

--- a/receiver.go
+++ b/receiver.go
@@ -708,7 +708,6 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		)
 
 		// send flow
-		// TODO: missing Available
 		resp := &frames.PerformFlow{
 			Handle:        &r.l.handle,
 			DeliveryCount: &deliveryCount,

--- a/session.go
+++ b/session.go
@@ -22,18 +22,6 @@ const (
 
 // SessionOptions contains the optional settings for configuring an AMQP session.
 type SessionOptions struct {
-	// IncomingWindow sets the maximum number of unacknowledged
-	// transfer frames the server can send.
-	//
-	// Default value: 5000
-	IncomingWindow uint32
-
-	// OutgoingWindow sets the maximum number of unacknowledged
-	// transfer frames the client can send.
-	//
-	// Default value: 5000
-	OutgoingWindow uint32
-
 	// MaxLinks sets the maximum number of links (Senders/Receivers)
 	// allowed on the session.
 	//
@@ -92,17 +80,11 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 	}
 
 	if opts != nil {
-		if opts.IncomingWindow != 0 {
-			s.incomingWindow = opts.IncomingWindow
-		}
 		if opts.MaxLinks != 0 {
 			// MaxLinks is the number of total links.
 			// handleMax is the max handle ID which starts
 			// at zero.  so we decrement by one
 			s.handleMax = opts.MaxLinks - 1
-		}
-		if opts.OutgoingWindow != 0 {
-			s.outgoingWindow = opts.OutgoingWindow
 		}
 	}
 


### PR DESCRIPTION
The values weren't actually honored which is ok per spec, so remove them from the public surface area.
Cleaned up handling of sender link credit.  Since we don't use availableCredit, it's been removed.

Fixes https://github.com/Azure/go-amqp/issues/83