### PR TITLE
Don't close Sender when peer rejects message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * The `Receiver.DrainCredit()` API has been removed.
 * The `Batching` field in `ReceiverOptions` has been renamed to `BatchSize` and its type changed to `uint32`.
 * The `IncomingWindow` and `OutgoingWindow` fields in `SessionOptions` have been removed.
+* The field `SenderOptions.IgnoreDispositionErrors` has been removed.
+  * By default, messages that are rejected by the peer no longer close the `Sender`.
 
 ### Bugs Fixed
 

--- a/link_options.go
+++ b/link_options.go
@@ -33,11 +33,6 @@ type SenderOptions struct {
 	// Default: 0.
 	ExpiryTimeout uint32
 
-	// IgnoreDispositionErrors controls automatic close on disposition errors.
-	//
-	// Default: false.
-	IgnoreDispositionErrors bool
-
 	// Name sets the name of the link.
 	//
 	// Link names must be unique per-connection and direction.

--- a/link_test.go
+++ b/link_test.go
@@ -198,7 +198,6 @@ func TestNewSendingLink(t *testing.T) {
 				require.False(t, l.l.dynamicAddr)
 				require.Empty(t, l.l.source.ExpiryPolicy)
 				require.Zero(t, l.l.source.Timeout)
-				require.True(t, l.closeOnDispositionError)
 				require.NotEmpty(t, l.l.key.name)
 				require.Empty(t, l.l.properties)
 				require.Nil(t, l.l.senderSettleMode)
@@ -209,13 +208,12 @@ func TestNewSendingLink(t *testing.T) {
 		{
 			label: "with options",
 			opts: SenderOptions{
-				Capabilities:            []string{"foo", "bar"},
-				Durability:              DurabilityUnsettledState,
-				DynamicAddress:          true,
-				ExpiryPolicy:            ExpiryPolicyLinkDetach,
-				ExpiryTimeout:           5,
-				IgnoreDispositionErrors: true,
-				Name:                    name,
+				Capabilities:   []string{"foo", "bar"},
+				Durability:     DurabilityUnsettledState,
+				DynamicAddress: true,
+				ExpiryPolicy:   ExpiryPolicyLinkDetach,
+				ExpiryTimeout:  5,
+				Name:           name,
 				Properties: map[string]any{
 					"property": 123,
 				},
@@ -228,7 +226,6 @@ func TestNewSendingLink(t *testing.T) {
 				require.True(t, l.l.dynamicAddr)
 				require.Equal(t, ExpiryPolicyLinkDetach, l.l.source.ExpiryPolicy)
 				require.Equal(t, uint32(5), l.l.source.Timeout)
-				require.False(t, l.closeOnDispositionError)
 				require.Equal(t, name, l.l.key.name)
 				require.Equal(t, map[encoding.Symbol]any{
 					"property": 123,


### PR DESCRIPTION
This is not required per spec and there is no good reason for doing so.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
