### PR TITLE
Make writes deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed potential race during `Conn.Close()`.
 * Disable sending frames when closing `Session`, `Sender`, and `Receiver`.
 * Don't leak in-flight messages when a message settlement API is cancelled or times out waiting for acknowledgement.
+* `Sender.Send()` will return an `*amqp.Error` with condition `amqp.ErrCondTransferLimitExceeded` when attempting to send a transfer on a link with no credit.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0 (Unreleased)
 
+### Features Added
+
+* Added `ConnOptions.WriteTimeout` to control the write deadline when writing to `net.Conn`.
+
 ### Bugs Fixed
 
 * Calling `Dial()` with a cancelled context doesn't create a connection.
@@ -15,6 +19,7 @@
 * Debug logging includes the address of the object that's writing a log entry.
 * Context expiration or cancellation when creating instances of `Session`, `Receiver`, and `Sender` no longer result in the potential for `Conn` to unexpectedly terminate.
 * Session channel and link handle exhaustion will now return `*ConnError` and `*SessionError` respectively, closing the respective `Conn` or `Session`.
+* If a `context.Context` contains a deadline/timeout, that value will be used as the write deadline when writing to `net.Conn`.
 
 ## 0.19.1 (2023-03-31)
 

--- a/conn.go
+++ b/conn.go
@@ -25,6 +25,7 @@ const (
 	defaultIdleTimeout  = 1 * time.Minute
 	defaultMaxFrameSize = 65536
 	defaultMaxSessions  = 65536
+	defaultWriteTimeout = 30 * time.Second
 )
 
 // ConnOptions contains the optional settings for configuring an AMQP connection.
@@ -73,6 +74,17 @@ type ConnOptions struct {
 	// providing a URL scheme of "amqps://" is sufficient.
 	TLSConfig *tls.Config
 
+	// WriteTimeout controls the write deadline when writing AMQP frames to the
+	// underlying net.Conn and no caller provided context.Context is available or
+	// the context contains no deadline (e.g. context.Background()).
+	// The timeout is set per write.
+	//
+	// Setting to a value less than zero means no timeout is set, so writes
+	// defer to the underlying behavior of net.Conn with no write deadline.
+	//
+	// Default: 30s
+	WriteTimeout time.Duration
+
 	// test hook
 	dialer dialer
 }
@@ -114,8 +126,9 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 
 // Conn is an AMQP connection.
 type Conn struct {
-	net    net.Conn // underlying connection
-	dialer dialer   // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	net          net.Conn      // underlying connection
+	dialer       dialer        // used for testing purposes, it allows faking dialing TCP/TLS endpoints
+	writeTimeout time.Duration // controls write deadline in absense of a context
 
 	// TLS
 	tlsNegotiation bool        // negotiate TLS
@@ -160,10 +173,10 @@ type Conn struct {
 	rxErr  error         // contains last error reading from c.net; DO NOT TOUCH outside of connReader until rxDone has been closed!
 
 	// connWriter
-	txFrame chan frames.Frame // AMQP frames to be sent by connWriter
-	txBuf   buffer.Buffer     // buffer for marshaling frames before transmitting
-	txDone  chan struct{}     // closed when connWriter exits
-	txErr   error             // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	txFrame chan frameEnvelope // AMQP frames to be sent by connWriter
+	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
+	txDone  chan struct{}      // closed when connWriter exits
+	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
 }
 
 // used to abstract the underlying dialer for testing purposes
@@ -249,9 +262,10 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		done:              make(chan struct{}),
 		rxtxExit:          make(chan struct{}),
 		rxDone:            make(chan struct{}),
-		txFrame:           make(chan frames.Frame),
+		txFrame:           make(chan frameEnvelope),
 		txDone:            make(chan struct{}),
 		sessionsByChannel: map[uint16]*Session{},
+		writeTimeout:      defaultWriteTimeout,
 	}
 
 	// apply options
@@ -259,6 +273,11 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		opts = &ConnOptions{}
 	}
 
+	if opts.WriteTimeout > 0 {
+		c.writeTimeout = opts.WriteTimeout
+	} else if opts.WriteTimeout < 0 {
+		c.writeTimeout = 0
+	}
 	if opts.ContainerID != "" {
 		c.containerID = opts.ContainerID
 	}
@@ -427,7 +446,8 @@ func (c *Conn) close() {
 			// we experienced a peer-initiated close that contained an Error.  return it
 			c.doneErr = &ConnError{RemoteErr: amqpErr}
 		} else if c.txErr != nil {
-			c.doneErr = &ConnError{inner: c.txErr}
+			// c.txErr is already wrapped in a ConnError
+			c.doneErr = c.txErr
 		} else if c.rxErr != nil {
 			c.doneErr = &ConnError{inner: c.rxErr}
 		} else {
@@ -452,7 +472,7 @@ func (c *Conn) closeDuringStart() {
 // created, it will be cleaned up in future calls to NewSession.
 func (c *Conn) NewSession(ctx context.Context, opts *SessionOptions) (*Session, error) {
 	// clean up any abandoned sessions first
-	if err := c.freeAbandonedSessions(); err != nil {
+	if err := c.freeAbandonedSessions(ctx); err != nil {
 		return nil, err
 	}
 
@@ -469,7 +489,7 @@ func (c *Conn) NewSession(ctx context.Context, opts *SessionOptions) (*Session, 
 	return session, nil
 }
 
-func (c *Conn) freeAbandonedSessions() error {
+func (c *Conn) freeAbandonedSessions(ctx context.Context) error {
 	c.abandonedSessionsMu.Lock()
 	defer c.abandonedSessionsMu.Unlock()
 
@@ -477,7 +497,7 @@ func (c *Conn) freeAbandonedSessions() error {
 
 	for _, s := range c.abandonedSessions {
 		fr := frames.PerformEnd{}
-		if err := s.txFrame(&fr, nil); err != nil {
+		if err := s.txFrameAndWait(ctx, &fr); err != nil {
 			return err
 		}
 	}
@@ -691,6 +711,16 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 	}
 }
 
+// frameEnvelope is used when sending a frame to connWriter to be written to net.Conn
+type frameEnvelope struct {
+	Ctx   context.Context
+	Frame frames.Frame
+
+	// optional channel that is closed on successful write to net.Conn or contains the write error
+	// NOTE: use a buffered channel of size 1 when populating
+	Sent chan error
+}
+
 func (c *Conn) connWriter() {
 	defer func() {
 		close(c.txDone)
@@ -722,17 +752,25 @@ func (c *Conn) connWriter() {
 
 		select {
 		// frame write request
-		case fr := <-c.txFrame:
-			debug.Log(1, "TX (connWriter %p): %s", c, fr)
-			err = c.writeFrame(fr)
-			if err == nil && fr.Done != nil {
-				close(fr.Done)
+		case env := <-c.txFrame:
+			timeout := c.getWriteTimeout(env.Ctx)
+			debug.Log(1, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+			err = c.writeFrame(timeout, env.Frame)
+			if env.Sent != nil {
+				if err == nil {
+					close(env.Sent)
+				} else {
+					env.Sent <- err
+				}
 			}
 
 		// keepalive timer
 		case <-keepalive:
 			debug.Log(3, "TX (connWriter %p): sending keep-alive frame", c)
-			_, err = c.net.Write(keepaliveFrame)
+			_ = c.net.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+			if _, err = c.net.Write(keepaliveFrame); err != nil {
+				err = &ConnError{inner: err}
+			}
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.
 			// However, keepalives are small (8 bytes) and the interval
@@ -752,7 +790,7 @@ func (c *Conn) connWriter() {
 				Body: &frames.PerformClose{},
 			}
 			debug.Log(1, "TX (connWriter %p): %s", c, fr)
-			c.txErr = c.writeFrame(fr)
+			c.txErr = c.writeFrame(c.writeTimeout, fr)
 			return
 		}
 	}
@@ -760,24 +798,36 @@ func (c *Conn) connWriter() {
 
 // writeFrame writes a frame to the network.
 // used externally by SASL only.
-func (c *Conn) writeFrame(fr frames.Frame) error {
+//   - timeout - the write deadline to set. zero means no deadline
+//
+// errors are wrapped in a ConnError as they can be returned to outside callers.
+func (c *Conn) writeFrame(timeout time.Duration, fr frames.Frame) error {
 	// writeFrame into txBuf
 	c.txBuf.Reset()
 	err := frames.Write(&c.txBuf, fr)
 	if err != nil {
-		return err
+		return &ConnError{inner: err}
 	}
 
 	// validate the frame isn't exceeding peer's max frame size
 	requiredFrameSize := c.txBuf.Len()
 	if uint64(requiredFrameSize) > uint64(c.peerMaxFrameSize) {
-		return fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)
+		return &ConnError{inner: fmt.Errorf("%T frame size %d larger than peer's max frame size %d", fr, requiredFrameSize, c.peerMaxFrameSize)}
+	}
+
+	if timeout == 0 {
+		_ = c.net.SetWriteDeadline(time.Time{})
+	} else if timeout > 0 {
+		_ = c.net.SetWriteDeadline(time.Now().Add(timeout))
 	}
 
 	// write to network
 	n, err := c.net.Write(c.txBuf.Bytes())
 	if l := c.txBuf.Len(); n > 0 && n < l && err != nil {
 		debug.Log(1, "TX (writeFrame %p): wrote %d bytes less than len %d: %v", c, n, l, err)
+	}
+	if err != nil {
+		err = &ConnError{inner: err}
 	}
 	return err
 }
@@ -793,13 +843,17 @@ func (c *Conn) writeProtoHeader(pID protoID) error {
 var keepaliveFrame = []byte{0x00, 0x00, 0x00, 0x08, 0x02, 0x00, 0x00, 0x00}
 
 // SendFrame is used by sessions and links to send frames across the network.
-func (c *Conn) sendFrame(fr frames.Frame) error {
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (c *Conn) sendFrame(ctx context.Context, fr frames.Frame, sent chan error) {
 	select {
-	case c.txFrame <- fr:
+	case c.txFrame <- frameEnvelope{Ctx: ctx, Frame: fr, Sent: sent}:
 		debug.Log(2, "TX (Conn %p): mux frame to connWriter: %s", c, fr)
-		return nil
 	case <-c.done:
-		return c.doneErr
+		if sent != nil {
+			sent <- c.doneErr
+		}
 	}
 }
 
@@ -932,7 +986,7 @@ func (c *Conn) startTLS(ctx context.Context) (stateFunc, error) {
 }
 
 // openAMQP round trips the AMQP open performative
-func (c *Conn) openAMQP(context.Context) (stateFunc, error) {
+func (c *Conn) openAMQP(ctx context.Context) (stateFunc, error) {
 	// send open frame
 	open := &frames.PerformOpen{
 		ContainerID:  c.containerID,
@@ -948,7 +1002,7 @@ func (c *Conn) openAMQP(context.Context) (stateFunc, error) {
 		Channel: 0,
 	}
 	debug.Log(1, "TX (openAMQP %p): %s", c, fr)
-	err := c.writeFrame(fr)
+	err := c.writeFrame(c.getWriteTimeout(ctx), fr)
 	if err != nil {
 		return nil, err
 	}
@@ -1043,6 +1097,15 @@ func (c *Conn) readSingleFrame() (frames.Frame, error) {
 	}
 
 	return fr, nil
+}
+
+// getWriteTimeout returns the timeout as calculated from the context's deadline
+// or the default write timeout if the context has no deadline.
+func (c *Conn) getWriteTimeout(ctx context.Context) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return time.Until(deadline)
+	}
+	return c.writeTimeout
 }
 
 type protoHeader struct {

--- a/conn.go
+++ b/conn.go
@@ -753,7 +753,15 @@ func (c *Conn) connWriter() {
 		select {
 		// frame write request
 		case env := <-c.txFrame:
-			timeout := c.getWriteTimeout(env.Ctx)
+			timeout, ctxErr := c.getWriteTimeout(env.Ctx)
+			if ctxErr != nil {
+				debug.Log(1, "TX (connWriter %p) deadline exceeded: %s", c, env.Frame)
+				if env.Sent != nil {
+					env.Sent <- ctxErr
+				}
+				continue
+			}
+
 			debug.Log(1, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
 			err = c.writeFrame(timeout, env.Frame)
 			if env.Sent != nil {
@@ -1002,8 +1010,11 @@ func (c *Conn) openAMQP(ctx context.Context) (stateFunc, error) {
 		Channel: 0,
 	}
 	debug.Log(1, "TX (openAMQP %p): %s", c, fr)
-	err := c.writeFrame(c.getWriteTimeout(ctx), fr)
+	timeout, err := c.getWriteTimeout(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err = c.writeFrame(timeout, fr); err != nil {
 		return nil, err
 	}
 
@@ -1101,11 +1112,16 @@ func (c *Conn) readSingleFrame() (frames.Frame, error) {
 
 // getWriteTimeout returns the timeout as calculated from the context's deadline
 // or the default write timeout if the context has no deadline.
-func (c *Conn) getWriteTimeout(ctx context.Context) time.Duration {
+// if the context has timed out or was cancelled, an error is returned.
+func (c *Conn) getWriteTimeout(ctx context.Context) (time.Duration, error) {
 	if deadline, ok := ctx.Deadline(); ok {
-		return time.Until(deadline)
+		until := time.Until(deadline)
+		if until <= 0 {
+			return 0, context.DeadlineExceeded
+		}
+		return until, nil
 	}
-	return c.writeTimeout
+	return c.writeTimeout, nil
 }
 
 type protoHeader struct {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -120,3 +120,18 @@ func newReceiverWithHooks(ctx context.Context, s *Session, source string, opts *
 
 	return r, nil
 }
+
+// this is the same API as Session.NewSender() but with support for adding test hooks
+func newSenderWithHooks(ctx context.Context, s *Session, target string, opts *SenderOptions, hooks senderTestHooks) (*Sender, error) {
+	r, err := newSender(target, s, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err = r.attach(ctx); err != nil {
+		return nil, err
+	}
+
+	go r.mux(hooks)
+
+	return r, nil
+}

--- a/internal/frames/frames.go
+++ b/internal/frames/frames.go
@@ -353,9 +353,6 @@ type Frame struct {
 	Type    Type      // AMQP/SASL
 	Channel uint16    // channel this frame is for
 	Body    FrameBody // body of the frame
-
-	// optional channel which will be closed after net transmit
-	Done chan encoding.DeliveryState
 }
 
 // String implements the fmt.Stringer interface for type Frame.

--- a/link_test.go
+++ b/link_test.go
@@ -46,7 +46,7 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 			// with the correct value, a wrong frame, or the context expires.
 			select {
 			case txFrame := <-l.l.session.tx:
-				switch frame := txFrame.(type) {
+				switch frame := txFrame.FrameBody.(type) {
 				case *frames.PerformFlow:
 					require.False(t, frame.Drain)
 					// replenished credits: l.receiver.maxCredit-uint32(l.countUnsettled())
@@ -119,7 +119,7 @@ func TestLinkFlowWithManualCreditor(t *testing.T) {
 	// flow happens immmediately in 'mux'
 	txFrame := <-l.l.session.tx
 
-	switch frame := txFrame.(type) {
+	switch frame := txFrame.FrameBody.(type) {
 	case *frames.PerformFlow:
 		require.False(t, frame.Drain)
 		require.EqualValues(t, 100+1, *frame.LinkCredit)
@@ -183,7 +183,7 @@ func newTestLink(t *testing.T) *Receiver {
 			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
 			done: make(chan struct{}),
 			session: &Session{
-				tx:      make(chan frames.FrameBody, 100),
+				tx:      make(chan frameBodyEnvelope, 100),
 				done:    make(chan struct{}),
 				conn:    conn,
 				handles: bitmap.New(32),

--- a/receiver.go
+++ b/receiver.go
@@ -24,9 +24,9 @@ type Receiver struct {
 	l link
 
 	// message receiving
-	receiverReady chan struct{}                   // receiver sends on this when mux is paused to indicate it can handle more messages
-	messagesQ     *queue.Holder[Message]          // used to send completed messages to receiver
-	txDisposition chan *frames.PerformDisposition // used to funnel disposition frames through the mux
+	receiverReady chan struct{}          // receiver sends on this when mux is paused to indicate it can handle more messages
+	messagesQ     *queue.Holder[Message] // used to send completed messages to receiver
+	txDisposition chan frameBodyEnvelope // used to funnel disposition frames through the mux
 
 	unsettledMessages     map[string]struct{} // used to keep track of messages being handled downstream
 	unsettledMessagesLock sync.RWMutex        // lock to protect concurrent access to unsettledMessages
@@ -249,14 +249,21 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 		State:   state,
 	}
 
+	sent := make(chan error, 1)
 	select {
-	case r.txDisposition <- fr:
-		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
-		return nil
 	case <-r.l.done:
 		return r.l.doneErr
 	case <-ctx.Done():
 		return ctx.Err()
+	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
+		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+	}
+
+	select {
+	case err := <-sent:
+		return err
+	case <-r.l.done:
+		return r.l.doneErr
 	}
 }
 
@@ -356,7 +363,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		l:             l,
 		autoSendFlow:  true,
 		receiverReady: make(chan struct{}, 1),
-		txDisposition: make(chan *frames.PerformDisposition),
+		txDisposition: make(chan frameBodyEnvelope),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -574,8 +581,8 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 				return
 			}
 
-		case fr := <-txDisposition:
-			_ = r.l.txFrame(fr)
+		case env := <-txDisposition:
+			r.l.txFrame(env.Ctx, env.FrameBody, env.Sent)
 
 		case <-r.receiverReady:
 			continue
@@ -592,7 +599,7 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 				Handle: r.l.handle,
 				Closed: true,
 			}
-			_ = r.l.txFrame(fr)
+			r.l.txFrame(context.Background(), fr, nil)
 
 		case <-r.l.session.done:
 			r.l.doneErr = r.l.session.doneErr
@@ -627,7 +634,7 @@ func (r *Receiver) muxFlow(linkCredit uint32, drain bool) error {
 	}
 
 	select {
-	case r.l.session.tx <- fr:
+	case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: fr}:
 		debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, fr)
 		return nil
 	case <-r.l.close:
@@ -671,7 +678,7 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		}
 
 		select {
-		case r.l.session.tx <- resp:
+		case r.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: resp}:
 			debug.Log(2, "TX (Receiver %p): mux frame to Session (%p): %d, %s", r, r.l.session, r.l.session.channel, resp)
 		case <-r.l.close:
 			return nil

--- a/receiver.go
+++ b/receiver.go
@@ -251,12 +251,10 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 
 	sent := make(chan error, 1)
 	select {
-	case <-r.l.done:
-		return r.l.doneErr
-	case <-ctx.Done():
-		return ctx.Err()
 	case r.txDisposition <- frameBodyEnvelope{Ctx: ctx, FrameBody: fr, Sent: sent}:
 		debug.Log(2, "TX (Receiver %p): mux txDisposition %s", r, fr)
+	case <-r.l.done:
+		return r.l.doneErr
 	}
 
 	select {

--- a/receiver.go
+++ b/receiver.go
@@ -310,6 +310,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	case <-ctx.Done():
 		// didn't receive the ack in the time allotted, leave message as unsettled
+		// TODO: if the ack arrives later, we need to remove the message from the unsettled map and reclaim the credit
 		return ctx.Err()
 	}
 }

--- a/sender.go
+++ b/sender.go
@@ -168,8 +168,6 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 			// frame was sent to our mux
 		case <-s.l.done:
 			return nil, s.l.doneErr
-		case <-ctx.Done():
-			return nil, ctx.Err()
 		}
 
 		select {

--- a/sender.go
+++ b/sender.go
@@ -452,8 +452,6 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 			Settled: true,
 		}
 
-		// TODO: the context used here should be the one associated with the original Send()
-
 		select {
 		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: dr}:
 			debug.Log(2, "TX (Sender %p): mux frame to Session (%p): %d, %s", s, s.l.session, s.l.session.channel, dr)

--- a/sender.go
+++ b/sender.go
@@ -168,6 +168,8 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 			// frame was sent to our mux
 		case <-s.l.done:
 			return nil, s.l.doneErr
+		case <-ctx.Done():
+			return nil, &Error{Condition: ErrCondTransferLimitExceeded, Description: fmt.Sprintf("credit limit exceeded for sending link %s", s.l.key.name)}
 		}
 
 		select {

--- a/sender.go
+++ b/sender.go
@@ -16,7 +16,7 @@ import (
 // Sender sends messages on a single AMQP link.
 type Sender struct {
 	l         link
-	transfers chan frames.PerformTransfer // sender uses to send transfer frames
+	transfers chan transferEnvelope // sender uses to send transfer frames
 
 	mu              sync.Mutex // protects buf and nextDeliveryTag
 	buf             buffer.Buffer
@@ -160,13 +160,25 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 			fr.Done = make(chan encoding.DeliveryState, 1)
 		}
 
+		// NOTE: we MUST send a copy of fr here since we modify it post send
+
+		sent := make(chan error, 1)
 		select {
-		case s.transfers <- fr:
+		case s.transfers <- transferEnvelope{Ctx: ctx, Frame: fr, Sent: sent}:
 			// frame was sent to our mux
 		case <-s.l.done:
 			return nil, s.l.doneErr
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+
+		select {
+		case err := <-sent:
+			if err != nil {
+				return nil, err
+			}
+		case <-s.l.done:
+			return nil, s.l.doneErr
 		}
 
 		// clear values that are only required on first message
@@ -288,21 +300,27 @@ func (s *Sender) attach(ctx context.Context) error {
 		return err
 	}
 
-	s.transfers = make(chan frames.PerformTransfer)
-
-	go s.mux()
+	s.transfers = make(chan transferEnvelope)
 
 	return nil
 }
 
-func (s *Sender) mux() {
+type senderTestHooks struct {
+	MuxTransfer func()
+}
+
+func (s *Sender) mux(hooks senderTestHooks) {
+	if hooks.MuxTransfer == nil {
+		hooks.MuxTransfer = nop
+	}
+
 	defer func() {
 		close(s.l.done)
 	}()
 
 Loop:
 	for {
-		var outgoingTransfers chan frames.PerformTransfer
+		var outgoingTransfers chan transferEnvelope
 		if s.l.linkCredit > 0 {
 			debug.Log(1, "TX (Sender %p) (enable): target: %q, link credit: %d, deliveryCount: %d", s, s.l.target.Address, s.l.linkCredit, s.l.deliveryCount)
 			outgoingTransfers = s.transfers
@@ -337,12 +355,13 @@ Loop:
 			}
 
 		// send data
-		case tr := <-outgoingTransfers:
+		case env := <-outgoingTransfers:
+			hooks.MuxTransfer()
 			select {
-			case s.l.session.txTransfer <- &tr:
-				debug.Log(2, "TX (Sender %p): mux transfer to Session: %d, %s", s, s.l.session.channel, &tr)
+			case s.l.session.txTransfer <- env:
+				debug.Log(2, "TX (Sender %p): mux transfer to Session: %d, %s", s, s.l.session.channel, env.Frame)
 				// decrement link-credit after entire message transferred
-				if !tr.More {
+				if !env.Frame.More {
 					s.l.deliveryCount++
 					s.l.linkCredit--
 					// we are the sender and we keep track of the peer's link credit
@@ -367,7 +386,7 @@ Loop:
 				Handle: s.l.handle,
 				Closed: true,
 			}
-			_ = s.l.txFrame(fr)
+			s.l.txFrame(context.Background(), fr, nil)
 
 		case <-s.l.session.done:
 			s.l.doneErr = s.l.session.doneErr
@@ -412,7 +431,7 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 		}
 
 		select {
-		case s.l.session.tx <- resp:
+		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: resp}:
 			debug.Log(2, "TX (Sender %p): mux frame to Session (%p): %d, %s", s, s.l.session, s.l.session.channel, resp)
 		case <-s.l.close:
 			return nil
@@ -435,8 +454,10 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 			Settled: true,
 		}
 
+		// TODO: the context used here should be the one associated with the original Send()
+
 		select {
-		case s.l.session.tx <- dr:
+		case s.l.session.tx <- frameBodyEnvelope{Ctx: context.Background(), FrameBody: dr}:
 			debug.Log(2, "TX (Sender %p): mux frame to Session (%p): %d, %s", s, s.l.session, s.l.session.channel, dr)
 		case <-s.l.close:
 			return nil

--- a/sender_test.go
+++ b/sender_test.go
@@ -721,9 +721,12 @@ func TestSenderSendTimeout(t *testing.T) {
 
 	// no credits have been issued so the send will time out
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
-	require.Error(t, snd.Send(ctx, NewMessage([]byte("test")), nil))
+	err = snd.Send(ctx, NewMessage([]byte("test")), nil)
 	cancel()
 
+	var amqpErr *Error
+	require.ErrorAs(t, err, &amqpErr)
+	require.EqualValues(t, ErrCondTransferLimitExceeded, amqpErr.Condition)
 	require.NoError(t, client.Close())
 }
 

--- a/sender_test.go
+++ b/sender_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/go-amqp/internal/encoding"
 	"github.com/Azure/go-amqp/internal/fake"
 	"github.com/Azure/go-amqp/internal/frames"
+	"github.com/Azure/go-amqp/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,6 +150,58 @@ func TestSenderSendOnSessionClosed(t *testing.T) {
 	var amqpErr *Error
 	// there should be no inner error when closed on our side
 	require.False(t, errors.As(err, &amqpErr))
+	require.NoError(t, client.Close())
+}
+
+func TestSenderSendConcurrentSessionClosed(t *testing.T) {
+	muxSem := test.NewMuxSemaphore(0)
+
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	snd, err := newSenderWithHooks(ctx, session, "target", nil, senderTestHooks{MuxTransfer: muxSem.OnLoop})
+	cancel()
+	require.NoError(t, err)
+	require.NotNil(t, snd)
+
+	sendInitialFlowFrame(t, 0, netConn, 0, 100)
+
+	sendErr := make(chan error)
+
+	go func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		err := snd.Send(ctx, NewMessage([]byte("failed")), nil)
+		cancel()
+		sendErr <- err
+	}()
+
+	muxSem.Wait()
+
+	// transfer was handed off to the sender's mux and it's now paused
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	require.NoError(t, session.Close(ctx))
+	cancel()
+
+	// resume the sender's mux
+	muxSem.Release(-1)
+
+	select {
+	case err := <-sendErr:
+		var sessionErr *SessionError
+		require.ErrorAs(t, err, &sessionErr)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for send error")
+	}
+
 	require.NoError(t, client.Close())
 }
 

--- a/session.go
+++ b/session.go
@@ -33,11 +33,11 @@ type SessionOptions struct {
 //
 // A session multiplexes Receivers.
 type Session struct {
-	channel       uint16                       // session's local channel
-	remoteChannel uint16                       // session's remote channel, owned by conn.connReader
-	conn          *Conn                        // underlying conn
-	tx            chan frames.FrameBody        // non-transfer frames to be sent; session must track disposition
-	txTransfer    chan *frames.PerformTransfer // transfer frames to be sent; session must track disposition
+	channel       uint16                 // session's local channel
+	remoteChannel uint16                 // session's remote channel, owned by conn.connReader
+	conn          *Conn                  // underlying conn
+	tx            chan frameBodyEnvelope // non-transfer frames to be sent; session must track disposition
+	txTransfer    chan transferEnvelope  // transfer frames to be sent; session must track disposition
 
 	// frames destined for this session are added to this queue by conn.connReader
 	rxQ *queue.Holder[frames.FrameBody]
@@ -72,8 +72,8 @@ func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
 	s := &Session{
 		conn:           c,
 		channel:        channel,
-		tx:             make(chan frames.FrameBody),
-		txTransfer:     make(chan *frames.PerformTransfer),
+		tx:             make(chan frameBodyEnvelope),
+		txTransfer:     make(chan transferEnvelope),
 		incomingWindow: defaultWindow,
 		outgoingWindow: defaultWindow,
 		handleMax:      math.MaxUint32 - 1,
@@ -131,7 +131,9 @@ func (s *Session) begin(ctx context.Context) error {
 		HandleMax:      s.handleMax,
 	}
 
-	_ = s.txFrame(begin, nil)
+	if err := s.txFrameAndWait(ctx, begin); err != nil {
+		return err
+	}
 
 	// wait for response
 	fr, err := s.waitForFrame(ctx)
@@ -207,15 +209,31 @@ func (s *Session) Close(ctx context.Context) error {
 }
 
 // txFrame sends a frame to the connWriter.
-// it returns an error if the connection has been closed.
-func (s *Session) txFrame(p frames.FrameBody, done chan encoding.DeliveryState) error {
-	debug.Log(2, "TX (Session %p) mux frame to Conn (%p): %s", s, s.conn, p)
-	return s.conn.sendFrame(frames.Frame{
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+//   - sent is the optional channel that will contain the error if the write fails
+func (s *Session) txFrame(ctx context.Context, fr frames.FrameBody, sent chan error) {
+	debug.Log(2, "TX (Session %p) mux frame to Conn (%p): %s", s, s.conn, fr)
+	s.conn.sendFrame(ctx, frames.Frame{
 		Type:    frames.TypeAMQP,
 		Channel: s.channel,
-		Body:    p,
-		Done:    done,
-	})
+		Body:    fr,
+	}, sent)
+}
+
+// txFrameAndWait sends a frame to the connWriter and waits for the write to complete
+//   - ctx is used to provide the write deadline
+//   - fr is the frame to write to net.Conn
+func (s *Session) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error {
+	sent := make(chan error, 1)
+	s.txFrame(ctx, fr, sent)
+
+	select {
+	case err := <-sent:
+		return err
+	case <-s.conn.done:
+		return s.conn.doneErr
+	}
 }
 
 // NewReceiver opens a new receiver link on the session.
@@ -256,6 +274,8 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 	if err = l.attach(ctx); err != nil {
 		return nil, err
 	}
+
+	go l.mux(senderTestHooks{})
 
 	return l, nil
 }
@@ -304,7 +324,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 		closeInProgress = true
 		s.doneErr = e2
-		_ = s.txFrame(&frames.PerformEnd{Error: e1}, nil)
+		s.txFrame(context.Background(), &frames.PerformEnd{Error: e1}, nil)
 		close(s.endSent)
 	}
 
@@ -350,7 +370,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 			}
 			// session is being closed by the client
 			closeInProgress = true
-			_ = s.txFrame(&frames.PerformEnd{}, nil)
+			s.txFrame(context.Background(), &frames.PerformEnd{}, nil)
 			close(s.endSent)
 
 		// incoming frame
@@ -460,7 +480,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(resp, nil)
+					s.txFrame(context.Background(), resp, nil)
 				}
 
 			case *frames.PerformAttach:
@@ -525,7 +545,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						NextOutgoingID: nextOutgoingID,
 						OutgoingWindow: s.outgoingWindow,
 					}
-					_ = s.txFrame(flow, nil)
+					s.txFrame(context.Background(), flow, nil)
 				}
 
 			case *frames.PerformDetach:
@@ -563,7 +583,7 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}
 
 				fr := frames.PerformEnd{}
-				_ = s.txFrame(&fr, nil)
+				s.txFrame(context.Background(), &fr, nil)
 
 				// per spec, when end is received, we're no longer allowed to receive frames
 				return
@@ -576,7 +596,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				}, fmt.Errorf("internal error: unexpected frame %T", body))
 			}
 
-		case fr := <-txTransfer:
+		case env := <-txTransfer:
+			fr := &env.Frame
 			// record current delivery ID
 			var deliveryID uint32
 			if fr.DeliveryID == &needsDeliveryID {
@@ -603,14 +624,22 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				delete(handlesByDeliveryID, deliveryID)
 			}
 
-			// if not settled, add done chan to map
-			// and clear from frame so conn doesn't close it.
-			if !fr.Settled && fr.Done != nil {
-				settlementByDeliveryID[deliveryID] = fr.Done
-				fr.Done = nil
+			s.txFrame(env.Ctx, fr, env.Sent)
+			if sendErr := <-env.Sent; sendErr != nil {
+				s.doneErr = sendErr
+
+				// put the error back as our sender will read from this channel
+				env.Sent <- sendErr
+				return
 			}
 
-			_ = s.txFrame(fr, fr.Done)
+			// if not settled, add done chan to map
+			if !fr.Settled && fr.Done != nil {
+				settlementByDeliveryID[deliveryID] = fr.Done
+			} else if fr.Done != nil {
+				// sender-settled, close done now that the transfer has been sent
+				close(fr.Done)
+			}
 
 			// "Upon sending a transfer, the sending endpoint will increment
 			// its next-outgoing-id, decrement its remote-incoming-window,
@@ -621,9 +650,10 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				remoteIncomingWindow--
 			}
 
-		case fr := <-tx:
+		case env := <-tx:
+			fr := env.FrameBody
 			debug.Log(2, "TX (Session %p): %d, %s", s, s.channel, fr)
-			switch fr := fr.(type) {
+			switch fr := env.FrameBody.(type) {
 			case *frames.PerformDisposition:
 				if fr.Settled && fr.Role == encoding.RoleSender {
 					// sender with a peer that's in mode second; sending confirmation of disposition.
@@ -647,18 +677,18 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 						}
 					}
 				}
-				_ = s.txFrame(fr, nil)
+				s.txFrame(env.Ctx, fr, env.Sent)
 			case *frames.PerformFlow:
 				niID := nextIncomingID
 				fr.NextIncomingID = &niID
 				fr.IncomingWindow = s.incomingWindow
 				fr.NextOutgoingID = nextOutgoingID
 				fr.OutgoingWindow = s.outgoingWindow
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			case *frames.PerformTransfer:
 				panic("transfer frames must use txTransfer")
 			default:
-				_ = s.txFrame(fr, nil)
+				s.txFrame(context.Background(), fr, env.Sent)
 			}
 		}
 	}
@@ -703,7 +733,7 @@ func (s *Session) abandonLink(l *link) {
 	s.abandonedLinks = append(s.abandonedLinks, l)
 }
 
-func (s *Session) freeAbandonedLinks() error {
+func (s *Session) freeAbandonedLinks(ctx context.Context) error {
 	s.abandonedLinksMu.Lock()
 	defer s.abandonedLinksMu.Unlock()
 
@@ -714,7 +744,7 @@ func (s *Session) freeAbandonedLinks() error {
 			Handle: l.handle,
 			Closed: true,
 		}
-		if err := s.txFrame(dr, nil); err != nil {
+		if err := s.txFrameAndWait(ctx, dr); err != nil {
 			return err
 		}
 	}
@@ -728,6 +758,21 @@ func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 	q.Enqueue(fr)
 	l.rxQ.Release(q)
 	debug.Log(2, "RX (Session %p): mux frame to link (%p): %s, %s", s, l, l.key.name, fr)
+}
+
+// transferEnvelope is used by senders to send transfer frames
+type transferEnvelope struct {
+	Ctx   context.Context
+	Frame frames.PerformTransfer
+	Sent  chan error
+}
+
+// frameBodyEnvelope is used by senders and receivers to send frames.
+// these frames come from the mux which is why there's no Sent channel.
+type frameBodyEnvelope struct {
+	Ctx       context.Context
+	FrameBody frames.FrameBody
+	Sent      chan error
 }
 
 // the address of this var is a sentinel value indicating

--- a/session.go
+++ b/session.go
@@ -768,6 +768,7 @@ type transferEnvelope struct {
 	Frame frames.PerformTransfer
 
 	// Sent is *never* nil as we use this for confirmation of sending
+	// NOTE: use a buffered channel of size 1 when populating
 	Sent chan error
 }
 
@@ -779,6 +780,7 @@ type frameBodyEnvelope struct {
 	// Sent *can* be nil depending on what frame is being sent.
 	// e.g. sending a disposition frame frame a receiver's settlement
 	// APIs will have a non-nil channel vs sending a flow frame
+	// NOTE: use a buffered channel of size 1 when populating
 	Sent chan error
 }
 

--- a/session.go
+++ b/session.go
@@ -233,6 +233,8 @@ func (s *Session) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error
 		return err
 	case <-s.conn.done:
 		return s.conn.doneErr
+	case <-s.done:
+		return s.doneErr
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -764,15 +764,20 @@ func (s *Session) muxFrameToLink(l *link, fr frames.FrameBody) {
 type transferEnvelope struct {
 	Ctx   context.Context
 	Frame frames.PerformTransfer
-	Sent  chan error
+
+	// Sent is *never* nil as we use this for confirmation of sending
+	Sent chan error
 }
 
 // frameBodyEnvelope is used by senders and receivers to send frames.
-// these frames come from the mux which is why there's no Sent channel.
 type frameBodyEnvelope struct {
 	Ctx       context.Context
 	FrameBody frames.FrameBody
-	Sent      chan error
+
+	// Sent *can* be nil depending on what frame is being sent.
+	// e.g. sending a disposition frame frame a receiver's settlement
+	// APIs will have a non-nil channel vs sending a flow frame
+	Sent chan error
 }
 
 // the address of this var is a sentinel value indicating


### PR DESCRIPTION
Added Conn.WriteDeadline to control the write deadline when writing to net.Conn.  The default value is 30 seconds.  This can be overridden by APIs that take a context and the context has a deadline/timeout. For APIs that directly send frames, wait for the frame to be written to the underlying net.Conn before considering the write a success.

Fixes https://github.com/Azure/go-amqp/issues/280