### PR TITLE
Add unit test to verify conn is closed when start fails

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -111,6 +111,7 @@ func Dial(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error) {
 }
 
 // NewConn establishes a new AMQP client connection over conn.
+// NOTE: [Conn] takes ownership of the provided [net.Conn] and will close it as required.
 // opts: pass nil to accept the default values.
 func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, error) {
 	c, err := newConn(conn, opts)

--- a/conn_test.go
+++ b/conn_test.go
@@ -283,8 +283,11 @@ func TestStart(t *testing.T) {
 				// verify that the conn was closed
 				err := netConn.Close()
 				require.ErrorIs(t, err, fake.ErrAlreadyClosed)
-			} else if !tt.fails && err != nil {
-				t.Error(err)
+			} else if !tt.fails {
+				require.NoError(t, err)
+				// verify that the conn wasn't closed
+				err := netConn.Close()
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -278,8 +278,11 @@ func TestStart(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			err = conn.start(ctx)
 			cancel()
-			if tt.fails && err == nil {
-				t.Error("unexpected nil error")
+			if tt.fails {
+				require.Error(t, err)
+				// verify that the conn was closed
+				err := netConn.Close()
+				require.ErrorIs(t, err, fake.ErrAlreadyClosed)
 			} else if !tt.fails && err != nil {
 				t.Error(err)
 			}

--- a/conn_test.go
+++ b/conn_test.go
@@ -283,7 +283,7 @@ func TestStart(t *testing.T) {
 				// verify that the conn was closed
 				err := netConn.Close()
 				require.ErrorIs(t, err, fake.ErrAlreadyClosed)
-			} else if !tt.fails {
+			} else {
 				require.NoError(t, err)
 				// verify that the conn wasn't closed
 				err := netConn.Close()

--- a/internal/fake/net_conn.go
+++ b/internal/fake/net_conn.go
@@ -98,6 +98,9 @@ type Response struct {
 	WriteDelay time.Duration
 }
 
+// ErrAlreadyClosed is returned by Close() if [NetConn] is already closed.
+var ErrAlreadyClosed = errors.New("fake already closed")
+
 ///////////////////////////////////////////////////////
 // following methods are for the net.Conn interface
 ///////////////////////////////////////////////////////
@@ -188,7 +191,7 @@ func (n *NetConn) write() {
 // Close is called by conn.close.
 func (n *NetConn) Close() error {
 	if n.closed {
-		return errors.New("double close")
+		return ErrAlreadyClosed
 	}
 	n.closed = true
 	close(n.close)


### PR DESCRIPTION
Related to https://github.com/Azure/go-amqp/issues/170 which was fixed in https://github.com/Azure/go-amqp/pull/273