### PR TITLE
Disable Session sending frames after end performative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * Higher debug levels add entries when a frame transitions across mux boundaries and other diagnostics info.
 * Document default values for incoming and outgoing windows.
 * Refactored handling of incoming frames to eliminate potential deadlocks due to "mux pumping".
+* Disallow sending of frames once the end performative has been sent.
 
 ## 0.18.1 (2023-01-17)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -635,141 +635,143 @@ func TestIntegrationClose(t *testing.T) {
 		t.Skip()
 	}
 
-	label := "link"
-	t.Run(label, func(t *testing.T) {
-		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
+	for times := 0; times < 100; times++ {
+		label := "link"
+		t.Run(label, func(t *testing.T) {
+			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
-		// Create client
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer client.Close()
+			// Create client
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
 
-		// Open a session
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		session, err := client.NewSession(ctx, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Open a session
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			session, err := client.NewSession(ctx, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// Create a sender
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Create a sender
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		testClose(t, receiver.Close)
+			testClose(t, receiver.Close)
 
-		_, err = receiver.Receive(context.Background(), nil)
-		var linkErr *amqp.LinkError
-		require.ErrorAs(t, err, &linkErr)
+			_, err = receiver.Receive(context.Background(), nil)
+			var linkErr *amqp.LinkError
+			require.ErrorAs(t, err, &linkErr)
 
-		err = client.Close() // close before leak check
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = client.Close() // close before leak check
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		checkLeaks()
-	})
+			checkLeaks()
+		})
 
-	label = "session"
-	t.Run(label, func(t *testing.T) {
-		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
+		label = "session"
+		t.Run(label, func(t *testing.T) {
+			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
-		// Create client
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer client.Close()
+			// Create client
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
 
-		// Open a session
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		session, err := client.NewSession(ctx, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Open a session
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			session, err := client.NewSession(ctx, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// Create a sender
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Create a sender
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		testClose(t, session.Close)
+			testClose(t, session.Close)
 
-		msg, err := receiver.Receive(context.Background(), nil)
-		var sessionErr *amqp.SessionError
-		require.ErrorAs(t, err, &sessionErr)
-		if msg != nil {
-			t.Fatal("expected nil message")
-		}
+			msg, err := receiver.Receive(context.Background(), nil)
+			var sessionErr *amqp.SessionError
+			require.ErrorAs(t, err, &sessionErr)
+			if msg != nil {
+				t.Fatal("expected nil message")
+			}
 
-		err = client.Close() // close before leak check
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = client.Close() // close before leak check
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		checkLeaks()
-	})
+			checkLeaks()
+		})
 
-	label = "conn"
-	t.Run(label, func(t *testing.T) {
-		checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
+		label = "conn"
+		t.Run(label, func(t *testing.T) {
+			checkLeaks := leaktest.CheckTimeout(t, 60*time.Second)
 
-		// Create client
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		client, err := amqp.Dial(ctx, localBrokerAddr, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer client.Close()
+			// Create client
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
 
-		// Open a session
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		session, err := client.NewSession(ctx, nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Open a session
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			session, err := client.NewSession(ctx, nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		// Create a sender
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
-		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Create a sender
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+			receiver, err := session.NewReceiver(ctx, "TestIntegrationClose", nil)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		err = client.Close()
-		if err != nil {
-			t.Fatalf("Expected nil error from client.Close(), got: %+v", err)
-		}
+			err = client.Close()
+			if err != nil {
+				t.Fatalf("Expected nil error from client.Close(), got: %+v", err)
+			}
 
-		msg, err := receiver.Receive(context.Background(), nil)
-		var connErr *amqp.ConnError
-		if !errors.As(err, &connErr) {
-			t.Fatalf("unexpected error type %T", err)
-			return
-		}
-		if msg != nil {
-			t.Fatal("expected nil message")
-		}
+			msg, err := receiver.Receive(context.Background(), nil)
+			var connErr *amqp.ConnError
+			if !errors.As(err, &connErr) {
+				t.Fatalf("unexpected error type %T", err)
+				return
+			}
+			if msg != nil {
+				t.Fatal("expected nil message")
+			}
 
-		checkLeaks()
-	})
+			checkLeaks()
+		})
+	}
 }
 
 func TestMultipleSessionsOpenClose(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -317,7 +317,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			clientClosed = true
 			fr := frames.PerformEnd{Error: err}
 			_ = s.txFrame(&fr, nil)
-			// TODO: per spec, after end has been sent, the session is no longer allowed to send frames
 
 		// incoming frame
 		case q := <-s.rxQ.Wait():
@@ -528,6 +527,12 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 
 		case fr := <-txTransfer:
+			if clientClosed {
+				// now that the end performative has been sent we're
+				// not allowed to send any more frames.
+				continue
+			}
+
 			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
 			// record current delivery ID
 			var deliveryID uint32
@@ -571,6 +576,12 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 
 		case fr := <-s.tx:
+			if clientClosed {
+				// now that the end performative has been sent we're
+				// not allowed to send any more frames.
+				continue
+			}
+
 			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
 			switch fr := fr.(type) {
 			case *frames.PerformDisposition:

--- a/session.go
+++ b/session.go
@@ -530,6 +530,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			if clientClosed {
 				// now that the end performative has been sent we're
 				// not allowed to send any more frames.
+				debug.Log(1, "TX (Session): discarding transfer: %s\n", fr)
 				continue
 			}
 
@@ -579,6 +580,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			if clientClosed {
 				// now that the end performative has been sent we're
 				// not allowed to send any more frames.
+				debug.Log(1, "TX (Session): discarding frame: %s\n", fr)
 				continue
 			}
 


### PR DESCRIPTION
This is against the spec and results in the peer terminating the connection.  Just ignore any outgoing frames.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
