### PR TITLE
Always encode MessageHeader.Durable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 * Fixed a rare race in `Conn.start` that could cause goroutines to be leaked if the provided context was canceld/expired.
 
+### Other Changes
+
+* The field `MessageHeader.Durable` is not omitted when it's `false`.
+
 ## 1.1.0 (2024-08-20)
 
 ### Features Added

--- a/message.go
+++ b/message.go
@@ -340,7 +340,7 @@ type MessageHeader struct {
 
 func (h *MessageHeader) Marshal(wr *buffer.Buffer) error {
 	return encoding.MarshalComposite(wr, encoding.TypeCodeMessageHeader, []encoding.MarshalField{
-		{Value: &h.Durable, Omit: !h.Durable},
+		{Value: &h.Durable},
 		{Value: &h.Priority, Omit: h.Priority == 4},
 		{Value: (*encoding.Milliseconds)(&h.TTL), Omit: h.TTL == 0},
 		{Value: &h.FirstAcquirer, Omit: !h.FirstAcquirer},

--- a/message_test.go
+++ b/message_test.go
@@ -3,6 +3,7 @@ package amqp
 import (
 	"testing"
 
+	"github.com/Azure/go-amqp/internal/buffer"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -90,4 +91,15 @@ func TestMessageWithSequence(t *testing.T) {
 		{"hello1", "world1", int64(11), int64(12), int64(13)},
 		{"hello2", "world2", int64(21), int64(22), int64(23)},
 	}, newM.Sequence)
+}
+
+func TestMessageHeaderMarshal(t *testing.T) {
+	header := MessageHeader{}
+	buf := &buffer.Buffer{}
+	err := header.Marshal(buf)
+	require.NoError(t, err)
+	b := buf.Detach()
+	require.NotNil(t, b)
+	// 0x42 is false for the Durable field
+	require.Equal(t, []byte{0x0, 0x53, 0x70, 0xd0, 0x0, 0x0, 0x0, 0x7, 0x0, 0x0, 0x0, 0x2, 0x42, 0x50, 0x0}, b)
 }


### PR DESCRIPTION
This allows sending an explicit false.

Fixes https://github.com/Azure/go-amqp/issues/330