### PR TITLE
Fix potential race in Conn.Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Calling `Dial()` with a cancelled context doesn't create a connection.
 * Context cancellation is properly honored in calls to `Dial()` and `NewConn()`.
+* Fixed potential race during `Conn.Close()`.
 
 ## 0.19.1 (2023-03-31)
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -18,9 +18,9 @@ import (
 
 func fuzzConn(data []byte) int {
 	// Receive
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	client, err := NewConn(ctx, testconn.New(data), &ConnOptions{
-		IdleTimeout: 10 * time.Millisecond,
+		IdleTimeout: 20 * time.Millisecond,
 		SASLType:    SASLTypePlain("listen", "3aCXZYFcuZA89xe6lZkfYJvOPnTGipA3ap7NvPruBhI="),
 	})
 	cancel()


### PR DESCRIPTION
Bumped up context timeout in TestFuzzConnCrashers.  This is unrelated to the race change.  Some iterations of the test starting failing with a context.DeadlineExceeded error.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
