### PR TITLE
Fix race in Conn.start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Added type `Null` used to send an AMQP `null` message value.
 
+### Bugs Fixed
+
+* Fixed a rare race in `Conn.start` that could cause goroutines to be leaked if the provided context was canceld/expired.
+
 ## 1.1.0 (2024-08-20)
 
 ### Features Added


### PR DESCRIPTION
If the provided context is canceled/expires after connReader and connWriter are started, the resultant *Conn will be nil causing their goroutines to be leaked.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
