### PR TITLE
fakes: distinguish between local and remote channels

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := senderFrameHandler(SenderSettleModeUnsettled)(req)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
 		if b != nil || err != nil {
 			return b, err
 		}
@@ -44,7 +44,7 @@ func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
 	})
 	cancel()
 	require.NoError(b, err)
-	sendInitialFlowFrame(b, conn, 0, 1000000)
+	sendInitialFlowFrame(b, 0, conn, 0, 1000000)
 	b.ResetTimer()
 	b.ReportAllocs()
 
@@ -58,8 +58,8 @@ func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
 }
 
 func BenchmarkSenderSendSSMSettled(b *testing.B) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := senderFrameHandler(SenderSettleModeSettled)(req)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := senderFrameHandler(0, SenderSettleModeSettled)(remoteChannel, req)
 		if b != nil || err != nil {
 			return b, err
 		}
@@ -89,7 +89,7 @@ func BenchmarkSenderSendSSMSettled(b *testing.B) {
 	})
 	cancel()
 	require.NoError(b, err)
-	sendInitialFlowFrame(b, conn, 0, 1000000)
+	sendInitialFlowFrame(b, 0, conn, 0, 1000000)
 	b.ResetTimer()
 	b.ReportAllocs()
 
@@ -103,8 +103,8 @@ func BenchmarkSenderSendSSMSettled(b *testing.B) {
 }
 
 func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(ReceiverSettleModeFirst)(req)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
 		if b != nil || err != nil {
 			return b, err
 		}
@@ -154,8 +154,8 @@ func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
 }
 
 func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(ReceiverSettleModeSecond)(req)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(0, ReceiverSettleModeSecond)(remoteChannel, req)
 		if b != nil || err != nil {
 			return b, err
 		}
@@ -205,8 +205,8 @@ func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
 }
 
 func BenchmarkReceiverSettleMessage(b *testing.B) {
-	responder := func(req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(ReceiverSettleModeFirst)(req)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
 		if b != nil || err != nil {
 			return b, err
 		}

--- a/link_test.go
+++ b/link_test.go
@@ -167,7 +167,7 @@ func TestMuxFlowHandlesDrainProperly(t *testing.T) {
 }
 
 func newTestLink(t *testing.T) *Receiver {
-	fakeConn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(ReceiverSettleModeFirst))
+	fakeConn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	conn, err := NewConn(ctx, fakeConn, nil)
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestNewReceivingLink(t *testing.T) {
 func TestSessionFlowDisablesTransfer(t *testing.T) {
 	t.Skip("TODO: finish for link testing")
 	nextIncomingID := uint32(0)
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	client, err := NewConn(ctx, netConn, nil)


### PR DESCRIPTION
The fakes used the same, or hard-coded, values for the local and remote channels which prevented writing certain kinds of tests.

Test-only change.