### PR TITLE
Clean up tests that trigger the race detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Disallow sending of frames once the end performative has been sent.
 * Clean up client-side state when a `context.Context` expires or is cancelled and document the potential side-effects.
 * Unexpected frames will now terminate a `Session`, `Receiver`, or `Sender` as required.
+* Cleaned up tests that triggered the race detector.
 
 ## 0.18.1 (2023-01-17)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
           $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net462/TestAmqpBroker.exe $AMQP_BROKER_ADDR /headless &
           brokerPID=$!
           echo '##[section]Starting tests'
-          go test -tags -race -v -coverprofile=coverage.txt -covermode atomic ./... 2>&1 | tee gotestoutput.log 
+          go test -race -v -coverprofile=coverage.txt -covermode atomic ./... 2>&1 | tee gotestoutput.log 
           go-junit-report < gotestoutput.log > report.xml
           kill $brokerPID
           gocov convert coverage.txt > coverage.json

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -61,5 +62,75 @@ func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
 		for i := 0; i < v.NumField(); i++ {
 			structTypes(v.Field(i), m)
 		}
+	}
+}
+
+// MuxSemaphore is a helper for managing rendezvous with the mux at certain points during execution.
+type MuxSemaphore struct {
+	count    int
+	pausedCh chan struct{}
+	resumeCh chan struct{}
+}
+
+// NewMuxSemaphore creates a new MuxSemaphore with the specified count.
+//   - count is the number of iterations the mux will execute before pausing
+func NewMuxSemaphore(count int) *MuxSemaphore {
+	return &MuxSemaphore{
+		count:    count,
+		pausedCh: make(chan struct{}),
+		resumeCh: make(chan struct{}),
+	}
+}
+
+// OnLoop is to be called from your mux test hook.
+// panics if the pause/resume cycle takes more than 5s.
+func (m *MuxSemaphore) OnLoop() {
+	if m.count > 0 {
+		m.count--
+		return
+	} else if m.count < 0 {
+		return
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+
+	select {
+	case m.pausedCh <- struct{}{}:
+		// mux is now paused
+	case <-timer.C:
+		panic("pause time exceeded")
+	}
+
+	select {
+	case <-m.resumeCh:
+		// mux resumed
+	case <-timer.C:
+		panic("resume time exceeded")
+	}
+
+	timer.Stop()
+}
+
+// Wait - blocks until the mux is paused.
+// panics if the wait exceeds 5s.
+func (m *MuxSemaphore) Wait() {
+	select {
+	case <-m.pausedCh:
+		// mux is paused
+	case <-time.After(5 * time.Second):
+		panic("wait time exceeded")
+	}
+}
+
+// Release - call this to resume the mux with a new count (zero-based)
+//   - count is the number of iterations the mux will execute before pausing, pass -1 to close the semaphore
+//
+// panics if the wait exceeds 5s.
+func (m *MuxSemaphore) Release(count int) {
+	select {
+	case m.resumeCh <- struct{}{}:
+		m.count = count
+	case <-time.After(5 * time.Second):
+		panic("release time exceeded")
 	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -606,7 +606,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 
 	select {
 	case r.l.session.tx <- fr:
-		debug.Log(2, "TX (Receiver): %s", fr)
+		debug.Log(2, "TX (Receiver): mux frame to Session: %d, %s", r.l.session.channel, fr)
 		return nil
 	case <-r.l.close:
 		return nil
@@ -650,7 +650,7 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 
 		select {
 		case r.l.session.tx <- resp:
-			debug.Log(2, "TX (Sender): %s", resp)
+			debug.Log(2, "TX (Receiver): mux frame to Session: %d, %s", r.l.session.channel, resp)
 		case <-r.l.close:
 			return nil
 		case <-r.l.session.done:

--- a/receiver.go
+++ b/receiver.go
@@ -450,12 +450,24 @@ func (r *Receiver) attach(ctx context.Context) error {
 		return err
 	}
 
-	go r.mux()
-
 	return nil
 }
 
-func (r *Receiver) mux() {
+func nop() {}
+
+type receiverTestHooks struct {
+	MuxStart  func()
+	MuxSelect func()
+}
+
+func (r *Receiver) mux(hooks receiverTestHooks) {
+	if hooks.MuxSelect == nil {
+		hooks.MuxSelect = nop
+	}
+	if hooks.MuxStart == nil {
+		hooks.MuxStart = nop
+	}
+
 	defer func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
@@ -468,6 +480,8 @@ func (r *Receiver) mux() {
 		r.l.session.deallocateHandle(&r.l)
 		close(r.l.done)
 	}()
+
+	hooks.MuxStart()
 
 	if r.autoSendFlow {
 		r.l.doneErr = r.muxFlow(r.l.linkCredit, false)
@@ -520,6 +534,8 @@ func (r *Receiver) mux() {
 			// swap out channel so it no longer triggers
 			closed = nil
 		}
+
+		hooks.MuxSelect()
 
 		select {
 		case <-r.l.forceClose:

--- a/sender.go
+++ b/sender.go
@@ -340,6 +340,7 @@ Loop:
 		case tr := <-outgoingTransfers:
 			select {
 			case s.l.session.txTransfer <- &tr:
+				// TODO: this logging races with assignment of DeliveryID by Session.mux()
 				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
 				// decrement link-credit after entire message transferred
 				if !tr.More {

--- a/sender.go
+++ b/sender.go
@@ -340,8 +340,7 @@ Loop:
 		case tr := <-outgoingTransfers:
 			select {
 			case s.l.session.txTransfer <- &tr:
-				// TODO: this logging races with assignment of DeliveryID by Session.mux()
-				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, tr)
+				debug.Log(2, "TX (Sender): mux transfer to Session: %d, %s", s.l.session.channel, &tr)
 				// decrement link-credit after entire message transferred
 				if !tr.More {
 					s.l.deliveryCount++
@@ -414,7 +413,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 
 		select {
 		case s.l.session.tx <- resp:
-			debug.Log(2, "TX (Sender): %s", resp)
+			debug.Log(2, "TX (Sender): mux frame to Session: %d, %s", s.l.session.channel, resp)
 		case <-s.l.close:
 			return nil
 		case <-s.l.session.done:

--- a/session.go
+++ b/session.go
@@ -492,7 +492,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				s.muxFrameToLink(link, fr)
-				debug.Log(2, "RX (Session): mux transfer to link: %s", fr)
 
 				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
 				if !body.Settled && body.DeliveryID != nil && link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond {
@@ -569,7 +568,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				continue
 			}
 
-			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
 			// record current delivery ID
 			var deliveryID uint32
 			if fr.DeliveryID == &needsDeliveryID {
@@ -587,6 +585,9 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// to deliveryIDByHandle already
 				deliveryID = deliveryIDByHandle[fr.Handle]
 			}
+
+			// log after the delivery ID has been assigned
+			debug.Log(2, "TX (Session): %d, %s", s.channel, fr)
 
 			// frame has been sender-settled, remove from map
 			if fr.Settled {

--- a/session.go
+++ b/session.go
@@ -219,6 +219,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 		return nil, err
 	}
 
+	go r.mux(receiverTestHooks{})
+
 	return r, nil
 }
 


### PR DESCRIPTION
Added some mux test hooks and supporting test infrastructure.

Fixes https://github.com/Azure/go-amqp/issues/169