### PR TITLE
Sending frames synchronizes with mux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Calling `Dial()` with a cancelled context doesn't create a connection.
 * Context cancellation is properly honored in calls to `Dial()` and `NewConn()`.
 * Fixed potential race during `Conn.Close()`.
+* Disable sending frames when closing `Session`, `Sender`, and `Receiver`.
 
 ### Other Changes
 

--- a/receiver.go
+++ b/receiver.go
@@ -250,7 +250,7 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 
 	select {
 	case r.txDisposition <- fr:
-		// frame was sent to our mux
+		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
 		return nil
 	case <-r.l.done:
 		return r.l.doneErr
@@ -291,10 +291,9 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		//   - nil, meaning the peer accepted the message no problem
 		//   - an *Error, meaning the peer rejected the message with a provided error
 		//   - a non-AMQP error. this comes from calls to inFlight.clear() during mux unwind.
-		// the first two cases the message is settled, the last one it isn't.
+		// only for the first two cases is the message considered settled
 
-		var amqpErr *Error
-		if err == nil || errors.As(err, &amqpErr) {
+		if amqpErr := (&Error{}); err == nil || errors.As(err, &amqpErr) {
 			debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
 			// we've received confirmation of disposition
 			r.deleteUnsettled(msg)

--- a/receiver.go
+++ b/receiver.go
@@ -24,8 +24,9 @@ type Receiver struct {
 	l link
 
 	// message receiving
-	receiverReady chan struct{}          // receiver sends on this when mux is paused to indicate it can handle more messages
-	messagesQ     *queue.Holder[Message] // used to send completed messages to receiver
+	receiverReady chan struct{}                   // receiver sends on this when mux is paused to indicate it can handle more messages
+	messagesQ     *queue.Holder[Message]          // used to send completed messages to receiver
+	txDisposition chan *frames.PerformDisposition // used to funnel disposition frames through the mux
 
 	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
 	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
@@ -238,7 +239,7 @@ func (r *Receiver) Close(ctx context.Context) error {
 }
 
 // sendDisposition sends a disposition frame to the peer
-func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.DeliveryState) error {
+func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint32, state encoding.DeliveryState) error {
 	fr := &frames.PerformDisposition{
 		Role:    encoding.RoleReceiver,
 		First:   first,
@@ -248,11 +249,13 @@ func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.De
 	}
 
 	select {
+	case r.txDisposition <- fr:
+		// frame was sent to our mux
+		return nil
 	case <-r.l.done:
 		return r.l.doneErr
-	default:
-		// TODO: this is racy
-		return r.l.session.txFrame(fr, nil)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -261,13 +264,17 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		return nil
 	}
 
+	// NOTE: we MUST add to the in-flight map before sending the disposition. if not, it's possible
+	// to receive the ack'ing disposition frame *before* the in-flight map has been updated which
+	// will cause the below <-wait to never trigger.
+
 	var wait chan error
 	if r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond {
 		debug.Log(3, "TX (Receiver %p): delivery ID %d is in flight", r, msg.deliveryID)
 		wait = r.inFlight.add(msg.deliveryID)
 	}
 
-	if err := r.sendDisposition(msg.deliveryID, nil, state); err != nil {
+	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
 		return err
 	}
 
@@ -280,12 +287,25 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	select {
 	case err := <-wait:
-		debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
-		// we've received confirmation of disposition
-		r.deleteUnsettled(msg)
-		r.onSettlement(1)
-		msg.settled = true
+		// err has three possibilities
+		//   - nil, meaning the peer accepted the message no problem
+		//   - an *Error, meaning the peer rejected the message with a provided error
+		//   - a non-AMQP error. this comes from calls to inFlight.clear() during mux unwind.
+		// the first two cases the message is settled, the last one it isn't.
+
+		var amqpErr *Error
+		if err == nil || errors.As(err, &amqpErr) {
+			debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
+			// we've received confirmation of disposition
+			r.deleteUnsettled(msg)
+			r.onSettlement(1)
+			msg.settled = true
+			return err
+		}
+
+		debug.Log(3, "RX (Receiver %p): error settling delivery ID %d: %v", r, msg.deliveryID, err)
 		return err
+
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
 		return ctx.Err()
@@ -339,6 +359,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		l:             l,
 		autoSendFlow:  true,
 		receiverReady: make(chan struct{}, 1),
+		txDisposition: make(chan *frames.PerformDisposition),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -529,10 +550,16 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 			return
 		}
 
+		txDisposition := r.txDisposition
 		closed := r.l.close
 		if r.l.closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// disable sending of disposition frames once closing is in progress.
+			// this is to prevent races between mux shutdown and clearing of
+			// any in-flight dispositions.
+			txDisposition = nil
 		}
 
 		hooks.MuxSelect()
@@ -556,6 +583,9 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 				return
 			}
 
+		case fr := <-txDisposition:
+			_ = r.l.txFrame(fr)
+
 		case <-r.receiverReady:
 			continue
 
@@ -564,13 +594,14 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 				// a client-side close due to protocol error is in progress
 				continue
 			}
+
 			// receiver is being closed by the client
 			r.l.closeInProgress = true
 			fr := &frames.PerformDetach{
 				Handle: r.l.handle,
 				Closed: true,
 			}
-			_ = r.l.session.txFrame(fr, nil)
+			_ = r.l.txFrame(fr)
 
 		case <-r.l.session.done:
 			r.l.doneErr = r.l.session.doneErr

--- a/receiver.go
+++ b/receiver.go
@@ -288,7 +288,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	select {
 	case err := <-wait:
 		// err has three possibilities
-		//   - nil, meaning the peer accepted the message no problem
+		//   - nil, meaning the peer acknowledged the settlement
 		//   - an *Error, meaning the peer rejected the message with a provided error
 		//   - a non-AMQP error. this comes from calls to inFlight.clear() during mux unwind.
 		// only for the first two cases is the message considered settled

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -488,7 +488,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(0)
+	muxSem.Release(1)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
@@ -564,7 +564,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()
@@ -706,7 +706,7 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.RejectMessage(ctx, msg, nil)
 	cancel()
@@ -777,7 +777,7 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.ReleaseMessage(ctx, msg)
 	cancel()
@@ -853,7 +853,7 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.ModifyMessage(ctx, msg, &ModifyMessageOptions{
 		UndeliverableHere: true,
@@ -973,7 +973,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()

--- a/session.go
+++ b/session.go
@@ -61,6 +61,7 @@ type Session struct {
 
 	// part of internal public surface area
 	done     chan struct{} // closed when the session has terminated (mux exited); DO NOT wait on this from within Session.mux() as it will never trigger!
+	endSent  chan struct{} // closed when the end performative has been sent; once this is closed, links MUST NOT send any frames!
 	doneErr  error         // contains the mux error state; ONLY written to by the mux and MUST only be read from after done is closed!
 	closeErr error         // contains the error state returned from Close(); ONLY Close() reads/writes this!
 }
@@ -79,6 +80,7 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 		close:          make(chan struct{}),
 		forceClose:     make(chan struct{}),
 		done:           make(chan struct{}),
+		endSent:        make(chan struct{}),
 	}
 
 	if opts != nil {
@@ -299,6 +301,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		closeInProgress = true
 		s.doneErr = e2
 		_ = s.txFrame(&frames.PerformEnd{Error: e1}, nil)
+		close(s.endSent)
 	}
 
 	for {
@@ -310,10 +313,15 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			txTransfer = nil
 		}
 
+		tx := s.tx
 		closed := s.close
 		if closeInProgress {
 			// swap out channel so it no longer triggers
 			closed = nil
+
+			// once the end performative is sent, we're not allowed to send any frames
+			tx = nil
+			txTransfer = nil
 		}
 
 		// notes on client-side closing session
@@ -343,8 +351,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 			// session is being closed by the client
 			closeInProgress = true
-			fr := frames.PerformEnd{}
-			_ = s.txFrame(&fr, nil)
+			_ = s.txFrame(&frames.PerformEnd{}, nil)
+			close(s.endSent)
 
 		// incoming frame
 		case q := <-s.rxQ.Wait():
@@ -569,13 +577,6 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 
 		case fr := <-txTransfer:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session %p): discarding transfer: %s\n", s, fr)
-				continue
-			}
-
 			// record current delivery ID
 			var deliveryID uint32
 			if fr.DeliveryID == &needsDeliveryID {
@@ -620,14 +621,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				remoteIncomingWindow--
 			}
 
-		case fr := <-s.tx:
-			if closeInProgress {
-				// now that the end performative has been sent we're
-				// not allowed to send any more frames.
-				debug.Log(1, "TX (Session %p): discarding frame: %s", s, fr)
-				continue
-			}
-
+		case fr := <-tx:
 			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
 			switch fr := fr.(type) {
 			case *frames.PerformDisposition:

--- a/session.go
+++ b/session.go
@@ -453,7 +453,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					continue
 				}
 
-				if body.Echo {
+				if body.Echo && !closeInProgress {
 					niID := nextIncomingID
 					resp := &frames.PerformFlow{
 						NextIncomingID: &niID,
@@ -516,7 +516,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				// Update peer's outgoing window if half has been consumed.
-				if s.needFlowCount >= s.incomingWindow/2 {
+				if s.needFlowCount >= s.incomingWindow/2 && !closeInProgress {
 					debug.Log(3, "RX (Session %p): channel %d: flow - s.needFlowCount(%d) >= s.incomingWindow(%d)/2\n", s, s.channel, s.needFlowCount, s.incomingWindow)
 					s.needFlowCount = 0
 					nID := nextIncomingID


### PR DESCRIPTION
Session mux no longer consumes frames once the end performative has been sent.  Instead, added channel endSent that links can select on. Added method link.txFrame for proper muxing of frames to session. Receivers send disposition frames through the mux to properly sync with the receiver being closed.
Senders disable the outgoing transfers channel once close has started.

Fixes https://github.com/Azure/go-amqp/issues/278