### PR TITLE
Fix non-determinism in fake NetConn.Write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.2 (Unreleased)
+
+### Bugs Fixed
+
+* Fixed an issue that could cause frames to be sent even when the provided `context.Context` was cancelled.
+
 ## 1.0.1 (2023-06-08)
 
 ### Bugs Fixed

--- a/conn.go
+++ b/conn.go
@@ -551,7 +551,7 @@ func (c *Conn) connReader() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "RX (connReader %p): terminal error: %v", c, err)
+			debug.Log(0, "RX (connReader %p): terminal error: %v", c, err)
 			c.rxErr = err
 			return
 		}
@@ -562,7 +562,7 @@ func (c *Conn) connReader() {
 			continue
 		}
 
-		debug.Log(1, "RX (connReader %p): %s", c, fr)
+		debug.Log(0, "RX (connReader %p): %s", c, fr)
 
 		var (
 			session *Session
@@ -745,7 +745,7 @@ func (c *Conn) connWriter() {
 	var err error
 	for {
 		if err != nil {
-			debug.Log(1, "TX (connWriter %p): terminal error: %v", c, err)
+			debug.Log(0, "TX (connWriter %p): terminal error: %v", c, err)
 			c.txErr = err
 			return
 		}
@@ -762,7 +762,7 @@ func (c *Conn) connWriter() {
 				continue
 			}
 
-			debug.Log(1, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+			debug.Log(0, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
 			err = c.writeFrame(timeout, env.Frame)
 			if env.Sent != nil {
 				if err == nil {

--- a/conn.go
+++ b/conn.go
@@ -755,7 +755,7 @@ func (c *Conn) connWriter() {
 		case env := <-c.txFrame:
 			timeout, ctxErr := c.getWriteTimeout(env.Ctx)
 			if ctxErr != nil {
-				debug.Log(1, "TX (connWriter %p) context cancelled or deadline exceeded: %s", c, env.Frame)
+				debug.Log(1, "TX (connWriter %p) getWriteTimeout: %s: %s", c, ctxErr.Error(), env.Frame)
 				if env.Sent != nil {
 					env.Sent <- ctxErr
 				}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1015,7 +1015,7 @@ func TestGetWriteTimeout(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	duration, err = conn.getWriteTimeout(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, timeout, duration)
+	require.InDelta(t, timeout, duration, float64(time.Millisecond))
 	// sleep until after the timeout expires
 	time.Sleep(2 * timeout)
 	duration, err = conn.getWriteTimeout(ctx)

--- a/conn_test.go
+++ b/conn_test.go
@@ -944,15 +944,8 @@ func TestNewSessionTimedOut(t *testing.T) {
 	require.Nil(t, session)
 
 	// should have one session to clean up
-	// TODO: sync with mux after abandoned session has been created
-	time.Sleep(100 * time.Millisecond)
 	require.Len(t, client.abandonedSessions, 1)
 	require.Len(t, client.sessionsByChannel, 1)
-
-	// we sleep here to wait for the begin performative to
-	// arrive, thus creating the now abandoned session.
-	// TODO: add test hooks to session mux to eliminate the sleep
-	time.Sleep(100 * time.Millisecond)
 
 	// creating a new session cleans up the old one
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
@@ -960,9 +953,6 @@ func TestNewSessionTimedOut(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, session)
-
-	// TODO: sync with mux after abandoned session has been cleaned up
-	time.Sleep(100 * time.Millisecond)
 	require.Empty(t, client.abandonedSessions)
 	require.Len(t, client.sessionsByChannel, 1)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,7 +1,6 @@
 package amqp
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Azure/go-amqp/internal/encoding"
@@ -111,34 +110,4 @@ func receiverFrameHandlerNoUnhandled(channel uint16, rsm encoding.ReceiverSettle
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-}
-
-// this is the same API as Session.NewReceiver() but with support for adding test hooks
-func newReceiverWithHooks(ctx context.Context, s *Session, source string, opts *ReceiverOptions, hooks receiverTestHooks) (*Receiver, error) {
-	r, err := newReceiver(source, s, opts)
-	if err != nil {
-		return nil, err
-	}
-	if err = r.attach(ctx); err != nil {
-		return nil, err
-	}
-
-	go r.mux(hooks)
-
-	return r, nil
-}
-
-// this is the same API as Session.NewSender() but with support for adding test hooks
-func newSenderWithHooks(ctx context.Context, s *Session, target string, opts *SenderOptions, hooks senderTestHooks) (*Sender, error) {
-	r, err := newSender(target, s, opts)
-	if err != nil {
-		return nil, err
-	}
-	if err = r.attach(ctx); err != nil {
-		return nil, err
-	}
-
-	go r.mux(hooks)
-
-	return r, nil
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -845,7 +845,10 @@ func TestNewSessionWithCancelledContext(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	for times := 0; times < 100; times++ {
+	// we use an iteration greater than the max number of sessions to ensure
+	// that no begin performatives are being sent. if they are then the peer
+	// will reject the session with a different error.
+	for times := 0; times < 10000; times++ {
 		ctx, cancel = context.WithCancel(context.Background())
 		cancel()
 		session, err := client.NewSession(ctx, nil)

--- a/receiver.go
+++ b/receiver.go
@@ -475,7 +475,7 @@ func (r *Receiver) attach(ctx context.Context) error {
 	return nil
 }
 
-func nop() {}
+func nopHook() {}
 
 type receiverTestHooks struct {
 	MuxStart  func()
@@ -484,10 +484,10 @@ type receiverTestHooks struct {
 
 func (r *Receiver) mux(hooks receiverTestHooks) {
 	if hooks.MuxSelect == nil {
-		hooks.MuxSelect = nop
+		hooks.MuxSelect = nopHook
 	}
 	if hooks.MuxStart == nil {
-		hooks.MuxStart = nop
+		hooks.MuxStart = nopHook
 	}
 
 	defer func() {

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -474,7 +474,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeFirst.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -550,7 +550,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -627,7 +627,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptOnClosedLink(t *testing.T) 
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -692,7 +692,7 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -763,7 +763,7 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -839,7 +839,7 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -945,7 +945,7 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -1254,7 +1254,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()
@@ -1427,7 +1427,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptSlow(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	r, err := newReceiverWithHooks(ctx, session, "source", &ReceiverOptions{
+	r, err := newReceiverForSession(ctx, session, "source", &ReceiverOptions{
 		SettlementMode: ReceiverSettleModeSecond.Ptr(),
 	}, receiverTestHooks{MuxSelect: muxSem.OnLoop})
 	cancel()

--- a/sender.go
+++ b/sender.go
@@ -317,7 +317,7 @@ type senderTestHooks struct {
 
 func (s *Sender) mux(hooks senderTestHooks) {
 	if hooks.MuxTransfer == nil {
-		hooks.MuxTransfer = nop
+		hooks.MuxTransfer = nopHook
 	}
 
 	defer func() {

--- a/sender_test.go
+++ b/sender_test.go
@@ -168,7 +168,7 @@ func TestSenderSendConcurrentSessionClosed(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	snd, err := newSenderWithHooks(ctx, session, "target", nil, senderTestHooks{MuxTransfer: muxSem.OnLoop})
+	snd, err := newSenderForSession(ctx, session, "target", nil, senderTestHooks{MuxTransfer: muxSem.OnLoop})
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, snd)
@@ -1123,15 +1123,8 @@ func TestNewSenderTimedOut(t *testing.T) {
 	require.Nil(t, snd)
 
 	// should have one sender to clean up
-	// TODO: sync with mux after abandoned link has been created
-	time.Sleep(100 * time.Millisecond)
 	require.Len(t, session.abandonedLinks, 1)
 	require.Len(t, session.linksByKey, 1)
-
-	// we sleep here to wait for the attach performative to
-	// arrive, thus creating the now abandoned link.
-	// TODO: add test hook to eliminate the sleep
-	time.Sleep(100 * time.Millisecond)
 
 	// creating a new sender cleans up the old one
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
@@ -1139,9 +1132,6 @@ func TestNewSenderTimedOut(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	require.NotNil(t, snd)
-
-	// TODO: sync with mux after abandoned link has been cleaned up
-	time.Sleep(100 * time.Millisecond)
 	require.Empty(t, session.abandonedLinks)
 	require.Len(t, session.linksByKey, 1)
 }

--- a/session.go
+++ b/session.go
@@ -247,6 +247,11 @@ func (s *Session) txFrameAndWait(ctx context.Context, fr frames.FrameBody) error
 // completes, an error is returned. If the Receiver was successfully
 // created, it will be cleaned up in future calls to NewReceiver.
 func (s *Session) NewReceiver(ctx context.Context, source string, opts *ReceiverOptions) (*Receiver, error) {
+	return newReceiverForSession(ctx, s, source, opts, receiverTestHooks{})
+}
+
+// split out so tests can add hooks
+func newReceiverForSession(ctx context.Context, s *Session, source string, opts *ReceiverOptions, hooks receiverTestHooks) (*Receiver, error) {
 	r, err := newReceiver(source, s, opts)
 	if err != nil {
 		return nil, err
@@ -255,7 +260,7 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 		return nil, err
 	}
 
-	go r.mux(receiverTestHooks{})
+	go r.mux(hooks)
 
 	return r, nil
 }
@@ -269,6 +274,11 @@ func (s *Session) NewReceiver(ctx context.Context, source string, opts *Receiver
 // completes, an error is returned. If the Sender was successfully
 // created, it will be cleaned up in future calls to NewSender.
 func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOptions) (*Sender, error) {
+	return newSenderForSession(ctx, s, target, opts, senderTestHooks{})
+}
+
+// split out so tests can add hooks
+func newSenderForSession(ctx context.Context, s *Session, target string, opts *SenderOptions, hooks senderTestHooks) (*Sender, error) {
 	l, err := newSender(target, s, opts)
 	if err != nil {
 		return nil, err
@@ -277,7 +287,7 @@ func (s *Session) NewSender(ctx context.Context, target string, opts *SenderOpti
 		return nil, err
 	}
 
-	go l.mux(senderTestHooks{})
+	go l.mux(hooks)
 
 	return l, nil
 }


### PR DESCRIPTION
Serialize the responses to write so that they show up in their specified order. This was responsible for some spurious test failures. Consolidate creation of senders and receivers with test hooks. Make sending and receiving of frames log level 0 to get the minimum amount of logging that can be useful.

Fixes https://github.com/Azure/go-amqp/issues/300