### PR TITLE
Encode nil data section as null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added type `Null` used to send an AMQP `null` message value.
 
+### Bugs Fixed
+
+* Calling `NewMessage` with a `nil` value encodes the application data as `null` instead of `vbin8`.
+
 ## 1.1.0 (2024-08-20)
 
 ### Features Added

--- a/internal/encoding/encode.go
+++ b/internal/encoding/encode.go
@@ -383,6 +383,12 @@ func WriteBinary(wr *buffer.Buffer, bin []byte) error {
 	l := len(bin)
 
 	switch {
+	case l == 0:
+		wr.Append([]byte{
+			byte(TypeCodeNull),
+		})
+		return nil
+
 	// List8
 	case l < 256:
 		wr.Append([]byte{

--- a/message_test.go
+++ b/message_test.go
@@ -55,6 +55,32 @@ func TestMessageNull(t *testing.T) {
 	require.Equal(t, []byte{0, 0x53, 0x77, 0x40}, b)
 }
 
+func TestMessageMarshalBinary_Null(t *testing.T) {
+	msg := NewMessage(nil)
+	b, err := msg.MarshalBinary()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Equal(t, []byte{0, 0x53, 0x75, 0x40}, b)
+
+	msg = &Message{
+		Data: [][]byte{
+			{12},
+			nil,
+			{34},
+			nil,
+		},
+	}
+	b, err = msg.MarshalBinary()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.Equal(t, []byte{
+		0, 0x53, 0x75, 0xa0, 0x1, 0xc, // first data chunk with value 12
+		0, 0x53, 0x75, 0x40, // second data chunk with nil
+		0, 0x53, 0x75, 0xa0, 0x1, 0x22, // third data chunk with value 34
+		0, 0x53, 0x75, 0x40, // fourth data chunk with nil
+	}, b)
+}
+
 func TestMessageUnmarshaling(t *testing.T) {
 	for _, tt := range exampleEncodedMessages {
 		t.Run(tt.label, func(t *testing.T) {


### PR DESCRIPTION
For data sections that are nil, encode them as null instead of vbin8.

Fixes https://github.com/Azure/go-amqp/issues/332