### PR TITLE
Move exported internal types to their own file

### DIFF
--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -46,12 +46,12 @@ func (d *Durability) String() string {
 	}
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (d Durability) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint32(d))
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (d *Durability) Unmarshal(r *buffer.Buffer) error {
 	return Unmarshal(r, (*uint32)(d))
 }
@@ -82,12 +82,12 @@ const (
 // from its originally configured timeout value.
 type ExpiryPolicy Symbol
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (e ExpiryPolicy) Marshal(wr *buffer.Buffer) error {
 	return Symbol(e).Marshal(wr)
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (e *ExpiryPolicy) Unmarshal(r *buffer.Buffer) error {
 	err := Unmarshal(r, (*Symbol)(e))
 	if err != nil {
@@ -147,12 +147,12 @@ func (m *SenderSettleMode) String() string {
 	}
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (m SenderSettleMode) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint8(m))
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (m *SenderSettleMode) Unmarshal(r *buffer.Buffer) error {
 	n, err := ReadUbyte(r)
 	*m = SenderSettleMode(n)
@@ -197,12 +197,12 @@ func (m *ReceiverSettleMode) String() string {
 	}
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (m ReceiverSettleMode) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint8(m))
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
 	n, err := ReadUbyte(r)
 	*m = ReceiverSettleMode(n)
@@ -213,12 +213,12 @@ func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
 // http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
 type Filter map[Symbol]*DescribedType
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (f Filter) Marshal(wr *buffer.Buffer) error {
 	return writeMap(wr, f)
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (f *Filter) Unmarshal(r *buffer.Buffer) error {
 	count, err := readMapHeader(r)
 	if err != nil {
@@ -247,12 +247,12 @@ func (f *Filter) Unmarshal(r *buffer.Buffer) error {
 // String keys are encoded as AMQP Symbols.
 type Annotations map[any]any
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (a Annotations) Marshal(wr *buffer.Buffer) error {
 	return writeMap(wr, a)
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
 	count, err := readMapHeader(r)
 	if err != nil {
@@ -278,12 +278,12 @@ func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
 // ErrCond is one of the error conditions defined in the AMQP spec.
 type ErrCond string
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (ec ErrCond) Marshal(wr *buffer.Buffer) error {
 	return (Symbol)(ec).Marshal(wr)
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (ec *ErrCond) Unmarshal(r *buffer.Buffer) error {
 	s, err := ReadString(r)
 	*ec = ErrCond(s)
@@ -314,7 +314,7 @@ type Error struct {
 	Info map[string]any
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (e *Error) Marshal(wr *buffer.Buffer) error {
 	return MarshalComposite(wr, TypeCodeError, []MarshalField{
 		{Value: &e.Condition, Omit: false},
@@ -323,7 +323,7 @@ func (e *Error) Marshal(wr *buffer.Buffer) error {
 	})
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (e *Error) Unmarshal(r *buffer.Buffer) error {
 	return UnmarshalComposite(r, TypeCodeError, []UnmarshalField{
 		{Field: &e.Condition, HandleNull: func() error { return errors.New("Error.Condition is required") }},
@@ -353,7 +353,7 @@ func (e *Error) Error() string {
 // Symbol is an AMQP symbolic string.
 type Symbol string
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (s Symbol) Marshal(wr *buffer.Buffer) error {
 	l := len(s)
 	switch {
@@ -394,14 +394,14 @@ func (u UUID) String() string {
 	return string(buf[:])
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (u UUID) Marshal(wr *buffer.Buffer) error {
 	wr.AppendByte(byte(TypeCodeUUID))
 	wr.Append(u[:])
 	return nil
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (u *UUID) Unmarshal(r *buffer.Buffer) error {
 	un, err := readUUID(r)
 	*u = un
@@ -415,7 +415,7 @@ type DescribedType struct {
 	Value      any
 }
 
-// Marshal encodes the type into a buffer. It is not intended for public use.
+// Marshal encodes this type into a buffer. It is not intended for public use.
 func (t DescribedType) Marshal(wr *buffer.Buffer) error {
 	wr.AppendByte(0x0) // descriptor constructor
 	err := Marshal(wr, t.Descriptor)
@@ -425,7 +425,7 @@ func (t DescribedType) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, t.Value)
 }
 
-// Unmarshal decodes a buffer in this type. It is not intended for public use.
+// Unmarshal decodes a buffer into this type. It is not intended for public use.
 func (t *DescribedType) Unmarshal(r *buffer.Buffer) error {
 	b, err := r.ReadByte()
 	if err != nil {

--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -27,6 +27,8 @@ const (
 // Durability specifies the durability of a link.
 type Durability uint32
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (d *Durability) String() string {
 	if d == nil {
 		return "<nil>"
@@ -102,6 +104,8 @@ func (e *ExpiryPolicy) Unmarshal(r *buffer.Buffer) error {
 	return ValidateExpiryPolicy(*e)
 }
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (e *ExpiryPolicy) String() string {
 	if e == nil {
 		return "<nil>"
@@ -128,6 +132,8 @@ func (m SenderSettleMode) Ptr() *SenderSettleMode {
 	return &m
 }
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (m *SenderSettleMode) String() string {
 	if m == nil {
 		return "<nil>"
@@ -176,6 +182,8 @@ func (m ReceiverSettleMode) Ptr() *ReceiverSettleMode {
 	return &m
 }
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (m *ReceiverSettleMode) String() string {
 	if m == nil {
 		return "<nil>"
@@ -316,6 +324,8 @@ func (e *Error) Unmarshal(r *buffer.Buffer) error {
 	}...)
 }
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (e *Error) String() string {
 	if e == nil {
 		return "*Error(nil)"
@@ -417,6 +427,8 @@ func (t *DescribedType) Unmarshal(r *buffer.Buffer) error {
 	return Unmarshal(r, &t.Value)
 }
 
+// String implements the [fmt.Stringer] interface.
+// Note that the values are for diagnostic purposes and may change over time.
 func (t DescribedType) String() string {
 	return fmt.Sprintf("DescribedType{descriptor: %v, value: %v}",
 		t.Descriptor,

--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -82,18 +82,6 @@ const (
 // from its originally configured timeout value.
 type ExpiryPolicy Symbol
 
-func ValidateExpiryPolicy(e ExpiryPolicy) error {
-	switch e {
-	case ExpiryLinkDetach,
-		ExpirySessionEnd,
-		ExpiryConnectionClose,
-		ExpiryNever:
-		return nil
-	default:
-		return fmt.Errorf("unknown expiry-policy %q", e)
-	}
-}
-
 // Marshal encodes the type into a buffer. It is not intended for public use.
 func (e ExpiryPolicy) Marshal(wr *buffer.Buffer) error {
 	return Symbol(e).Marshal(wr)

--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -46,10 +46,12 @@ func (d *Durability) String() string {
 	}
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (d Durability) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint32(d))
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (d *Durability) Unmarshal(r *buffer.Buffer) error {
 	return Unmarshal(r, (*uint32)(d))
 }
@@ -92,10 +94,12 @@ func ValidateExpiryPolicy(e ExpiryPolicy) error {
 	}
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (e ExpiryPolicy) Marshal(wr *buffer.Buffer) error {
 	return Symbol(e).Marshal(wr)
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (e *ExpiryPolicy) Unmarshal(r *buffer.Buffer) error {
 	err := Unmarshal(r, (*Symbol)(e))
 	if err != nil {
@@ -154,10 +158,12 @@ func (m *SenderSettleMode) String() string {
 	}
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (m SenderSettleMode) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint8(m))
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (m *SenderSettleMode) Unmarshal(r *buffer.Buffer) error {
 	n, err := ReadUbyte(r)
 	*m = SenderSettleMode(n)
@@ -201,10 +207,12 @@ func (m *ReceiverSettleMode) String() string {
 	}
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (m ReceiverSettleMode) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, uint8(m))
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
 	n, err := ReadUbyte(r)
 	*m = ReceiverSettleMode(n)
@@ -213,10 +221,12 @@ func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
 
 type Filter map[Symbol]*DescribedType
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (f Filter) Marshal(wr *buffer.Buffer) error {
 	return writeMap(wr, f)
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (f *Filter) Unmarshal(r *buffer.Buffer) error {
 	count, err := readMapHeader(r)
 	if err != nil {
@@ -245,10 +255,12 @@ func (f *Filter) Unmarshal(r *buffer.Buffer) error {
 // String keys are encoded as AMQP Symbols.
 type Annotations map[any]any
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (a Annotations) Marshal(wr *buffer.Buffer) error {
 	return writeMap(wr, a)
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
 	count, err := readMapHeader(r)
 	if err != nil {
@@ -274,10 +286,12 @@ func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
 // ErrCond is one of the error conditions defined in the AMQP spec.
 type ErrCond string
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (ec ErrCond) Marshal(wr *buffer.Buffer) error {
 	return (Symbol)(ec).Marshal(wr)
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (ec *ErrCond) Unmarshal(r *buffer.Buffer) error {
 	s, err := ReadString(r)
 	*ec = ErrCond(s)
@@ -308,6 +322,7 @@ type Error struct {
 	Info map[string]any
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (e *Error) Marshal(wr *buffer.Buffer) error {
 	return MarshalComposite(wr, TypeCodeError, []MarshalField{
 		{Value: &e.Condition, Omit: false},
@@ -316,6 +331,7 @@ func (e *Error) Marshal(wr *buffer.Buffer) error {
 	})
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (e *Error) Unmarshal(r *buffer.Buffer) error {
 	return UnmarshalComposite(r, TypeCodeError, []UnmarshalField{
 		{Field: &e.Condition, HandleNull: func() error { return errors.New("Error.Condition is required") }},
@@ -344,6 +360,7 @@ func (e *Error) Error() string {
 // symbol is an AMQP symbolic string.
 type Symbol string
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (s Symbol) Marshal(wr *buffer.Buffer) error {
 	l := len(s)
 	switch {
@@ -384,12 +401,14 @@ func (u UUID) String() string {
 	return string(buf[:])
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (u UUID) Marshal(wr *buffer.Buffer) error {
 	wr.AppendByte(byte(TypeCodeUUID))
 	wr.Append(u[:])
 	return nil
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (u *UUID) Unmarshal(r *buffer.Buffer) error {
 	un, err := readUUID(r)
 	*u = un
@@ -401,6 +420,7 @@ type DescribedType struct {
 	Value      any
 }
 
+// Marshal encodes the type into a buffer. It is not intended for public use.
 func (t DescribedType) Marshal(wr *buffer.Buffer) error {
 	wr.AppendByte(0x0) // descriptor constructor
 	err := Marshal(wr, t.Descriptor)
@@ -410,6 +430,7 @@ func (t DescribedType) Marshal(wr *buffer.Buffer) error {
 	return Marshal(wr, t.Value)
 }
 
+// Unmarshal decodes a buffer in this type. It is not intended for public use.
 func (t *DescribedType) Unmarshal(r *buffer.Buffer) error {
 	b, err := r.ReadByte()
 	if err != nil {

--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -1,0 +1,425 @@
+package encoding
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/Azure/go-amqp/internal/buffer"
+)
+
+// Durability Policies
+const (
+	// No terminus state is retained durably.
+	DurabilityNone Durability = 0
+
+	// Only the existence and configuration of the terminus is
+	// retained durably.
+	DurabilityConfiguration Durability = 1
+
+	// In addition to the existence and configuration of the
+	// terminus, the unsettled state for durable messages is
+	// retained durably.
+	DurabilityUnsettledState Durability = 2
+)
+
+// Durability specifies the durability of a link.
+type Durability uint32
+
+func (d *Durability) String() string {
+	if d == nil {
+		return "<nil>"
+	}
+
+	switch *d {
+	case DurabilityNone:
+		return "none"
+	case DurabilityConfiguration:
+		return "configuration"
+	case DurabilityUnsettledState:
+		return "unsettled-state"
+	default:
+		return fmt.Sprintf("unknown durability %d", *d)
+	}
+}
+
+func (d Durability) Marshal(wr *buffer.Buffer) error {
+	return Marshal(wr, uint32(d))
+}
+
+func (d *Durability) Unmarshal(r *buffer.Buffer) error {
+	return Unmarshal(r, (*uint32)(d))
+}
+
+// Expiry Policies
+const (
+	// The expiry timer starts when terminus is detached.
+	ExpiryLinkDetach ExpiryPolicy = "link-detach"
+
+	// The expiry timer starts when the most recently
+	// associated session is ended.
+	ExpirySessionEnd ExpiryPolicy = "session-end"
+
+	// The expiry timer starts when most recently associated
+	// connection is closed.
+	ExpiryConnectionClose ExpiryPolicy = "connection-close"
+
+	// The terminus never expires.
+	ExpiryNever ExpiryPolicy = "never"
+)
+
+// ExpiryPolicy specifies when the expiry timer of a terminus
+// starts counting down from the timeout value.
+//
+// If the link is subsequently re-attached before the terminus is expired,
+// then the count down is aborted. If the conditions for the
+// terminus-expiry-policy are subsequently re-met, the expiry timer restarts
+// from its originally configured timeout value.
+type ExpiryPolicy Symbol
+
+func ValidateExpiryPolicy(e ExpiryPolicy) error {
+	switch e {
+	case ExpiryLinkDetach,
+		ExpirySessionEnd,
+		ExpiryConnectionClose,
+		ExpiryNever:
+		return nil
+	default:
+		return fmt.Errorf("unknown expiry-policy %q", e)
+	}
+}
+
+func (e ExpiryPolicy) Marshal(wr *buffer.Buffer) error {
+	return Symbol(e).Marshal(wr)
+}
+
+func (e *ExpiryPolicy) Unmarshal(r *buffer.Buffer) error {
+	err := Unmarshal(r, (*Symbol)(e))
+	if err != nil {
+		return err
+	}
+	return ValidateExpiryPolicy(*e)
+}
+
+func (e *ExpiryPolicy) String() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return string(*e)
+}
+
+// Sender Settlement Modes
+const (
+	// Sender will send all deliveries initially unsettled to the receiver.
+	SenderSettleModeUnsettled SenderSettleMode = 0
+
+	// Sender will send all deliveries settled to the receiver.
+	SenderSettleModeSettled SenderSettleMode = 1
+
+	// Sender MAY send a mixture of settled and unsettled deliveries to the receiver.
+	SenderSettleModeMixed SenderSettleMode = 2
+)
+
+// SenderSettleMode specifies how the sender will settle messages.
+type SenderSettleMode uint8
+
+func (m SenderSettleMode) Ptr() *SenderSettleMode {
+	return &m
+}
+
+func (m *SenderSettleMode) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+
+	switch *m {
+	case SenderSettleModeUnsettled:
+		return "unsettled"
+
+	case SenderSettleModeSettled:
+		return "settled"
+
+	case SenderSettleModeMixed:
+		return "mixed"
+
+	default:
+		return fmt.Sprintf("unknown sender mode %d", uint8(*m))
+	}
+}
+
+func (m SenderSettleMode) Marshal(wr *buffer.Buffer) error {
+	return Marshal(wr, uint8(m))
+}
+
+func (m *SenderSettleMode) Unmarshal(r *buffer.Buffer) error {
+	n, err := ReadUbyte(r)
+	*m = SenderSettleMode(n)
+	return err
+}
+
+// Receiver Settlement Modes
+const (
+	// Receiver will spontaneously settle all incoming transfers.
+	ReceiverSettleModeFirst ReceiverSettleMode = 0
+
+	// Receiver will only settle after sending the disposition to the
+	// sender and receiving a disposition indicating settlement of
+	// the delivery from the sender.
+	ReceiverSettleModeSecond ReceiverSettleMode = 1
+)
+
+// ReceiverSettleMode specifies how the receiver will settle messages.
+type ReceiverSettleMode uint8
+
+func (m ReceiverSettleMode) Ptr() *ReceiverSettleMode {
+	return &m
+}
+
+func (m *ReceiverSettleMode) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+
+	switch *m {
+	case ReceiverSettleModeFirst:
+		return "first"
+
+	case ReceiverSettleModeSecond:
+		return "second"
+
+	default:
+		return fmt.Sprintf("unknown receiver mode %d", uint8(*m))
+	}
+}
+
+func (m ReceiverSettleMode) Marshal(wr *buffer.Buffer) error {
+	return Marshal(wr, uint8(m))
+}
+
+func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
+	n, err := ReadUbyte(r)
+	*m = ReceiverSettleMode(n)
+	return err
+}
+
+type Filter map[Symbol]*DescribedType
+
+func (f Filter) Marshal(wr *buffer.Buffer) error {
+	return writeMap(wr, f)
+}
+
+func (f *Filter) Unmarshal(r *buffer.Buffer) error {
+	count, err := readMapHeader(r)
+	if err != nil {
+		return err
+	}
+
+	m := make(Filter, count/2)
+	for i := uint32(0); i < count; i += 2 {
+		key, err := ReadString(r)
+		if err != nil {
+			return err
+		}
+		var value DescribedType
+		err = Unmarshal(r, &value)
+		if err != nil {
+			return err
+		}
+		m[Symbol(key)] = &value
+	}
+	*f = m
+	return nil
+}
+
+// Annotations keys must be of type string, int, or int64.
+//
+// String keys are encoded as AMQP Symbols.
+type Annotations map[any]any
+
+func (a Annotations) Marshal(wr *buffer.Buffer) error {
+	return writeMap(wr, a)
+}
+
+func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
+	count, err := readMapHeader(r)
+	if err != nil {
+		return err
+	}
+
+	m := make(Annotations, count/2)
+	for i := uint32(0); i < count; i += 2 {
+		key, err := ReadAny(r)
+		if err != nil {
+			return err
+		}
+		value, err := ReadAny(r)
+		if err != nil {
+			return err
+		}
+		m[key] = value
+	}
+	*a = m
+	return nil
+}
+
+// ErrCond is one of the error conditions defined in the AMQP spec.
+type ErrCond string
+
+func (ec ErrCond) Marshal(wr *buffer.Buffer) error {
+	return (Symbol)(ec).Marshal(wr)
+}
+
+func (ec *ErrCond) Unmarshal(r *buffer.Buffer) error {
+	s, err := ReadString(r)
+	*ec = ErrCond(s)
+	return err
+}
+
+/*
+<type name="error" class="composite" source="list">
+    <descriptor name="amqp:error:list" code="0x00000000:0x0000001d"/>
+    <field name="condition" type="symbol" requires="error-condition" mandatory="true"/>
+    <field name="description" type="string"/>
+    <field name="info" type="fields"/>
+</type>
+*/
+
+// Error is an AMQP error.
+type Error struct {
+	// A symbolic value indicating the error condition.
+	Condition ErrCond
+
+	// descriptive text about the error condition
+	//
+	// This text supplies any supplementary details not indicated by the condition field.
+	// This text can be logged as an aid to resolving issues.
+	Description string
+
+	// map carrying information about the error condition
+	Info map[string]any
+}
+
+func (e *Error) Marshal(wr *buffer.Buffer) error {
+	return MarshalComposite(wr, TypeCodeError, []MarshalField{
+		{Value: &e.Condition, Omit: false},
+		{Value: &e.Description, Omit: e.Description == ""},
+		{Value: e.Info, Omit: len(e.Info) == 0},
+	})
+}
+
+func (e *Error) Unmarshal(r *buffer.Buffer) error {
+	return UnmarshalComposite(r, TypeCodeError, []UnmarshalField{
+		{Field: &e.Condition, HandleNull: func() error { return errors.New("Error.Condition is required") }},
+		{Field: &e.Description},
+		{Field: &e.Info},
+	}...)
+}
+
+func (e *Error) String() string {
+	if e == nil {
+		return "*Error(nil)"
+	}
+	return fmt.Sprintf("*Error{Condition: %s, Description: %s, Info: %v}",
+		e.Condition,
+		e.Description,
+		e.Info,
+	)
+}
+
+func (e *Error) Error() string {
+	return e.String()
+}
+
+// symbol is an AMQP symbolic string.
+type Symbol string
+
+func (s Symbol) Marshal(wr *buffer.Buffer) error {
+	l := len(s)
+	switch {
+	// Sym8
+	case l < 256:
+		wr.Append([]byte{
+			byte(TypeCodeSym8),
+			byte(l),
+		})
+		wr.AppendString(string(s))
+
+	// Sym32
+	case uint(l) < math.MaxUint32:
+		wr.AppendByte(uint8(TypeCodeSym32))
+		wr.AppendUint32(uint32(l))
+		wr.AppendString(string(s))
+	default:
+		return errors.New("too long")
+	}
+	return nil
+}
+
+// UUID is a 128 bit identifier as defined in RFC 4122.
+type UUID [16]byte
+
+// String returns the hex encoded representation described in RFC 4122, Section 3.
+func (u UUID) String() string {
+	var buf [36]byte
+	hex.Encode(buf[:8], u[:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+	return string(buf[:])
+}
+
+func (u UUID) Marshal(wr *buffer.Buffer) error {
+	wr.AppendByte(byte(TypeCodeUUID))
+	wr.Append(u[:])
+	return nil
+}
+
+func (u *UUID) Unmarshal(r *buffer.Buffer) error {
+	un, err := readUUID(r)
+	*u = un
+	return err
+}
+
+type DescribedType struct {
+	Descriptor any
+	Value      any
+}
+
+func (t DescribedType) Marshal(wr *buffer.Buffer) error {
+	wr.AppendByte(0x0) // descriptor constructor
+	err := Marshal(wr, t.Descriptor)
+	if err != nil {
+		return err
+	}
+	return Marshal(wr, t.Value)
+}
+
+func (t *DescribedType) Unmarshal(r *buffer.Buffer) error {
+	b, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	if b != 0x0 {
+		return fmt.Errorf("invalid described type header %02x", b)
+	}
+
+	err = Unmarshal(r, &t.Descriptor)
+	if err != nil {
+		return err
+	}
+	return Unmarshal(r, &t.Value)
+}
+
+func (t DescribedType) String() string {
+	return fmt.Sprintf("DescribedType{descriptor: %v, value: %v}",
+		t.Descriptor,
+		t.Value,
+	)
+}

--- a/internal/encoding/exported_types.go
+++ b/internal/encoding/exported_types.go
@@ -120,6 +120,7 @@ const (
 // SenderSettleMode specifies how the sender will settle messages.
 type SenderSettleMode uint8
 
+// Ptr returns a pointer to the value of m.
 func (m SenderSettleMode) Ptr() *SenderSettleMode {
 	return &m
 }
@@ -172,6 +173,7 @@ const (
 // ReceiverSettleMode specifies how the receiver will settle messages.
 type ReceiverSettleMode uint8
 
+// Ptr returns a pointer to the value of m.
 func (m ReceiverSettleMode) Ptr() *ReceiverSettleMode {
 	return &m
 }
@@ -207,6 +209,8 @@ func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
 	return err
 }
 
+// Filter is a set of named filters.
+// http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
 type Filter map[Symbol]*DescribedType
 
 // Marshal encodes the type into a buffer. It is not intended for public use.
@@ -341,11 +345,12 @@ func (e *Error) String() string {
 	)
 }
 
+// Error implements the error interface.
 func (e *Error) Error() string {
 	return e.String()
 }
 
-// symbol is an AMQP symbolic string.
+// Symbol is an AMQP symbolic string.
 type Symbol string
 
 // Marshal encodes the type into a buffer. It is not intended for public use.
@@ -403,6 +408,8 @@ func (u *UUID) Unmarshal(r *buffer.Buffer) error {
 	return err
 }
 
+// DescribedType is used for describing a filter.
+// http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set
 type DescribedType struct {
 	Descriptor any
 	Value      any

--- a/internal/encoding/types.go
+++ b/internal/encoding/types.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -114,200 +113,6 @@ const (
 	TypeCodeDeleteOnNoLinksOrMessages AMQPType = 0x2e
 )
 
-// Durability Policies
-const (
-	// No terminus state is retained durably.
-	DurabilityNone Durability = 0
-
-	// Only the existence and configuration of the terminus is
-	// retained durably.
-	DurabilityConfiguration Durability = 1
-
-	// In addition to the existence and configuration of the
-	// terminus, the unsettled state for durable messages is
-	// retained durably.
-	DurabilityUnsettledState Durability = 2
-)
-
-// Durability specifies the durability of a link.
-type Durability uint32
-
-func (d *Durability) String() string {
-	if d == nil {
-		return "<nil>"
-	}
-
-	switch *d {
-	case DurabilityNone:
-		return "none"
-	case DurabilityConfiguration:
-		return "configuration"
-	case DurabilityUnsettledState:
-		return "unsettled-state"
-	default:
-		return fmt.Sprintf("unknown durability %d", *d)
-	}
-}
-
-func (d Durability) Marshal(wr *buffer.Buffer) error {
-	return Marshal(wr, uint32(d))
-}
-
-func (d *Durability) Unmarshal(r *buffer.Buffer) error {
-	return Unmarshal(r, (*uint32)(d))
-}
-
-// Expiry Policies
-const (
-	// The expiry timer starts when terminus is detached.
-	ExpiryLinkDetach ExpiryPolicy = "link-detach"
-
-	// The expiry timer starts when the most recently
-	// associated session is ended.
-	ExpirySessionEnd ExpiryPolicy = "session-end"
-
-	// The expiry timer starts when most recently associated
-	// connection is closed.
-	ExpiryConnectionClose ExpiryPolicy = "connection-close"
-
-	// The terminus never expires.
-	ExpiryNever ExpiryPolicy = "never"
-)
-
-// ExpiryPolicy specifies when the expiry timer of a terminus
-// starts counting down from the timeout value.
-//
-// If the link is subsequently re-attached before the terminus is expired,
-// then the count down is aborted. If the conditions for the
-// terminus-expiry-policy are subsequently re-met, the expiry timer restarts
-// from its originally configured timeout value.
-type ExpiryPolicy Symbol
-
-func ValidateExpiryPolicy(e ExpiryPolicy) error {
-	switch e {
-	case ExpiryLinkDetach,
-		ExpirySessionEnd,
-		ExpiryConnectionClose,
-		ExpiryNever:
-		return nil
-	default:
-		return fmt.Errorf("unknown expiry-policy %q", e)
-	}
-}
-
-func (e ExpiryPolicy) Marshal(wr *buffer.Buffer) error {
-	return Symbol(e).Marshal(wr)
-}
-
-func (e *ExpiryPolicy) Unmarshal(r *buffer.Buffer) error {
-	err := Unmarshal(r, (*Symbol)(e))
-	if err != nil {
-		return err
-	}
-	return ValidateExpiryPolicy(*e)
-}
-
-func (e *ExpiryPolicy) String() string {
-	if e == nil {
-		return "<nil>"
-	}
-	return string(*e)
-}
-
-// Sender Settlement Modes
-const (
-	// Sender will send all deliveries initially unsettled to the receiver.
-	SenderSettleModeUnsettled SenderSettleMode = 0
-
-	// Sender will send all deliveries settled to the receiver.
-	SenderSettleModeSettled SenderSettleMode = 1
-
-	// Sender MAY send a mixture of settled and unsettled deliveries to the receiver.
-	SenderSettleModeMixed SenderSettleMode = 2
-)
-
-// SenderSettleMode specifies how the sender will settle messages.
-type SenderSettleMode uint8
-
-func (m SenderSettleMode) Ptr() *SenderSettleMode {
-	return &m
-}
-
-func (m *SenderSettleMode) String() string {
-	if m == nil {
-		return "<nil>"
-	}
-
-	switch *m {
-	case SenderSettleModeUnsettled:
-		return "unsettled"
-
-	case SenderSettleModeSettled:
-		return "settled"
-
-	case SenderSettleModeMixed:
-		return "mixed"
-
-	default:
-		return fmt.Sprintf("unknown sender mode %d", uint8(*m))
-	}
-}
-
-func (m SenderSettleMode) Marshal(wr *buffer.Buffer) error {
-	return Marshal(wr, uint8(m))
-}
-
-func (m *SenderSettleMode) Unmarshal(r *buffer.Buffer) error {
-	n, err := ReadUbyte(r)
-	*m = SenderSettleMode(n)
-	return err
-}
-
-// Receiver Settlement Modes
-const (
-	// Receiver will spontaneously settle all incoming transfers.
-	ReceiverSettleModeFirst ReceiverSettleMode = 0
-
-	// Receiver will only settle after sending the disposition to the
-	// sender and receiving a disposition indicating settlement of
-	// the delivery from the sender.
-	ReceiverSettleModeSecond ReceiverSettleMode = 1
-)
-
-// ReceiverSettleMode specifies how the receiver will settle messages.
-type ReceiverSettleMode uint8
-
-func (m ReceiverSettleMode) Ptr() *ReceiverSettleMode {
-	return &m
-}
-
-func (m *ReceiverSettleMode) String() string {
-	if m == nil {
-		return "<nil>"
-	}
-
-	switch *m {
-	case ReceiverSettleModeFirst:
-		return "first"
-
-	case ReceiverSettleModeSecond:
-		return "second"
-
-	default:
-		return fmt.Sprintf("unknown receiver mode %d", uint8(*m))
-	}
-}
-
-func (m ReceiverSettleMode) Marshal(wr *buffer.Buffer) error {
-	return Marshal(wr, uint8(m))
-}
-
-func (m *ReceiverSettleMode) Unmarshal(r *buffer.Buffer) error {
-	n, err := ReadUbyte(r)
-	*m = ReceiverSettleMode(n)
-	return err
-}
-
 type Role bool
 
 const (
@@ -387,35 +192,6 @@ func (u *Unsettled) Unmarshal(r *buffer.Buffer) error {
 	return nil
 }
 
-type Filter map[Symbol]*DescribedType
-
-func (f Filter) Marshal(wr *buffer.Buffer) error {
-	return writeMap(wr, f)
-}
-
-func (f *Filter) Unmarshal(r *buffer.Buffer) error {
-	count, err := readMapHeader(r)
-	if err != nil {
-		return err
-	}
-
-	m := make(Filter, count/2)
-	for i := uint32(0); i < count; i += 2 {
-		key, err := ReadString(r)
-		if err != nil {
-			return err
-		}
-		var value DescribedType
-		err = Unmarshal(r, &value)
-		if err != nil {
-			return err
-		}
-		m[Symbol(key)] = &value
-	}
-	*f = m
-	return nil
-}
-
 // peekMessageType reads the message type without
 // modifying any data.
 func PeekMessageType(buf []byte) (uint8, uint8, error) {
@@ -458,105 +234,6 @@ func tryReadNull(r *buffer.Buffer) bool {
 		return true
 	}
 	return false
-}
-
-// Annotations keys must be of type string, int, or int64.
-//
-// String keys are encoded as AMQP Symbols.
-type Annotations map[any]any
-
-func (a Annotations) Marshal(wr *buffer.Buffer) error {
-	return writeMap(wr, a)
-}
-
-func (a *Annotations) Unmarshal(r *buffer.Buffer) error {
-	count, err := readMapHeader(r)
-	if err != nil {
-		return err
-	}
-
-	m := make(Annotations, count/2)
-	for i := uint32(0); i < count; i += 2 {
-		key, err := ReadAny(r)
-		if err != nil {
-			return err
-		}
-		value, err := ReadAny(r)
-		if err != nil {
-			return err
-		}
-		m[key] = value
-	}
-	*a = m
-	return nil
-}
-
-// ErrCond is one of the error conditions defined in the AMQP spec.
-type ErrCond string
-
-func (ec ErrCond) Marshal(wr *buffer.Buffer) error {
-	return (Symbol)(ec).Marshal(wr)
-}
-
-func (ec *ErrCond) Unmarshal(r *buffer.Buffer) error {
-	s, err := ReadString(r)
-	*ec = ErrCond(s)
-	return err
-}
-
-/*
-<type name="error" class="composite" source="list">
-    <descriptor name="amqp:error:list" code="0x00000000:0x0000001d"/>
-    <field name="condition" type="symbol" requires="error-condition" mandatory="true"/>
-    <field name="description" type="string"/>
-    <field name="info" type="fields"/>
-</type>
-*/
-
-// Error is an AMQP error.
-type Error struct {
-	// A symbolic value indicating the error condition.
-	Condition ErrCond
-
-	// descriptive text about the error condition
-	//
-	// This text supplies any supplementary details not indicated by the condition field.
-	// This text can be logged as an aid to resolving issues.
-	Description string
-
-	// map carrying information about the error condition
-	Info map[string]any
-}
-
-func (e *Error) Marshal(wr *buffer.Buffer) error {
-	return MarshalComposite(wr, TypeCodeError, []MarshalField{
-		{Value: &e.Condition, Omit: false},
-		{Value: &e.Description, Omit: e.Description == ""},
-		{Value: e.Info, Omit: len(e.Info) == 0},
-	})
-}
-
-func (e *Error) Unmarshal(r *buffer.Buffer) error {
-	return UnmarshalComposite(r, TypeCodeError, []UnmarshalField{
-		{Field: &e.Condition, HandleNull: func() error { return errors.New("Error.Condition is required") }},
-		{Field: &e.Description},
-		{Field: &e.Info},
-	}...)
-}
-
-func (e *Error) String() string {
-	if e == nil {
-		return "*Error(nil)"
-	}
-	return fmt.Sprintf("*Error{Condition: %s, Description: %s, Info: %v}",
-		e.Condition,
-		e.Description,
-		e.Info,
-	)
-}
-
-func (e *Error) Error() string {
-	return e.String()
 }
 
 /*
@@ -735,31 +412,6 @@ func (sm *StateModified) String() string {
 	return fmt.Sprintf("Modified{DeliveryFailed: %t, UndeliverableHere: %t, MessageAnnotations: %v}", sm.DeliveryFailed, sm.UndeliverableHere, sm.MessageAnnotations)
 }
 
-// symbol is an AMQP symbolic string.
-type Symbol string
-
-func (s Symbol) Marshal(wr *buffer.Buffer) error {
-	l := len(s)
-	switch {
-	// Sym8
-	case l < 256:
-		wr.Append([]byte{
-			byte(TypeCodeSym8),
-			byte(l),
-		})
-		wr.AppendString(string(s))
-
-	// Sym32
-	case uint(l) < math.MaxUint32:
-		wr.AppendByte(uint8(TypeCodeSym32))
-		wr.AppendUint32(uint32(l))
-		wr.AppendString(string(s))
-	default:
-		return errors.New("too long")
-	}
-	return nil
-}
-
 type Milliseconds time.Duration
 
 func (m Milliseconds) Marshal(wr *buffer.Buffer) error {
@@ -872,36 +524,6 @@ func (m *mapSymbolAny) Unmarshal(r *buffer.Buffer) error {
 	return nil
 }
 
-// UUID is a 128 bit identifier as defined in RFC 4122.
-type UUID [16]byte
-
-// String returns the hex encoded representation described in RFC 4122, Section 3.
-func (u UUID) String() string {
-	var buf [36]byte
-	hex.Encode(buf[:8], u[:4])
-	buf[8] = '-'
-	hex.Encode(buf[9:13], u[4:6])
-	buf[13] = '-'
-	hex.Encode(buf[14:18], u[6:8])
-	buf[18] = '-'
-	hex.Encode(buf[19:23], u[8:10])
-	buf[23] = '-'
-	hex.Encode(buf[24:], u[10:])
-	return string(buf[:])
-}
-
-func (u UUID) Marshal(wr *buffer.Buffer) error {
-	wr.AppendByte(byte(TypeCodeUUID))
-	wr.Append(u[:])
-	return nil
-}
-
-func (u *UUID) Unmarshal(r *buffer.Buffer) error {
-	un, err := readUUID(r)
-	*u = un
-	return err
-}
-
 type LifetimePolicy uint8
 
 const (
@@ -931,44 +553,6 @@ func (p *LifetimePolicy) Unmarshal(r *buffer.Buffer) error {
 	}
 	*p = LifetimePolicy(typ)
 	return nil
-}
-
-type DescribedType struct {
-	Descriptor any
-	Value      any
-}
-
-func (t DescribedType) Marshal(wr *buffer.Buffer) error {
-	wr.AppendByte(0x0) // descriptor constructor
-	err := Marshal(wr, t.Descriptor)
-	if err != nil {
-		return err
-	}
-	return Marshal(wr, t.Value)
-}
-
-func (t *DescribedType) Unmarshal(r *buffer.Buffer) error {
-	b, err := r.ReadByte()
-	if err != nil {
-		return err
-	}
-
-	if b != 0x0 {
-		return fmt.Errorf("invalid described type header %02x", b)
-	}
-
-	err = Unmarshal(r, &t.Descriptor)
-	if err != nil {
-		return err
-	}
-	return Unmarshal(r, &t.Value)
-}
-
-func (t DescribedType) String() string {
-	return fmt.Sprintf("DescribedType{descriptor: %v, value: %v}",
-		t.Descriptor,
-		t.Value,
-	)
 }
 
 // SLICES

--- a/internal/encoding/types.go
+++ b/internal/encoding/types.go
@@ -113,6 +113,18 @@ const (
 	TypeCodeDeleteOnNoLinksOrMessages AMQPType = 0x2e
 )
 
+func ValidateExpiryPolicy(e ExpiryPolicy) error {
+	switch e {
+	case ExpiryLinkDetach,
+		ExpirySessionEnd,
+		ExpiryConnectionClose,
+		ExpiryNever:
+		return nil
+	default:
+		return fmt.Errorf("unknown expiry-policy %q", e)
+	}
+}
+
 type Role bool
 
 const (


### PR DESCRIPTION
This makes it clear which internal types are publicly exported.

No functional changes.