### PR TITLE
Expose the Symbol type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added methods `Done` and `Err` to `Conn`
   * `Done` returns a channel that's closed when `Conn` has closed.
   * `Err` explains why `Conn` was closed.
+* encoding.Symbol was exposed as a public type `Symbol`.
 
 ## 1.2.0 (2024-09-30)
 

--- a/message.go
+++ b/message.go
@@ -510,3 +510,6 @@ type Annotations = encoding.Annotations
 
 // UUID is a 128 bit identifier as defined in RFC 4122.
 type UUID = encoding.UUID
+
+// Symbol is an AMQP symbolic string.
+type Symbol = encoding.Symbol


### PR DESCRIPTION
This PR make the encoding.Symbol type exposed as a public type `Symbol`.

We recently [implemented AMQP Filter Expressions](https://github.com/rabbitmq/rabbitmq-server/pull/12415) in RabbitMQ. If the client wants to filter based on a property, the property name should be encoded as a `Symbol`, therefore the client needs to be able to use a `map[amqp.Symbol]any` in ` amqp.NewLinkFilter`

See https://github.com/rabbitmq/omq/blob/filter-properties/pkg/amqp10_client/consumer.go#L273-L279 for an example that works using a branch of go-amqp.

Thanks,