### PR TITLE
Don't leak message settlement on context cancel/timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Context cancellation is properly honored in calls to `Dial()` and `NewConn()`.
 * Fixed potential race during `Conn.Close()`.
 * Disable sending frames when closing `Session`, `Sender`, and `Receiver`.
+* Don't leak in-flight messages when a message settlement API is cancelled or times out waiting for acknowledgement.
 
 ### Other Changes
 

--- a/receiver.go
+++ b/receiver.go
@@ -272,7 +272,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 	var wait chan error
 	if r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond {
 		debug.Log(3, "TX (Receiver %p): delivery ID %d is in flight", r, msg.deliveryID)
-		wait = r.inFlight.add(msg.deliveryID)
+		wait = r.inFlight.add(msg)
 	}
 
 	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
@@ -297,9 +297,6 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		if amqpErr := (&Error{}); err == nil || errors.As(err, &amqpErr) {
 			debug.Log(3, "RX (Receiver %p): delivery ID %d has been settled", r, msg.deliveryID)
 			// we've received confirmation of disposition
-			r.deleteUnsettled(msg)
-			r.onSettlement(1)
-			msg.settled = true
 			return err
 		}
 
@@ -694,7 +691,11 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 			}
 		}
 		// removal from the in-flight map will also remove the message from the unsettled map
-		r.inFlight.remove(fr.First, fr.Last, dispositionError)
+		count := r.inFlight.remove(fr.First, fr.Last, dispositionError, func(msg *Message) {
+			r.deleteUnsettled(msg)
+			msg.settled = true
+		})
+		r.onSettlement(count)
 
 	default:
 		return r.l.muxHandleFrame(fr)
@@ -821,29 +822,34 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 // settlement mode is configured.
 type inFlight struct {
 	mu sync.RWMutex
-	m  map[uint32]chan error
+	m  map[uint32]inFlightInfo
 }
 
-func (f *inFlight) add(id uint32) chan error {
+type inFlightInfo struct {
+	wait chan error
+	msg  *Message
+}
+
+func (f *inFlight) add(msg *Message) chan error {
 	wait := make(chan error, 1)
 
 	f.mu.Lock()
 	if f.m == nil {
-		f.m = map[uint32]chan error{id: wait}
-	} else {
-		f.m[id] = wait
+		f.m = make(map[uint32]inFlightInfo)
 	}
+
+	f.m[msg.deliveryID] = inFlightInfo{wait: wait, msg: msg}
 	f.mu.Unlock()
 
 	return wait
 }
 
-func (f *inFlight) remove(first uint32, last *uint32, err error) {
+func (f *inFlight) remove(first uint32, last *uint32, err error, handler func(*Message)) uint32 {
 	f.mu.Lock()
 
 	if f.m == nil {
 		f.mu.Unlock()
-		return
+		return 0
 	}
 
 	ll := first
@@ -851,21 +857,25 @@ func (f *inFlight) remove(first uint32, last *uint32, err error) {
 		ll = *last
 	}
 
+	count := uint32(0)
 	for i := first; i <= ll; i++ {
-		wait, ok := f.m[i]
+		info, ok := f.m[i]
 		if ok {
-			wait <- err
+			handler(info.msg)
+			info.wait <- err
 			delete(f.m, i)
+			count++
 		}
 	}
 
 	f.mu.Unlock()
+	return count
 }
 
 func (f *inFlight) clear(err error) {
 	f.mu.Lock()
-	for id, wait := range f.m {
-		wait <- err
+	for id, info := range f.m {
+		info.wait <- err
 		delete(f.m, id)
 	}
 	f.mu.Unlock()

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1440,7 +1440,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptSlow(t *testing.T) {
 	if c := r.l.linkCredit; c != 0 {
 		t.Fatalf("unexpected link credit %d", c)
 	}
-	muxSem.Release(1)
+	muxSem.Release(2)
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = r.AcceptMessage(ctx, msg)
 	cancel()

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1387,4 +1387,76 @@ func TestReceiverConnWriterError(t *testing.T) {
 	require.Error(t, conn.Close())
 }
 
+func TestReceiveSuccessReceiverSettleModeSecondAcceptSlow(t *testing.T) {
+	muxSem := test.NewMuxSemaphore(2)
+
+	const linkHandle = 0
+	deliveryID := uint32(1)
+	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+		b, err := receiverFrameHandler(0, ReceiverSettleModeSecond)(remoteChannel, req)
+		if b != nil || err != nil {
+			return b, err
+		}
+		switch ff := req.(type) {
+		case *frames.PerformFlow:
+			if *ff.NextIncomingID == deliveryID {
+				// this is the first flow frame, send our payload
+				return fake.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+			}
+			// ignore future flow frames as we have no response
+			return nil, nil
+		case *frames.PerformDisposition:
+			// delay so that waiting for the ack times out
+			time.Sleep(1 * time.Second)
+			return fake.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateAccepted{})
+		default:
+			return nil, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	conn := fake.NewNetConn(responder)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, conn, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeSecond.Ptr(),
+	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
+	cancel()
+	require.NoError(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	msg, err := r.Receive(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+	if c := r.countUnsettled(); c != 1 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	muxSem.Wait()
+	// link credit must be zero since we only started with 1
+	if c := r.l.linkCredit; c != 0 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	muxSem.Release(1)
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = r.AcceptMessage(ctx, msg)
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	muxSem.Wait()
+	// even though we timed out waiting for the ack, the message should still be settled
+	if c := r.countUnsettled(); c != 0 {
+		t.Fatalf("unexpected unsettled count %d", c)
+	}
+	require.True(t, msg.settled)
+	// link credit should be back to 1
+	if c := r.l.linkCredit; c != 1 {
+		t.Fatalf("unexpected link credit %d", c)
+	}
+	muxSem.Release(-1)
+	require.NoError(t, client.Close())
+}
+
 // TODO: add unit tests for manual credit management


### PR DESCRIPTION
For receivers in mode second, handle clean-up of in-flight messages from the mux instead of the disposition call.  This ensures that the link credit is reclaimed if the disposition API is cancelled or times out waiting for the disposition acknowledgement.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
