### PR TITLE
Notify the socket close to the user using a channel

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -87,6 +87,12 @@ type ConnOptions struct {
 
 	// test hook
 	dialer dialer
+
+	// Channel to send close events to the user
+	// the event will be sent when the connection is closed correctly or by an error
+	// the event will contain the error and the connection
+	// if the channel is nil, the events will not be sent
+	ChCloseEvent chan *CloseEvent
 }
 
 // Dial connects to an AMQP broker.
@@ -123,6 +129,11 @@ func NewConn(ctx context.Context, conn net.Conn, opts *ConnOptions) (*Conn, erro
 		return nil, err
 	}
 	return c, nil
+}
+
+type CloseEvent struct {
+	Err        error
+	Connection *Conn
 }
 
 // Conn is an AMQP connection.
@@ -178,6 +189,8 @@ type Conn struct {
 	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
 	txDone  chan struct{}      // closed when connWriter exits
 	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+
+	chCloseEvent chan *CloseEvent // channel to send close events to the user
 }
 
 // used to abstract the underlying dialer for testing purposes
@@ -314,6 +327,9 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 	}
 	if opts.dialer != nil {
 		c.dialer = opts.dialer
+	}
+	if opts.ChCloseEvent != nil {
+		c.chCloseEvent = opts.ChCloseEvent
 	}
 	return c, nil
 }
@@ -554,6 +570,9 @@ func (c *Conn) connReader() {
 		if err != nil {
 			debug.Log(0, "RX (connReader %p): terminal error: %v", c, err)
 			c.rxErr = err
+			if c.chCloseEvent != nil {
+				c.chCloseEvent <- &CloseEvent{Err: err, Connection: c}
+			}
 			return
 		}
 


### PR DESCRIPTION
Add a channel to the options to notify when the socket is closed.

**This is a proposal**, so I'd like your opinion before proceeding with the tests, etc...

 
The scope is to notify the user when the connection is closed, so there is a way to trace/log and implement some custom reconnection policy in case of an error or based on certain conditions.

Here an example:
```golang
closeCh := make(chan *amqp.CloseEvent, 1)

	go func(ch chan *amqp.CloseEvent) {
		for closeEvent := range ch {
			fmt.Printf("Close event received: %v\n", closeEvent)
		}
	}(closeCh)

	conn, err := amqp.Dial(context.TODO(), "amqp://localhost", &amqp.ConnOptions{
		SASLType:     amqp.SASLTypeAnonymous(),
		ChCloseEvent: closeCh,
	})
	
	fmt.Println("Press any key to cleanup and exit")
	reader := bufio.NewReader(os.Stdin)
	_, _ = reader.ReadString('\n')

	err = conn.Close()
```

In case the socket is closed correctly, the user will receive:
```
Close event received: &{read tcp [::1]:50493->[::1]:5672: use of closed network connection 0x140001281a0}
```

In case the connection is killed ( in this case by rabbitmq) the user will receive:
```golang
Close event received: &{*Error{Condition: amqp:internal-error, Description: Connection forced: "Closed via management plugin", Info: map[]} 0x140001161a0}
```

This may also help for this issue https://github.com/Azure/go-amqp/issues/295 
Thank you 




- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
