### PR TITLE
Fix race on Session/Sender/Receiver Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.19.1 (Unreleased)
+
+### Bugs Fixed
+
+* Fixed a race closing a `Session`, `Receiver`, or `Sender` in succession when the first attempt times out.
+* Check the `LinkError.RemoteErr` field when determining if a link was cleanly closed.
+
 ## 0.19.0 (2023-03-30)
 
 ### Breaking Changes

--- a/receiver.go
+++ b/receiver.go
@@ -538,7 +538,7 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 		select {
 		case <-r.l.forceClose:
 			// the call to r.Close() timed out waiting for the ack
-			r.l.doneErr = &LinkError{inner: errors.New("the receiver was forcibly closed")}
+			r.l.doneErr = &LinkError{inner: errLinkForciblyClosed}
 			return
 
 		case q := <-r.l.rxQ.Wait():

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -264,6 +264,60 @@ func TestReceiverOnDetached(t *testing.T) {
 	require.ErrorAs(t, err, &linkErr)
 }
 
+func TestReceiverCloseTimeout(t *testing.T) {
+	responder := func(req frames.FrameBody) ([]byte, error) {
+		switch tt := req.(type) {
+		case *fake.AMQPProto:
+			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+		case *frames.PerformOpen:
+			return fake.PerformOpen("container")
+		case *frames.PerformBegin:
+			return fake.PerformBegin(0)
+		case *frames.PerformEnd:
+			return fake.PerformEnd(0, nil)
+		case *frames.PerformAttach:
+			return fake.ReceiverAttach(0, tt.Name, tt.Handle, ReceiverSettleModeSecond, nil)
+		case *frames.PerformDetach:
+			// sleep to trigger sender close timeout
+			time.Sleep(1 * time.Second)
+			return fake.PerformDetach(0, tt.Handle, nil)
+		case *frames.PerformFlow, *fake.KeepAlive:
+			return nil, nil
+		case *frames.PerformClose:
+			return fake.PerformClose(nil)
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	r, err := session.NewReceiver(ctx, "source", nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = r.Close(ctx)
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = r.Close(ctx)
+	cancel()
+	var linkErr *LinkError
+	require.ErrorAs(t, err, &linkErr)
+	require.Contains(t, linkErr.Error(), "forcibly closed")
+	require.NoError(t, client.Close())
+}
+
 func TestReceiveInvalidMessage(t *testing.T) {
 	const linkHandle = 0
 	deliveryID := uint32(1)

--- a/sender.go
+++ b/sender.go
@@ -319,7 +319,7 @@ Loop:
 		select {
 		case <-s.l.forceClose:
 			// the call to s.Close() timed out waiting for the ack
-			s.l.doneErr = &LinkError{inner: errors.New("the sender was forcibly closed")}
+			s.l.doneErr = &LinkError{inner: errLinkForciblyClosed}
 			return
 
 		// received frame

--- a/session_test.go
+++ b/session_test.go
@@ -128,7 +128,6 @@ func TestSessionCloseTimeout(t *testing.T) {
 		}
 	}
 	netConn := fake.NewNetConn(responder)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
 	cancel()
@@ -142,6 +141,14 @@ func TestSessionCloseTimeout(t *testing.T) {
 	err = session.Close(ctx)
 	cancel()
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = session.Close(ctx)
+	cancel()
+	var sessionErr *SessionError
+	require.ErrorAs(t, err, &sessionErr)
+	require.Contains(t, sessionErr.Error(), "forcibly closed")
+
 	require.NoError(t, client.Close())
 }
 


### PR DESCRIPTION
If Close() exits due to cancellation/timeout and the mux is still running, subsequent calls to Close() will read from doneErr which will race with the mux.
Record closing state while synchronizing with the mux and cache the value so subsequent calls return the same value.

Example: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2668077&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=bd05475d-acb5-5619-3ccb-c46842dbc997

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
