### PR TITLE
Robust handling of context expiration/cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Other Changes
 
 * Debug logging includes the address of the object that's writing a log entry.
+* Context expiration or cancellation when creating instances of `Session`, `Receiver`, and `Sender` no longer result in the potential for `Conn` to unexpectedly terminate.
+* Session channel and link handle exhaustion will now return `*ConnError` and `*SessionError` respectively, closing the respective `Conn` or `Session`.
 
 ## 0.19.1 (2023-03-31)
 

--- a/conn.go
+++ b/conn.go
@@ -473,6 +473,8 @@ func (c *Conn) freeAbandonedSessions() error {
 	c.abandonedSessionsMu.Lock()
 	defer c.abandonedSessionsMu.Unlock()
 
+	debug.Log(3, "TX (Conn %p): cleaning up %d abandoned sessions", c, len(c.abandonedSessions))
+
 	for _, s := range c.abandonedSessions {
 		fr := frames.PerformEnd{}
 		if err := s.txFrame(&fr, nil); err != nil {

--- a/conn.go
+++ b/conn.go
@@ -151,6 +151,9 @@ type Conn struct {
 	sessionsByChannel   map[uint16]*Session
 	sessionsByChannelMu sync.RWMutex
 
+	abandonedSessionsMu sync.Mutex
+	abandonedSessions   []*Session
+
 	// connReader
 	rxBuf  buffer.Buffer // incoming bytes buffer
 	rxDone chan struct{} // closed when connReader exits
@@ -445,20 +448,40 @@ func (c *Conn) closeDuringStart() {
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Session was successfully
+// created, it will be cleaned up in future calls to NewSession.
 func (c *Conn) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
+	// clean up any abandoned sessions first
+	if err := c.freeAbandonedSessions(); err != nil {
+		return nil, err
+	}
+
 	session, err := c.newSession(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := session.begin(ctx); err != nil {
-		c.deleteSession(session)
+		c.abandonSession(session)
 		return nil, err
 	}
 
 	return session, nil
+}
+
+func (c *Conn) freeAbandonedSessions() error {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+
+	for _, s := range c.abandonedSessions {
+		fr := frames.PerformEnd{}
+		if err := s.txFrame(&fr, nil); err != nil {
+			return err
+		}
+	}
+
+	c.abandonedSessions = nil
+	return nil
 }
 
 func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
@@ -469,7 +492,10 @@ func (c *Conn) newSession(opts *SessionOptions) (*Session, error) {
 	// note that channel always start at 0
 	channel, ok := c.channels.Next()
 	if !ok {
-		return nil, fmt.Errorf("reached connection channel max (%d)", c.channelMax)
+		if err := c.Close(); err != nil {
+			return nil, err
+		}
+		return nil, &ConnError{inner: fmt.Errorf("reached connection channel max (%d)", c.channelMax)}
 	}
 	session := newSession(c, uint16(channel), opts)
 	c.sessionsByChannel[session.channel] = session
@@ -483,6 +509,12 @@ func (c *Conn) deleteSession(s *Session) {
 
 	delete(c.sessionsByChannel, s.channel)
 	c.channels.Remove(uint32(s.channel))
+}
+
+func (c *Conn) abandonSession(s *Session) {
+	c.abandonedSessionsMu.Lock()
+	defer c.abandonedSessionsMu.Unlock()
+	c.abandonedSessions = append(c.abandonedSessions, s)
 }
 
 // connReader reads from the net.Conn, decodes frames, and either handles
@@ -557,6 +589,7 @@ func (c *Conn) connReader() {
 			// the ack (i.e. before passing it on to the session mux) on the session
 			// ending since the numbers are recycled.
 			delete(sessionsByRemoteChannel, fr.Channel)
+			c.deleteSession(session)
 
 		default:
 			// pass on performative to the correct session

--- a/link.go
+++ b/link.go
@@ -113,7 +113,10 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
 	if err := l.session.freeAbandonedLinks(); err != nil {
 		return err
-	} else if err := l.session.allocateHandle(ctx, l); err != nil {
+	}
+
+	// once the abandoned links have been cleaned up we can create our link
+	if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 

--- a/link.go
+++ b/link.go
@@ -37,9 +37,8 @@ type link struct {
 	rxQ *queue.Holder[frames.FrameBody]
 
 	// used for gracefully closing link
-	close      chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
-	forceClose chan struct{} // used for forcibly terminate a link if Close() times out/is cancelled
-	closeOnce  *sync.Once    // closeOnce protects close from being closed multiple times
+	close     chan struct{} // signals a link's mux to shut down; DO NOT use this to check if a link has terminated, use done instead
+	closeOnce *sync.Once    // closeOnce protects close from being closed multiple times
 
 	done     chan struct{} // closed when the link has terminated (mux exited); DO NOT wait on this from within a link's mux() as it will never trigger!
 	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
@@ -71,12 +70,11 @@ type link struct {
 
 func newLink(s *Session, r encoding.Role) link {
 	l := link{
-		key:        linkKey{shared.RandString(40), r},
-		session:    s,
-		close:      make(chan struct{}),
-		forceClose: make(chan struct{}),
-		closeOnce:  &sync.Once{},
-		done:       make(chan struct{}),
+		key:       linkKey{shared.RandString(40), r},
+		session:   s,
+		close:     make(chan struct{}),
+		closeOnce: &sync.Once{},
+		done:      make(chan struct{}),
 	}
 
 	// set the segment size relative to respective window
@@ -113,7 +111,9 @@ func (l *link) waitForFrame(ctx context.Context) (frames.FrameBody, error) {
 // attach sends the Attach performative to establish the link with its parent session.
 // this is automatically called by the new*Link constructors.
 func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAttach), afterAttach func(*frames.PerformAttach)) error {
-	if err := l.session.allocateHandle(l); err != nil {
+	if err := l.session.freeAbandonedLinks(); err != nil {
+		return err
+	} else if err := l.session.allocateHandle(ctx, l); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 	// wait for response
 	fr, err := l.waitForFrame(ctx)
 	if err != nil {
-		l.session.deallocateHandle(l)
+		l.session.abandonLink(l)
 		return err
 	}
 
@@ -164,7 +164,9 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 		// wait for detach
 		fr, err := l.waitForFrame(ctx)
 		if err != nil {
-			l.session.deallocateHandle(l)
+			// we timed out waiting for the peer to close the link, this really isn't an abandoned link.
+			// however, we still need to send the detach performative to ack the peer.
+			l.session.abandonLink(l)
 			return err
 		}
 
@@ -281,19 +283,21 @@ func (l *link) closeLink(ctx context.Context) error {
 	var ctxErr error
 	l.closeOnce.Do(func() {
 		close(l.close)
+
+		// once the mux has received the ack'ing detach performative, the mux will
+		// exit which deletes the link and closes l.done.
 		select {
 		case <-l.done:
 			l.closeErr = l.doneErr
 		case <-ctx.Done():
-			close(l.forceClose)
-
-			// notify the caller that the close timed out/was cancelled
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
 
-			// record that the link was forcibly closed.
+			// record that the close timed out/was cancelled.
 			// subsequent calls to closeLink() will return this
-			debug.Log(1, "TX (link %p) link %s was forcibly closed: %v", l, l.key.name, ctxErr)
-			l.closeErr = &LinkError{inner: fmt.Errorf(strLinkForciblyClosed, l.key.name)}
+			debug.Log(1, "TX (link %p) closing %s: %v", l, l.key.name, ctxErr)
+			l.closeErr = &LinkError{inner: ctxErr}
 		}
 	})
 
@@ -349,5 +353,3 @@ func (l *link) txFrame(fr frames.FrameBody) error {
 		return nil
 	}
 }
-
-const strLinkForciblyClosed = "link %s was forcibly closed"

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -314,7 +314,7 @@ func TestReceiverCloseTimeout(t *testing.T) {
 	cancel()
 	var linkErr *LinkError
 	require.ErrorAs(t, err, &linkErr)
-	require.Contains(t, linkErr.Error(), "forcibly closed")
+	require.Contains(t, linkErr.Error(), context.DeadlineExceeded.Error())
 	require.NoError(t, client.Close())
 }
 

--- a/session.go
+++ b/session.go
@@ -54,10 +54,12 @@ type Session struct {
 	linksByKey map[linkKey]*link // mapping of name+role link
 	handles    *bitmap.Bitmap    // allocated handles
 
+	abandonedLinksMu sync.Mutex
+	abandonedLinks   []*link
+
 	// used for gracefully closing session
-	close      chan struct{}
-	forceClose chan struct{}
-	closeOnce  sync.Once
+	close     chan struct{} // closed by calling Close(). it signals that the end performative should be sent
+	closeOnce sync.Once
 
 	// part of internal public surface area
 	done     chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
@@ -78,7 +80,6 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 		linksMu:        sync.RWMutex{},
 		linksByKey:     make(map[linkKey]*link),
 		close:          make(chan struct{}),
-		forceClose:     make(chan struct{}),
 		done:           make(chan struct{}),
 		endSent:        make(chan struct{}),
 	}
@@ -167,25 +168,29 @@ func (s *Session) begin(ctx context.Context) error {
 //   - ctx controls waiting for the peer to acknowledge the session is closed
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned.  However, the operation will continue to
+// execute in the background. Subsequent calls will return a *SessionError
+// that contains the context's error message.
 func (s *Session) Close(ctx context.Context) error {
 	var ctxErr error
 	s.closeOnce.Do(func() {
 		close(s.close)
+
+		// once the mux has received the ack'ing end performative, the mux will
+		// exit which deletes the session and closes s.done.
 		select {
 		case <-s.done:
 			s.closeErr = s.doneErr
-		case <-ctx.Done():
-			close(s.forceClose)
 
-			// notify the caller that the close timed out/was cancelled
+		case <-ctx.Done():
+			// notify the caller that the close timed out/was cancelled.
+			// the mux will remain running and once the ack is received it will terminate.
 			ctxErr = ctx.Err()
 
-			// record that the session was forcibly closed.
+			// record that the close timed out/was cancelled.
 			// subsequent calls to Close() will return this
-			debug.Log(1, "TX (Session %p) session for channel %d was forcibly closed: %v", s, s.channel, ctxErr)
-			s.closeErr = &SessionError{inner: errSessionForciblyClosed}
+			debug.Log(1, "TX (Session %p) channel %d: %v", s, s.channel, ctxErr)
+			s.closeErr = &SessionError{inner: ctxErr}
 		}
 	})
 
@@ -219,8 +224,8 @@ func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) 
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Receiver was successfully
+// created, it will be cleaned up in future calls to NewReceiver.
 func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
 	r, err := newReceiver(source, s, opts)
 	if err != nil {
@@ -241,8 +246,8 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 //   - opts contains optional values, pass nil to accept the defaults
 //
 // If the context's deadline expires or is cancelled before the operation
-// completes, the application can be left in an unknown state, potentially
-// resulting in connection errors.
+// completes, an error is returned. If the Sender was successfully
+// created, it will be cleaned up in future calls to NewSender.
 func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
 	l, err := newSender(target, s, opts)
 	if err != nil {
@@ -257,7 +262,6 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 
 func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	defer func() {
-		s.conn.deleteSession(s)
 		if s.doneErr == nil {
 			s.doneErr = &SessionError{}
 		} else if connErr := (&ConnError{}); !errors.As(s.doneErr, &connErr) {
@@ -337,11 +341,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		// conn has completed, exit
 		case <-s.conn.done:
 			s.doneErr = s.conn.doneErr
-			return
-
-		case <-s.forceClose:
-			// the call to s.Close() timed out waiting for the ack
-			s.doneErr = errSessionForciblyClosed
 			return
 
 		case <-closed:
@@ -547,6 +546,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				// are safe to clean up its state.
 				delete(links, link.remoteHandle)
 				delete(deliveryIDByHandle, link.handle)
+				s.deallocateHandle(link)
 
 			case *frames.PerformEnd:
 				// there are two possibilities:
@@ -664,7 +664,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 	}
 }
 
-func (s *Session) allocateHandle(l *link) error {
+func (s *Session) allocateHandle(ctx context.Context, l *link) error {
 	s.linksMu.Lock()
 	defer s.linksMu.Unlock()
 
@@ -676,8 +676,11 @@ func (s *Session) allocateHandle(l *link) error {
 
 	next, ok := s.handles.Next()
 	if !ok {
+		if err := s.Close(ctx); err != nil {
+			return err
+		}
 		// handle numbers are zero-based, report the actual count
-		return fmt.Errorf("reached session handle max (%d)", s.handleMax+1)
+		return &SessionError{inner: fmt.Errorf("reached session handle max (%d)", s.handleMax+1)}
 	}
 
 	l.handle = next         // allocate handle to the link
@@ -694,6 +697,30 @@ func (s *Session) deallocateHandle(l *link) {
 	s.handles.Remove(l.handle)
 }
 
+func (s *Session) abandonLink(l *link) {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+	s.abandonedLinks = append(s.abandonedLinks, l)
+}
+
+func (s *Session) freeAbandonedLinks() error {
+	s.abandonedLinksMu.Lock()
+	defer s.abandonedLinksMu.Unlock()
+
+	for _, l := range s.abandonedLinks {
+		dr := &frames.PerformDetach{
+			Handle: l.handle,
+			Closed: true,
+		}
+		if err := s.txFrame(dr, nil); err != nil {
+			return err
+		}
+	}
+
+	s.abandonedLinks = nil
+	return nil
+}
+
 func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	q := l.rxQ.Acquire()
 	q.Enqueue(fr)
@@ -704,5 +731,3 @@ func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 // the address of this var is a sentinel value indicating
 // that a transfer frame is in need of a delivery ID
 var needsDeliveryID uint32
-
-var errSessionForciblyClosed = errors.New("the session was forcibly closed")

--- a/session.go
+++ b/session.go
@@ -76,7 +76,7 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 		txTransfer:     make(chan *frames.PerformTransfer),
 		incomingWindow: defaultWindow,
 		outgoingWindow: defaultWindow,
-		handleMax:      math.MaxUint32,
+		handleMax:      math.MaxUint32 - 1,
 		linksMu:        sync.RWMutex{},
 		linksByKey:     make(map[linkKey]*link),
 		close:          make(chan struct{}),

--- a/session.go
+++ b/session.go
@@ -707,6 +707,8 @@ func (s *Session) freeAbandonedLinks() error {
 	s.abandonedLinksMu.Lock()
 	defer s.abandonedLinksMu.Unlock()
 
+	debug.Log(3, "TX (Session %p): cleaning up %d abandoned links", s, len(s.abandonedLinks))
+
 	for _, l := range s.abandonedLinks {
 		dr := &frames.PerformDetach{
 			Handle: l.handle,

--- a/session_test.go
+++ b/session_test.go
@@ -147,7 +147,7 @@ func TestSessionCloseTimeout(t *testing.T) {
 	cancel()
 	var sessionErr *SessionError
 	require.ErrorAs(t, err, &sessionErr)
-	require.Contains(t, sessionErr.Error(), "forcibly closed")
+	require.Contains(t, sessionErr.Error(), context.DeadlineExceeded.Error())
 
 	require.NoError(t, client.Close())
 }


### PR DESCRIPTION
If a context expires or is cancelled during session/link creation while waiting for the ack, add the instance to a slice for later cleanup. Removed force-closing of sessions/links.
Exhausting available session channels will return a *ConnError and close the Conn.
Exhausting available link handles will return a *SessionError and close the Session.

Fixes https://github.com/Azure/go-amqp/issues/277