### PR TITLE
Add fake.NetConnOptions

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -29,7 +29,7 @@ func BenchmarkSenderSendSSMUnsettled(b *testing.B) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -74,7 +74,7 @@ func BenchmarkSenderSendSSMSettled(b *testing.B) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -117,7 +117,7 @@ func BenchmarkReceiverReceiveRSMFirst(b *testing.B) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -168,7 +168,7 @@ func BenchmarkReceiverReceiveRSMSecond(b *testing.B) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -219,7 +219,7 @@ func BenchmarkReceiverSettleMessage(b *testing.B) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()

--- a/conn_test.go
+++ b/conn_test.go
@@ -272,7 +272,7 @@ func TestStart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
-			netConn := fake.NewNetConn(tt.responder)
+			netConn := fake.NewNetConn(tt.responder, fake.NetConnOptions{})
 			conn, err := newConn(netConn, nil)
 			require.NoError(t, err)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -294,7 +294,7 @@ func TestStart(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -302,7 +302,7 @@ func TestClose(t *testing.T) {
 	cancel()
 	require.NoError(t, conn.Close())
 	// with Close error
-	netConn = fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn = fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 	conn, err = newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
@@ -331,7 +331,7 @@ func TestServerSideClose(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -346,7 +346,7 @@ func TestServerSideClose(t *testing.T) {
 
 	// with error
 	closeReceived = make(chan struct{})
-	netConn = fake.NewNetConn(responder)
+	netConn = fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err = newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
@@ -384,7 +384,7 @@ func TestKeepAlives(t *testing.T) {
 		}
 	}
 
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -426,7 +426,7 @@ func TestKeepAlivesIdleTimeout(t *testing.T) {
 
 	const idleTimeout = 100 * time.Millisecond
 
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err := newConn(netConn, &ConnOptions{
 		IdleTimeout: idleTimeout,
 	})
@@ -453,7 +453,7 @@ func TestKeepAlivesIdleTimeout(t *testing.T) {
 }
 
 func TestConnReaderError(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -471,7 +471,7 @@ func TestConnReaderError(t *testing.T) {
 }
 
 func TestConnWriterError(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -501,7 +501,7 @@ func TestConnWithZeroByteReads(t *testing.T) {
 		}
 	}
 
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	netConn.SendFrame([]byte{})
 
 	conn, err := newConn(netConn, nil)
@@ -517,7 +517,7 @@ func TestConnNegotiationTimeout(t *testing.T) {
 		return fake.Response{}, nil
 	}
 
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -530,7 +530,7 @@ type mockDialer struct {
 }
 
 func (m mockDialer) NetDialerDial(ctx context.Context, c *Conn, host, port string) error {
-	c.net = fake.NewNetConn(m.resp)
+	c.net = fake.NewNetConn(m.resp, fake.NetConnOptions{})
 	return nil
 }
 
@@ -640,7 +640,7 @@ func TestClientNewSession(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -686,7 +686,7 @@ func TestClientMultipleSessions(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -736,7 +736,7 @@ func TestClientTooManySessions(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -777,7 +777,7 @@ func TestClientNewSessionMissingRemoteChannel(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -807,7 +807,7 @@ func TestClientNewSessionInvalidInitialResponse(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -843,7 +843,7 @@ func TestClientNewSessionInvalidSecondResponseSameChannel(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -887,7 +887,7 @@ func TestClientNewSessionInvalidSecondResponseDifferentChannel(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -935,7 +935,7 @@ func TestNewSessionTimedOut(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -980,7 +980,7 @@ func TestNewSessionWriteError(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1055,7 +1055,7 @@ func TestConnSmallFrames(t *testing.T) {
 		}
 	}
 
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	conn, err := newConn(netConn, nil)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/link_test.go
+++ b/link_test.go
@@ -163,7 +163,7 @@ func TestMuxFlowHandlesDrainProperly(t *testing.T) {
 }
 
 func newTestLink(t *testing.T) *Receiver {
-	fakeConn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	fakeConn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	conn, err := NewConn(ctx, fakeConn, nil)
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestNewReceivingLink(t *testing.T) {
 func TestSessionFlowDisablesTransfer(t *testing.T) {
 	t.Skip("TODO: finish for link testing")
 	nextIncomingID := uint32(0)
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	client, err := NewConn(ctx, netConn, nil)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestReceiverInvalidOptions(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -73,7 +73,7 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -101,7 +101,7 @@ func TestReceiverMethodsNoReceive(t *testing.T) {
 }
 
 func TestReceiverLinkSourceFilter(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -130,7 +130,7 @@ func TestReceiverLinkSourceFilter(t *testing.T) {
 }
 
 func TestReceiverOnClosed(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -163,7 +163,7 @@ func TestReceiverOnClosed(t *testing.T) {
 }
 
 func TestReceiverOnSessionClosed(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -193,7 +193,7 @@ func TestReceiverOnSessionClosed(t *testing.T) {
 }
 
 func TestReceiverOnConnClosed(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -226,7 +226,7 @@ func TestReceiverOnConnClosed(t *testing.T) {
 }
 
 func TestReceiverOnDetached(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -292,7 +292,7 @@ func TestReceiverCloseTimeout(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
 	cancel()
@@ -350,7 +350,7 @@ func TestReceiveInvalidMessage(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -464,7 +464,7 @@ func TestReceiveSuccessReceiverSettleModeFirst(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -540,7 +540,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAccept(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -617,7 +617,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptOnClosedLink(t *testing.T) 
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -682,7 +682,7 @@ func TestReceiveSuccessReceiverSettleModeSecondReject(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -753,7 +753,7 @@ func TestReceiveSuccessReceiverSettleModeSecondRelease(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -829,7 +829,7 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -879,7 +879,9 @@ func TestReceiveSuccessReceiverSettleModeSecondModify(t *testing.T) {
 }
 
 func TestReceiverPrefetch(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{
+		ChunkSize: 8,
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -935,7 +937,9 @@ func TestReceiveMultiFrameMessageSuccess(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{
+		ChunkSize: 8,
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1021,7 +1025,7 @@ func TestReceiveInvalidMultiFrameMessage(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1133,7 +1137,7 @@ func TestReceiveMultiFrameMessageAborted(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1196,7 +1200,7 @@ func TestReceiveMessageTooBig(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1244,7 +1248,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1287,7 +1291,7 @@ func TestReceiveSuccessAcceptFails(t *testing.T) {
 }
 
 func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1316,7 +1320,7 @@ func TestReceiverCloseOnUnsettledWithPending(t *testing.T) {
 }
 
 func TestReceiverConnReaderError(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1352,7 +1356,7 @@ func TestReceiverConnReaderError(t *testing.T) {
 }
 
 func TestReceiverConnWriterError(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -1417,7 +1421,7 @@ func TestReceiveSuccessReceiverSettleModeSecondAcceptSlow(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	conn := fake.NewNetConn(responder)
+	conn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()

--- a/sender_test.go
+++ b/sender_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSenderInvalidOptions(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -62,7 +62,7 @@ func TestSenderMethodsNoSend(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -96,7 +96,7 @@ func TestSenderMethodsNoSend(t *testing.T) {
 }
 
 func TestSenderSendOnClosed(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -124,7 +124,7 @@ func TestSenderSendOnClosed(t *testing.T) {
 }
 
 func TestSenderSendOnSessionClosed(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -157,7 +157,7 @@ func TestSenderSendOnSessionClosed(t *testing.T) {
 func TestSenderSendConcurrentSessionClosed(t *testing.T) {
 	muxSem := test.NewMuxSemaphore(0)
 
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -207,7 +207,7 @@ func TestSenderSendConcurrentSessionClosed(t *testing.T) {
 }
 
 func TestSenderSendOnConnClosed(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -235,7 +235,7 @@ func TestSenderSendOnConnClosed(t *testing.T) {
 }
 
 func TestSenderSendOnDetached(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -294,7 +294,7 @@ func TestSenderCloseTimeout(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
 	cancel()
@@ -349,7 +349,7 @@ func TestSenderAttachError(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
 	cancel()
@@ -398,7 +398,7 @@ func TestSenderAttachError(t *testing.T) {
 }
 
 func TestSenderSendMismatchedModes(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -445,7 +445,7 @@ func TestSenderSendSuccess(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -492,7 +492,7 @@ func TestSenderSendSettled(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -541,7 +541,9 @@ func TestSenderSendSettledModeMixed(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{
+		ChunkSize: 8,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -567,7 +569,7 @@ func TestSenderSendSettledModeMixed(t *testing.T) {
 }
 
 func TestSenderSendSettledError(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -626,7 +628,7 @@ func TestSenderSendRejectedNoDetach(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -677,7 +679,7 @@ func TestSenderSendDetached(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -707,7 +709,7 @@ func TestSenderSendDetached(t *testing.T) {
 }
 
 func TestSenderSendTimeout(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -773,7 +775,7 @@ func TestSenderSendMsgTooBig(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -831,7 +833,7 @@ func TestSenderSendTagTooBig(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -911,7 +913,9 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{
+		ChunkSize: 8,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -944,7 +948,7 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 }
 
 func TestSenderConnReaderError(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -979,7 +983,7 @@ func TestSenderConnReaderError(t *testing.T) {
 }
 
 func TestSenderConnWriterError(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1038,7 +1042,7 @@ func TestSenderFlowFrameWithEcho(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1105,7 +1109,7 @@ func TestNewSenderTimedOut(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1156,7 +1160,7 @@ func TestNewSenderWriteError(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1209,7 +1213,7 @@ func TestNewSenderContextCancelled(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1227,7 +1231,7 @@ func TestNewSenderContextCancelled(t *testing.T) {
 }
 
 func TestSenderUnexpectedFrame(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1275,7 +1279,7 @@ func TestSenderSendFails(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -1317,7 +1321,7 @@ func TestSenderSendCancelled(t *testing.T) {
 	// transferSem blocks before the transfer frame is send to the session mux
 	transferSem := test.NewMuxSemaphore(0)
 
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)

--- a/session_test.go
+++ b/session_test.go
@@ -41,7 +41,7 @@ func TestSessionClose(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -79,7 +79,7 @@ func TestSessionServerClose(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -130,7 +130,7 @@ func TestSessionCloseTimeout(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
 	cancel()
@@ -156,7 +156,9 @@ func TestSessionCloseTimeout(t *testing.T) {
 }
 
 func TestConnCloseSessionClose(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{
+		ChunkSize: 8,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -184,7 +186,7 @@ func TestConnCloseSessionClose(t *testing.T) {
 }
 
 func TestSessionNewReceiverBadOptionFails(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -230,7 +232,7 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -256,7 +258,7 @@ func TestSessionNewReceiverMismatchedLinkName(t *testing.T) {
 }
 
 func TestSessionNewSenderBadOptionFails(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -302,7 +304,7 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -326,7 +328,7 @@ func TestSessionNewSenderMismatchedLinkName(t *testing.T) {
 }
 
 func TestSessionNewSenderDuplicateLinks(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -359,7 +361,7 @@ func TestSessionNewSenderDuplicateLinks(t *testing.T) {
 }
 
 func TestSessionNewSenderMaxHandles(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -392,7 +394,7 @@ func TestSessionNewSenderMaxHandles(t *testing.T) {
 }
 
 func TestSessionUnexpectedFrame(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -423,7 +425,7 @@ func TestSessionUnexpectedFrame(t *testing.T) {
 }
 
 func TestSessionInvalidFlowFrame(t *testing.T) {
-	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled))
+	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -485,7 +487,9 @@ func TestSessionFlowFrameWithEcho(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{
+		ChunkSize: 10,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -535,7 +539,7 @@ func TestSessionInvalidAttachDeadlock(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, netConn, nil)
@@ -594,7 +598,7 @@ func TestNewSessionContextCancelled(t *testing.T) {
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
 	}
-	netConn := fake.NewNetConn(responder)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
 
 	newCtx, newCancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(newCtx, netConn, nil)
@@ -608,7 +612,7 @@ func TestNewSessionContextCancelled(t *testing.T) {
 }
 
 func TestSessionReceiveTransferNoHandle(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()
@@ -634,7 +638,7 @@ func TestSessionReceiveTransferNoHandle(t *testing.T) {
 }
 
 func TestSessionReceiveDetachrNoHandle(t *testing.T) {
-	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst))
+	conn := fake.NewNetConn(receiverFrameHandlerNoUnhandled(0, ReceiverSettleModeFirst), fake.NetConnOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	client, err := NewConn(ctx, conn, nil)
 	cancel()


### PR DESCRIPTION
Includes ChunkSize to set a default for the fake.NetConn.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
