### PR TITLE
Allow cross receiver message settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.3 (2024-01-09)
+
+### Bugs Fixed
+
+* Fixed an issue that could cause a memory leak when settling messages across `Receiver` instances.
+
 ## 1.0.2 (2023-09-05)
 
 ### Bugs Fixed

--- a/message.go
+++ b/message.go
@@ -300,6 +300,11 @@ func (m *Message) Unmarshal(r *buffer.Buffer) error {
 	return nil
 }
 
+func (m *Message) onSettlement() {
+	m.settled = true
+	m.rcv = nil
+}
+
 /*
 <type name="header" class="composite" source="list" provides="section">
     <descriptor name="amqp:header:list" code="0x00000000:0x00000070"/>

--- a/message.go
+++ b/message.go
@@ -101,8 +101,9 @@ type Message struct {
 	// encryption details).
 	Footer Annotations
 
-	deliveryID uint32 // used when sending disposition
-	settled    bool   // whether transfer was settled by sender
+	deliveryID uint32    // used when sending disposition
+	settled    bool      // whether transfer was settled by sender
+	rcv        *Receiver // used to settle message on the corresponding Receiver (nil if settled == true)
 }
 
 // NewMessage returns a *Message with data as the first payload in the Data field.

--- a/receiver.go
+++ b/receiver.go
@@ -144,7 +144,7 @@ func (r *Receiver) Receive(ctx context.Context, opts *ReceiveOptions) (*Message,
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message's disposition is in an unknown state.
 func (r *Receiver) AcceptMessage(ctx context.Context, msg *Message) error {
-	return r.messageDisposition(ctx, msg, &encoding.StateAccepted{})
+	return msg.rcv.messageDisposition(ctx, msg, &encoding.StateAccepted{})
 }
 
 // Reject notifies the server that the message is invalid.
@@ -155,7 +155,7 @@ func (r *Receiver) AcceptMessage(ctx context.Context, msg *Message) error {
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message's disposition is in an unknown state.
 func (r *Receiver) RejectMessage(ctx context.Context, msg *Message, e *Error) error {
-	return r.messageDisposition(ctx, msg, &encoding.StateRejected{Error: e})
+	return msg.rcv.messageDisposition(ctx, msg, &encoding.StateRejected{Error: e})
 }
 
 // Release releases the message back to the server. The message may be redelivered to this or another consumer.
@@ -165,7 +165,7 @@ func (r *Receiver) RejectMessage(ctx context.Context, msg *Message, e *Error) er
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message's disposition is in an unknown state.
 func (r *Receiver) ReleaseMessage(ctx context.Context, msg *Message) error {
-	return r.messageDisposition(ctx, msg, &encoding.StateReleased{})
+	return msg.rcv.messageDisposition(ctx, msg, &encoding.StateReleased{})
 }
 
 // Modify notifies the server that the message was not acted upon and should be modifed.
@@ -179,7 +179,7 @@ func (r *Receiver) ModifyMessage(ctx context.Context, msg *Message, options *Mod
 	if options == nil {
 		options = &ModifyMessageOptions{}
 	}
-	return r.messageDisposition(ctx,
+	return msg.rcv.messageDisposition(ctx,
 		msg, &encoding.StateModified{
 			DeliveryFailed:     options.DeliveryFailed,
 			UndeliverableHere:  options.UndeliverableHere,
@@ -809,6 +809,7 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 	// send to receiver
 	if !r.msg.settled {
 		r.addUnsettled(&r.msg)
+		r.msg.rcv = r
 		debug.Log(3, "RX (Receiver %p): add unsettled delivery ID %d", r, r.msg.deliveryID)
 	}
 

--- a/receiver.go
+++ b/receiver.go
@@ -290,6 +290,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	if wait == nil {
 		// mode first, there will be no settlement ack
+		msg.onSettlement()
 		r.deleteUnsettled(msg)
 		r.onSettlement(1)
 		return nil
@@ -703,7 +704,7 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		// removal from the in-flight map will also remove the message from the unsettled map
 		count := r.inFlight.remove(fr.First, fr.Last, dispositionError, func(msg *Message) {
 			r.deleteUnsettled(msg)
-			msg.settled = true
+			msg.onSettlement()
 		})
 		r.onSettlement(count)
 


### PR DESCRIPTION
It's not prevented at present, but can cause a memory leak due to entries never being removed from the unsettledMessages map. When a received message isn't settled, associate its receiver with the message. The settlement APIs will direct to the associated receiver.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
