### PR TITLE
Track receiver's unsettled messages as a count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.4 (2024-01-16)
+
+### Other Changes
+
+* A `Receiver`'s unsettled messages are tracked as a count (currently used for diagnostic purposes only).
+
 ## 1.0.3 (2024-01-09)
 
 ### Bugs Fixed

--- a/link_test.go
+++ b/link_test.go
@@ -33,7 +33,6 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 
 		// we've consumed half of the maximum credit we're allowed to have - reflow!
 		l.l.linkCredit = 1
-		l.unsettledMessages = map[string]struct{}{}
 		close(waitForCredit)
 
 		l.onSettlement(1)
@@ -88,10 +87,7 @@ func TestLinkFlowWithZeroCredits(t *testing.T) {
 	require.EqualValues(t, 0, l.l.linkCredit, "No link credits have been added")
 
 	l.l.linkCredit = 0
-	l.unsettledMessages = map[string]struct{}{
-		"hello":  {},
-		"hello2": {},
-	}
+	l.unsettledMessages = 2
 
 	muxSem.Release(0)
 


### PR DESCRIPTION
The unsettled map is currently used as a count for diagnostic purposes only, so it's safe to convert it to a count.

Fixes https://github.com/Azure/go-amqp/issues/317