### PR TITLE
Remove method Message.LinkName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * The field `SendSettled` in type `Message` has been moved to type `SendOptions` and renamed as `Settled`.
 * The following type aliases have been removed.
   * `Address`, `Binary`, `MessageID`, `SequenceNumber`, `Symbol`
+* Method `Message.LinkName()` has been removed.
 
 ### Bugs Fixed
 

--- a/message.go
+++ b/message.go
@@ -99,9 +99,8 @@ type Message struct {
 	// encryption details).
 	Footer Annotations
 
-	rcvr       *Receiver // the receiving link
-	deliveryID uint32    // used when sending disposition
-	settled    bool      // whether transfer was settled by sender
+	deliveryID uint32 // used when sending disposition
+	settled    bool   // whether transfer was settled by sender
 }
 
 // NewMessage returns a *Message with data as the payload.
@@ -122,14 +121,6 @@ func (m *Message) GetData() []byte {
 		return nil
 	}
 	return m.Data[0]
-}
-
-// LinkName returns the receiving link name or the empty string.
-func (m *Message) LinkName() string {
-	if m.rcvr != nil {
-		return m.rcvr.l.key.name
-	}
-	return ""
 }
 
 // MarshalBinary encodes the message into binary form.

--- a/receiver.go
+++ b/receiver.go
@@ -87,7 +87,6 @@ func (r *Receiver) Prefetched() *Message {
 	}
 
 	debug.Log(3, "RX (Receiver): prefetched delivery ID %d", msg.deliveryID)
-	msg.rcvr = r
 
 	if msg.settled {
 		r.onSettlement(1)
@@ -118,7 +117,6 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 		msg := q.Dequeue()
 		debug.Assert(msg != nil)
 		debug.Log(3, "RX (Receiver): received delivery ID %d", msg.deliveryID)
-		msg.rcvr = r
 		r.messagesQ.Release(q)
 		if msg.settled {
 			r.onSettlement(1)


### PR DESCRIPTION
The data isn't germane to the Message and should be tracked externally as required.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
