### PR TITLE
Move per-message presettlement setting to SendOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The `IncomingWindow` and `OutgoingWindow` fields in `SessionOptions` have been removed.
 * The field `SenderOptions.IgnoreDispositionErrors` has been removed.
   * By default, messages that are rejected by the peer no longer close the `Sender`.
+* The field `SendSettled` in type `Message` has been moved to type `SendOptions` and renamed as `Settled`.
 
 ### Bugs Fixed
 

--- a/message.go
+++ b/message.go
@@ -99,11 +99,6 @@ type Message struct {
 	// encryption details).
 	Footer Annotations
 
-	// Mark the message as settled when LinkSenderSettle is ModeMixed.
-	//
-	// This field is ignored when LinkSenderSettle is not ModeMixed.
-	SendSettled bool
-
 	rcvr       *Receiver // the receiving link
 	deliveryID uint32    // used when sending disposition
 	settled    bool      // whether transfer was settled by sender


### PR DESCRIPTION
It's purely a client side value and is not part of the message proper. Send now returns an error if the setting conflicts with the Sender.

Partially fixes https://github.com/Azure/go-amqp/issues/215