### PR TITLE
Add Done and Err methods to Conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Bugs Fixed
 
-* Fixed a rare race in `Conn.start` that could cause goroutines to be leaked if the provided context was canceld/expired.
+* Fixed a rare race in `Conn.start` that could cause goroutines to be leaked if the provided context was canceled/expired.
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Added type `Null` used to send an AMQP `null` message value.
 * Added method `Properties` to `Conn`, `Session`, `Receiver`, and `Sender` which contains the peer's respective properties.
+* Added methods `Done` and `Err` to `Conn`
+  * `Done` returns a channel that's closed when `Conn` has closed.
+  * `Err` explains why `Conn` was closed.
 
 ### Bugs Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Release History
 
+## 1.3.0 (unreleased)
+
+### Features Added
+
+* Added methods `Done` and `Err` to `Conn`
+  * `Done` returns a channel that's closed when `Conn` has closed.
+  * `Err` explains why `Conn` was closed.
+
 ## 1.2.0 (2024-09-30)
 
 ### Features Added
 
 * Added type `Null` used to send an AMQP `null` message value.
 * Added method `Properties` to `Conn`, `Session`, `Receiver`, and `Sender` which contains the peer's respective properties.
-* Added methods `Done` and `Err` to `Conn`
-  * `Done` returns a channel that's closed when `Conn` has closed.
-  * `Err` explains why `Conn` was closed.
 
 ### Bugs Fixed
 

--- a/conn.go
+++ b/conn.go
@@ -408,7 +408,8 @@ func (c *Conn) startImpl(ctx context.Context) error {
 // Close closes the connection.
 //
 // Returns nil if there were no errors during shutdown,
-// or a *ConnError.
+// or a *ConnError. This is for diagnostic purposes as
+// the connection is still closed.
 //
 // The error returned by subsequent calls to Close is
 // idempotent, so the same value will always be returned.
@@ -491,6 +492,7 @@ func (c *Conn) closeDuringStart() {
 }
 
 // returns the error indicating why Conn has closed
+// NOTE: only call this AFTER Conn.done has been closed!
 func (c *Conn) closedErr() error {
 	// an empty ConnError means the connection was closed by the caller
 	var connErr *ConnError

--- a/conn.go
+++ b/conn.go
@@ -408,8 +408,8 @@ func (c *Conn) startImpl(ctx context.Context) error {
 // Close closes the connection.
 //
 // Returns nil if there were no errors during shutdown,
-// or a *ConnError. This is for diagnostic purposes as
-// the connection is still closed.
+// or a *ConnError. This error is not actionable and is
+// purely for diagnostic purposes.
 //
 // The error returned by subsequent calls to Close is
 // idempotent, so the same value will always be returned.
@@ -431,12 +431,16 @@ func (c *Conn) Done() <-chan struct{} {
 }
 
 // If Done is not yet closed, Err returns nil.
-// If Done is closed, Err returns nil or an error explaining why.
+// If Done is closed, Err returns nil or a *ConnError explaining why.
 // A nil error indicates that [Close] was called and there
 // were no errors during shutdown.
 //
-// See the doc comments for [Close] which explains the
-// types of error values that can be returned.
+// A *ConnError indicates one of three things
+//   - there was an error during shutdown from a client-side call to [Close]. the
+//     error is not actionable and is purely for diagnostic purposes.
+//   - a fatal error was encountered that caused [Conn] to close
+//   - the peer closed the connection. [ConnError.RemoteErr] MAY contain an error
+//     from the peer indicating why it closed the connection
 func (c *Conn) Err() error {
 	select {
 	case <-c.done:

--- a/errors.go
+++ b/errors.go
@@ -83,7 +83,7 @@ type ConnError struct {
 	inner error
 }
 
-// Error implements the error interface for ConnectionError.
+// Error implements the error interface for ConnError.
 func (e *ConnError) Error() string {
 	if e.RemoteErr == nil && e.inner == nil {
 		return "amqp: connection closed"

--- a/example_test.go
+++ b/example_test.go
@@ -218,3 +218,41 @@ func ExampleLinkError() {
 		log.Fatalf("unexpected error type %T", err)
 	}
 }
+
+func ExampleConn_Done() {
+	ctx := context.TODO()
+
+	// create connection
+	conn, err := amqp.Dial(ctx, "amqps://my-namespace.servicebus.windows.net", &amqp.ConnOptions{
+		SASLType: amqp.SASLTypePlain("access-key-name", "access-key"),
+	})
+	if err != nil {
+		log.Fatal("Dialing AMQP server:", err)
+	}
+
+	// when the channel returned by Done is closed, conn has been closed
+	<-conn.Done()
+
+	// Err indicates why the connection was closed. a nil error indicates
+	// a client-side call to Close and there were no errors during shutdown.
+	closedErr := conn.Err()
+
+	// when Err returns a non-nil error, it means that either a client-side
+	// call to Close encountered an error during shutdown, a fatal error was
+	// encountered that caused the connection to close, or that the peer
+	// closed the connection.
+	if closedErr != nil {
+		// the error returned by Err is always a *ConnError
+		var connErr *amqp.ConnError
+		errors.As(closedErr, &connErr)
+
+		if connErr.RemoteErr != nil {
+			// this indicates that the peer closed the connection.
+			// the RemoteErr will contain info explaining why
+		} else {
+			// the connection encountered a fatal error or there was
+			// an error during client-side shutdown. this is for
+			// diagnostics, the connection has been closed.
+		}
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -247,8 +247,9 @@ func ExampleConn_Done() {
 		errors.As(closedErr, &connErr)
 
 		if connErr.RemoteErr != nil {
-			// this indicates that the peer closed the connection.
-			// the RemoteErr will contain info explaining why
+			// the peer closed the connection and provided an error explaining why.
+			// note that the peer MAY send an error when closing the connection but
+			// is not required to.
 		} else {
 			// the connection encountered a fatal error or there was
 			// an error during client-side shutdown. this is for


### PR DESCRIPTION
Signals when a connection has been closed and any associated error.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
