### PR TITLE
Return a programatically distinguishable error when the message is too big to send

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -98,7 +98,10 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 		maxTransferFrameHeader = 66 // determined by calcMaxTransferFrameHeader
 	)
 	if len(msg.DeliveryTag) > maxDeliveryTagLength {
-		return nil, fmt.Errorf("delivery tag is over the allowed %v bytes, len: %v", maxDeliveryTagLength, len(msg.DeliveryTag))
+		return nil, &Error{
+			Condition:   ErrCondMessageSizeExceeded,
+			Description: fmt.Sprintf("delivery tag is over the allowed %v bytes, len: %v", maxDeliveryTagLength, len(msg.DeliveryTag)),
+		}
 	}
 
 	s.mu.Lock()
@@ -111,7 +114,10 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (cha
 	}
 
 	if s.l.maxMessageSize != 0 && uint64(s.buf.Len()) > s.l.maxMessageSize {
-		return nil, fmt.Errorf("encoded message size exceeds max of %d", s.l.maxMessageSize)
+		return nil, &Error{
+			Condition:   ErrCondMessageSizeExceeded,
+			Description: fmt.Sprintf("encoded message size exceeds max of %d", s.l.maxMessageSize),
+		}
 	}
 
 	senderSettled := senderSettleModeValue(s.l.senderSettleMode) == SenderSettleModeSettled


### PR DESCRIPTION
I've got a bug in SB where we treat this as a retryable error but that's mostly because it isn't programatically inspectable.