### PR TITLE
Honor context cancellation in Dial and NewConn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 1.0.0 (Unreleased)
+
+### Bugs Fixed
+
+* Calling `Dial()` with a cancelled context doesn't create a connection.
+* Context cancellation is properly honored in calls to `Dial()` and `NewConn()`.
+
 ## 0.19.1 (2023-03-31)
 
 ### Bugs Fixed

--- a/conn.go
+++ b/conn.go
@@ -87,12 +87,11 @@ type ConnOptions struct {
 //
 // opts: pass nil to accept the default values.
 func Dial(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
-	deadline, _ := ctx.Deadline()
-	c, err := dialConn(deadline, addr, opts)
+	c, err := dialConn(ctx, addr, opts)
 	if err != nil {
 		return nil, err
 	}
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +105,7 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 	if err != nil {
 		return nil, err
 	}
-	deadline, _ := ctx.Deadline()
-	err = c.start(deadline)
+	err = c.start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -167,26 +165,26 @@ type Conn struct {
 
 // used to abstract the underlying dialer for testing purposes
 type dialer interface {
-	NetDialerDial(deadline time.Time, c *Conn, host, port string) error
-	TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) error
+	NetDialerDial(ctx context.Context, c *Conn, host, port string) error
+	TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) error
 }
 
 // implements the dialer interface
 type defaultDialer struct{}
 
-func (defaultDialer) NetDialerDial(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = dialer.Dial("tcp", net.JoinHostPort(host, port))
+func (defaultDialer) NetDialerDial(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &net.Dialer{}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func (defaultDialer) TLSDialWithDialer(deadline time.Time, c *Conn, host, port string) (err error) {
-	dialer := &net.Dialer{Deadline: deadline}
-	c.net, err = tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, port), c.tlsConfig)
+func (defaultDialer) TLSDialWithDialer(ctx context.Context, c *Conn, host, port string) (err error) {
+	dialer := &tls.Dialer{Config: c.tlsConfig}
+	c.net, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	return
 }
 
-func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error) {
+func dialConn(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -221,11 +219,11 @@ func dialConn(deadline time.Time, addr string, opts *ConnOptions) (*Conn, error)
 
 	switch u.Scheme {
 	case "amqp", "":
-		err = c.dialer.NetDialerDial(deadline, c, host, port)
+		err = c.dialer.NetDialerDial(ctx, c, host, port)
 	case "amqps", "amqp+ssl":
 		c.initTLSConfig()
 		c.tlsNegotiation = false
-		err = c.dialer.TLSDialWithDialer(deadline, c, host, port)
+		err = c.dialer.TLSDialWithDialer(ctx, c, host, port)
 	default:
 		err = fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
@@ -311,25 +309,36 @@ func (c *Conn) initTLSConfig() {
 
 // start establishes the connection and begins multiplexing network IO.
 // It is an error to call Start() on a connection that's been closed.
-func (c *Conn) start(deadline time.Time) error {
-	// set connection establishment deadline
-	_ = c.net.SetDeadline(deadline)
+func (c *Conn) start(ctx context.Context) (err error) {
+	// if the context has a deadline or is cancellable, start the interruptor goroutine.
+	// this will close the underlying net.Conn in response to the context.
 
-	// run connection establishment state machine
-	for state := c.negotiateProto; state != nil; {
-		var err error
-		state, err = state()
-		// check if err occurred
-		if err != nil {
-			close(c.txDone) // close here since connWriter hasn't been started yet
-			close(c.rxDone)
-			_ = c.Close()
-			return err
-		}
+	if ctx.Done() != nil {
+		done := make(chan struct{})
+		interruptRes := make(chan error, 1)
+
+		defer func() {
+			close(done)
+			if ctxErr := <-interruptRes; ctxErr != nil {
+				// return context error to caller
+				err = ctxErr
+			}
+		}()
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.closeDuringStart()
+				interruptRes <- ctx.Err()
+			case <-done:
+				interruptRes <- nil
+			}
+		}()
 	}
 
-	// remove connection establishment deadline
-	_ = c.net.SetDeadline(time.Time{})
+	if err = c.startImpl(ctx); err != nil {
+		return err
+	}
 
 	// we can't create the channel bitmap until the connection has been established.
 	// this is because our peer can tell us the max channels they support.
@@ -337,6 +346,29 @@ func (c *Conn) start(deadline time.Time) error {
 
 	go c.connWriter()
 	go c.connReader()
+
+	return
+}
+
+func (c *Conn) startImpl(ctx context.Context) error {
+	// set connection establishment deadline as required
+	if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+		_ = c.net.SetDeadline(deadline)
+
+		// remove connection establishment deadline
+		defer c.net.SetDeadline(time.Time{})
+	}
+
+	// run connection establishment state machine
+	for state := c.negotiateProto; state != nil; {
+		var err error
+		state, err = state(ctx)
+		// check if err occurred
+		if err != nil {
+			c.closeDuringStart()
+			return err
+		}
+	}
 
 	return nil
 }
@@ -389,6 +421,13 @@ func (c *Conn) close() {
 		} else {
 			c.doneErr = &ConnError{inner: closeErr}
 		}
+	})
+}
+
+// closeDuringStart is a special close to be used only during startup (i.e. c.start() and any of its children)
+func (c *Conn) closeDuringStart() {
+	c.closeOnce.Do(func() {
+		c.net.Close()
 	})
 }
 
@@ -724,11 +763,11 @@ func (c *Conn) sendFrame(fr frames.Frame) error {
 //
 // The state is advanced by returning the next state.
 // The state machine concludes when nil is returned.
-type stateFunc func() (stateFunc, error)
+type stateFunc func(context.Context) (stateFunc, error)
 
 // negotiateProto determines which proto to negotiate next.
 // used externally by SASL only.
-func (c *Conn) negotiateProto() (stateFunc, error) {
+func (c *Conn) negotiateProto(ctx context.Context) (stateFunc, error) {
 	// in the order each must be negotiated
 	switch {
 	case c.tlsNegotiation && !c.tlsComplete:
@@ -829,14 +868,14 @@ func (c *Conn) readProtoHeader() (protoHeader, error) {
 }
 
 // startTLS wraps the conn with TLS and returns to Client.negotiateProto
-func (c *Conn) startTLS() (stateFunc, error) {
+func (c *Conn) startTLS(ctx context.Context) (stateFunc, error) {
 	c.initTLSConfig()
 
 	_ = c.net.SetReadDeadline(time.Time{}) // clear timeout
 
 	// wrap existing net.Conn and perform TLS handshake
 	tlsConn := tls.Client(c.net, c.tlsConfig)
-	if err := tlsConn.Handshake(); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -849,7 +888,7 @@ func (c *Conn) startTLS() (stateFunc, error) {
 }
 
 // openAMQP round trips the AMQP open performative
-func (c *Conn) openAMQP() (stateFunc, error) {
+func (c *Conn) openAMQP(context.Context) (stateFunc, error) {
 	// send open frame
 	open := &frames.PerformOpen{
 		ContainerID:  c.containerID,
@@ -899,7 +938,7 @@ func (c *Conn) openAMQP() (stateFunc, error) {
 
 // negotiateSASL returns the SASL handler for the first matched
 // mechanism specified by the server
-func (c *Conn) negotiateSASL() (stateFunc, error) {
+func (c *Conn) negotiateSASL(context.Context) (stateFunc, error) {
 	// read mechanisms frame
 	fr, err := c.readSingleFrame()
 	if err != nil {
@@ -928,7 +967,7 @@ func (c *Conn) negotiateSASL() (stateFunc, error) {
 // SASL handlers return this stateFunc when the mechanism specific negotiation
 // has completed.
 // used externally by SASL only.
-func (c *Conn) saslOutcome() (stateFunc, error) {
+func (c *Conn) saslOutcome(context.Context) (stateFunc, error) {
 	// read outcome frame
 	fr, err := c.readSingleFrame()
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -356,7 +356,9 @@ func (c *Conn) startImpl(ctx context.Context) error {
 		_ = c.net.SetDeadline(deadline)
 
 		// remove connection establishment deadline
-		defer c.net.SetDeadline(time.Time{})
+		defer func() {
+			_ = c.net.SetDeadline(time.Time{})
+		}()
 	}
 
 	// run connection establishment state machine

--- a/integration_test.go
+++ b/integration_test.go
@@ -821,7 +821,7 @@ func TestDialWithCancelledContext(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
 	var dialErr *net.OpError

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -812,6 +813,22 @@ func TestMultipleSessionsOpenClose(t *testing.T) {
 	}
 
 	client.Close()
+	checkLeaks()
+}
+
+func TestDialWithCancelledContext(t *testing.T) {
+	if localBrokerAddr == "" {
+		t.Skip()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	cancel()
+	client, err := amqp.Dial(ctx, localBrokerAddr, nil)
+	var dialErr *net.OpError
+	require.ErrorAs(t, err, &dialErr)
+	require.Nil(t, client)
+
+	checkLeaks := leaktest.Check(t)
 	checkLeaks()
 }
 

--- a/sasl.go
+++ b/sasl.go
@@ -1,6 +1,7 @@
 package amqp
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/go-amqp/internal/debug"
@@ -32,7 +33,7 @@ func SASLTypePlain(username, password string) SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismPLAIN] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismPLAIN] = func(context.Context) (stateFunc, error) {
 			// send saslInit with PLAIN payload
 			init := &frames.SASLInit{
 				Mechanism:       "PLAIN",
@@ -65,7 +66,7 @@ func SASLTypeAnonymous() SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismANONYMOUS] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismANONYMOUS] = func(context.Context) (stateFunc, error) {
 			init := &frames.SASLInit{
 				Mechanism:       saslMechanismANONYMOUS,
 				InitialResponse: []byte("anonymous"),
@@ -98,7 +99,7 @@ func SASLTypeExternal(resp string) SASLType {
 		}
 
 		// add the handler the the map
-		c.saslHandlers[saslMechanismEXTERNAL] = func() (stateFunc, error) {
+		c.saslHandlers[saslMechanismEXTERNAL] = func(context.Context) (stateFunc, error) {
 			init := &frames.SASLInit{
 				Mechanism:       saslMechanismEXTERNAL,
 				InitialResponse: []byte(resp),
@@ -160,7 +161,7 @@ type saslXOAUTH2Handler struct {
 	errorResponse        []byte // https://developers.google.com/gmail/imap/xoauth2-protocol#error_response
 }
 
-func (s saslXOAUTH2Handler) init() (stateFunc, error) {
+func (s saslXOAUTH2Handler) init(context.Context) (stateFunc, error) {
 	originalPeerMaxFrameSize := s.conn.peerMaxFrameSize
 	if s.maxFrameSizeOverride > s.conn.peerMaxFrameSize {
 		s.conn.peerMaxFrameSize = s.maxFrameSizeOverride
@@ -180,7 +181,7 @@ func (s saslXOAUTH2Handler) init() (stateFunc, error) {
 	return s.step, nil
 }
 
-func (s saslXOAUTH2Handler) step() (stateFunc, error) {
+func (s saslXOAUTH2Handler) step(context.Context) (stateFunc, error) {
 	// read challenge or outcome frame
 	fr, err := s.conn.readFrame()
 	if err != nil {


### PR DESCRIPTION
Previously they only honored a deadline, now they handle both. TLS dialer now calls DialContext().

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
