### PR TITLE
Fixed write delay implementation for fake.NetConn

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -13,20 +13,20 @@ import (
 )
 
 func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
-	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch tt := req.(type) {
 		case *frames.PerformFlow:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformDisposition:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformTransfer:
-			return fake.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{})
+			return newResponse(fake.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{}))
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	conn := fake.NewNetConn(responder)
@@ -58,20 +58,20 @@ func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
 }
 
 func BenchmarkSenderSendSSMSettled(b *testing.B) {
-	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := senderFrameHandler(0, SenderSettleModeSettled)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(0, SenderSettleModeSettled)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch req.(type) {
 		case *frames.PerformFlow:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformDisposition:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformTransfer:
-			return nil, nil
+			return fake.Response{}, nil
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	conn := fake.NewNetConn(responder)
@@ -103,18 +103,18 @@ func BenchmarkSenderSendSSMSettled(b *testing.B) {
 }
 
 func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
-	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch req.(type) {
 		case *frames.PerformFlow:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformDisposition:
-			return nil, nil
+			return fake.Response{}, nil
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	conn := fake.NewNetConn(responder)
@@ -154,18 +154,18 @@ func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
 }
 
 func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
-	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(0, ReceiverSettleModeSecond)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := receiverFrameHandler(0, ReceiverSettleModeSecond)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch req.(type) {
 		case *frames.PerformFlow:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformDisposition:
-			return nil, nil
+			return fake.Response{}, nil
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	conn := fake.NewNetConn(responder)
@@ -205,18 +205,18 @@ func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
 }
 
 func BenchmarkReceiverSettleMessage(b *testing.B) {
-	responder := func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := receiverFrameHandler(0, ReceiverSettleModeFirst)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch req.(type) {
 		case *frames.PerformFlow:
-			return nil, nil
+			return fake.Response{}, nil
 		case *frames.PerformDisposition:
-			return nil, nil
+			return fake.Response{}, nil
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 	conn := fake.NewNetConn(responder)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newResponse(b []byte, err error) (fake.Response, error) {
+	if err != nil {
+		return fake.Response{}, err
+	}
+	return fake.Response{Payload: b}, nil
+}
+
 func sendInitialFlowFrame(t require.TestingT, channel uint16, netConn *fake.NetConn, handle uint32, credit uint32) {
 	nextIncoming := uint32(0)
 	count := uint32(0)
@@ -29,79 +36,79 @@ func sendInitialFlowFrame(t require.TestingT, channel uint16, netConn *fake.NetC
 }
 
 // standard frame handler for connecting/disconnecting etc.
-// returns nil, nil for unhandled frames.
-func senderFrameHandler(channel uint16, ssm encoding.SenderSettleMode) func(uint16, frames.FrameBody) ([]byte, error) {
-	return func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+// returns zero-value, nil for unhandled frames.
+func senderFrameHandler(channel uint16, ssm encoding.SenderSettleMode) func(uint16, frames.FrameBody) (fake.Response, error) {
+	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
 		switch tt := req.(type) {
 		case *fake.AMQPProto:
-			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+			return newResponse(fake.ProtoHeader(fake.ProtoAMQP))
 		case *frames.PerformOpen:
-			return fake.PerformOpen("container")
+			return newResponse(fake.PerformOpen("container"))
 		case *frames.PerformClose:
-			return fake.PerformClose(nil)
+			return newResponse(fake.PerformClose(nil))
 		case *frames.PerformBegin:
-			return fake.PerformBegin(channel, remoteChannel)
+			return newResponse(fake.PerformBegin(channel, remoteChannel))
 		case *frames.PerformEnd:
-			return fake.PerformEnd(channel, nil)
+			return newResponse(fake.PerformEnd(channel, nil))
 		case *frames.PerformAttach:
-			return fake.SenderAttach(channel, tt.Name, 0, ssm)
+			return newResponse(fake.SenderAttach(channel, tt.Name, 0, ssm))
 		case *frames.PerformDetach:
-			return fake.PerformDetach(channel, 0, nil)
+			return newResponse(fake.PerformDetach(channel, 0, nil))
 		default:
-			return nil, nil
+			return fake.Response{}, nil
 		}
 	}
 }
 
 // similar to senderFrameHandler but returns an error on unhandled frames
-func senderFrameHandlerNoUnhandled(channel uint16, ssm encoding.SenderSettleMode) func(uint16, frames.FrameBody) ([]byte, error) {
-	return func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := senderFrameHandler(channel, ssm)(remoteChannel, req)
-		if b == nil && err == nil {
-			return nil, fmt.Errorf("unhandled frame %T", req)
+func senderFrameHandlerNoUnhandled(channel uint16, ssm encoding.SenderSettleMode) func(uint16, frames.FrameBody) (fake.Response, error) {
+	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(channel, ssm)(remoteChannel, req)
+		if resp.Payload == nil && err == nil {
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
-		return b, err
+		return resp, err
 	}
 }
 
 // standard frame handler for connecting/disconnecting etc.
-// returns nil, nil for unhandled frames.
-func receiverFrameHandler(channel uint16, rsm encoding.ReceiverSettleMode) func(uint16, frames.FrameBody) ([]byte, error) {
-	return func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
+// returns zero-value, nil for unhandled frames.
+func receiverFrameHandler(channel uint16, rsm encoding.ReceiverSettleMode) func(uint16, frames.FrameBody) (fake.Response, error) {
+	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
 		switch tt := req.(type) {
 		case *fake.AMQPProto:
-			return []byte{'A', 'M', 'Q', 'P', 0, 1, 0, 0}, nil
+			return newResponse(fake.ProtoHeader(fake.ProtoAMQP))
 		case *frames.PerformOpen:
-			return fake.PerformOpen("container")
+			return newResponse(fake.PerformOpen("container"))
 		case *frames.PerformClose:
-			return fake.PerformClose(nil)
+			return newResponse(fake.PerformClose(nil))
 		case *frames.PerformBegin:
-			return fake.PerformBegin(channel, remoteChannel)
+			return newResponse(fake.PerformBegin(channel, remoteChannel))
 		case *frames.PerformEnd:
-			return fake.PerformEnd(channel, nil)
+			return newResponse(fake.PerformEnd(channel, nil))
 		case *frames.PerformAttach:
-			return fake.ReceiverAttach(channel, tt.Name, 0, rsm, tt.Source.Filter)
+			return newResponse(fake.ReceiverAttach(channel, tt.Name, 0, rsm, tt.Source.Filter))
 		case *frames.PerformDetach:
-			return fake.PerformDetach(channel, 0, nil)
+			return newResponse(fake.PerformDetach(channel, 0, nil))
 		default:
-			return nil, nil
+			return fake.Response{}, nil
 		}
 	}
 }
 
 // similar to receiverFrameHandler but returns an error on unhandled frames
 // NOTE: consumes flow frames
-func receiverFrameHandlerNoUnhandled(channel uint16, rsm encoding.ReceiverSettleMode) func(uint16, frames.FrameBody) ([]byte, error) {
-	return func(remoteChannel uint16, req frames.FrameBody) ([]byte, error) {
-		b, err := receiverFrameHandler(channel, rsm)(remoteChannel, req)
-		if b != nil || err != nil {
-			return b, err
+func receiverFrameHandlerNoUnhandled(channel uint16, rsm encoding.ReceiverSettleMode) func(uint16, frames.FrameBody) (fake.Response, error) {
+	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := receiverFrameHandler(channel, rsm)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
 		}
 		switch req.(type) {
 		case *frames.PerformFlow, *fake.KeepAlive:
-			return nil, nil
+			return fake.Response{}, nil
 		default:
-			return nil, fmt.Errorf("unhandled frame %T", req)
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
 }


### PR DESCRIPTION
NetConn.Write will now send its payload to Conn on a separate goroutine, allowing proper simulation of a delayed response.
A fake responder now returns a fake.Response that contains the payload and any write delay.
Added newResponse() helper for returning frames without delay.

Fixes https://github.com/Azure/go-amqp/issues/290