### PR TITLE
Fake can split up response frames into chunks

### DIFF
--- a/internal/fake/net_conn.go
+++ b/internal/fake/net_conn.go
@@ -96,6 +96,10 @@ type Response struct {
 	// WriteDelay is the duration to wait before writing Payload.
 	// Use this to introduce a delay when waiting for a response.
 	WriteDelay time.Duration
+
+	// ChunkSize is the size of chunks to split Payload into.
+	// The zero value means no chunks.
+	ChunkSize int
 }
 
 // ErrAlreadyClosed is returned by Close() if [NetConn] is already closed.
@@ -183,7 +187,22 @@ func (n *NetConn) write() {
 			// else all we do is stall Conn.connWriter() which doesn't
 			// actually simulate a delayed response to a frame.
 			time.Sleep(resp.WriteDelay)
-			n.readData <- resp.Payload
+			if resp.ChunkSize > 0 {
+				remaining := resp.Payload
+				for {
+					if l := len(remaining); l <= resp.ChunkSize {
+						resp.ChunkSize = l
+					}
+					chunk := remaining[:resp.ChunkSize]
+					n.readData <- chunk
+					remaining = remaining[resp.ChunkSize:]
+					if len(remaining) == 0 {
+						break
+					}
+				}
+			} else {
+				n.readData <- resp.Payload
+			}
 		}
 	}
 }

--- a/internal/fake/net_conn.go
+++ b/internal/fake/net_conn.go
@@ -98,7 +98,7 @@ type Response struct {
 	WriteDelay time.Duration
 
 	// ChunkSize is the size of chunks to split Payload into.
-	// The zero value means no chunks.
+	// A zero or negative value means no chunking.
 	ChunkSize int
 }
 
@@ -187,11 +187,12 @@ func (n *NetConn) write() {
 			// else all we do is stall Conn.connWriter() which doesn't
 			// actually simulate a delayed response to a frame.
 			time.Sleep(resp.WriteDelay)
-			remaining := resp.Payload
-			if resp.ChunkSize == 0 {
+			if resp.ChunkSize < 1 {
 				// send in one chunk
 				resp.ChunkSize = len(resp.Payload)
 			}
+
+			remaining := resp.Payload
 			for {
 				if l := len(remaining); l < resp.ChunkSize {
 					resp.ChunkSize = l


### PR DESCRIPTION
Added a unit test to cover the fix made in a819335.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
