### PR TITLE
Fixing a bug where we were bottlenecking on frames that had bodies smaller than 8 bytes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -663,13 +663,13 @@ func (c *Conn) readFrame() (frames.Frame, error) {
 			}
 		}
 
-		// read more if buf doesn't contain enough to parse the header
-		if c.rxBuf.Len() < frames.HeaderSize {
-			continue
-		}
-
 		// parse the header if a frame isn't in progress
 		if !frameInProgress {
+			// read more if buf doesn't contain enough to parse the header
+			if c.rxBuf.Len() < frames.HeaderSize {
+				continue
+			}
+
 			var err error
 			currentHeader, err = frames.ParseHeader(&c.rxBuf)
 			if err != nil {


### PR DESCRIPTION
The frame parsing code parses in two stages - headers, which tells you the body length, and the body itself. If the body was < 8 bytes (the standard frame header size) we'd end up skipping the body parse until we accumulated at least 8 bytes worth of material.

The fix is simple - move the "frame header size" check into the frame header portion of the parsing code.