### PR TITLE
Add Properties methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Added type `Null` used to send an AMQP `null` message value.
+* Added method `Properties` to `Conn`, `Session`, `Receiver`, and `Sender` which contains the peer's respective properties.
 
 ### Bugs Fixed
 

--- a/link.go
+++ b/link.go
@@ -66,6 +66,9 @@ type link struct {
 	// can independently set this value. The sender endpoint sets this to the last known value seen from the receiver.
 	linkCredit uint32
 
+	// properties returned by the peer
+	peerProperties map[string]any
+
 	senderSettleMode   *SenderSettleMode
 	receiverSettleMode *ReceiverSettleMode
 	maxMessageSize     uint64
@@ -219,6 +222,13 @@ func (l *link) attach(ctx context.Context, beforeAttach func(*frames.PerformAtta
 			return err
 		}
 		return err
+	}
+
+	if len(resp.Properties) > 0 {
+		l.peerProperties = map[string]any{}
+		for k, v := range resp.Properties {
+			l.peerProperties[string(k)] = v
+		}
 	}
 
 	return nil

--- a/receiver.go
+++ b/receiver.go
@@ -231,6 +231,12 @@ func (r *Receiver) LinkSourceFilterValue(name string) any {
 	return filter.Value
 }
 
+// Properties returns the peer's link properties.
+// Returns nil if the peer didn't send any properties.
+func (r *Receiver) Properties() map[string]any {
+	return r.l.peerProperties
+}
+
 // Close closes the Receiver and AMQP link.
 //   - ctx controls waiting for the peer to acknowledge the close
 //

--- a/sender.go
+++ b/sender.go
@@ -34,6 +34,12 @@ func (s *Sender) MaxMessageSize() uint64 {
 	return s.l.maxMessageSize
 }
 
+// Properties returns the peer's link properties.
+// Returns nil if the peer didn't send any properties.
+func (s *Sender) Properties() map[string]any {
+	return s.l.peerProperties
+}
+
 // SendOptions contains any optional values for the Sender.Send method.
 type SendOptions struct {
 	// Indicates the message is to be sent as settled when settlement mode is SenderSettleModeMixed.


### PR DESCRIPTION
Exposes peer properties for the respective performatives.

Fixes:
- https://github.com/Azure/go-amqp/issues/32
- https://github.com/Azure/go-amqp/issues/220