### PR TITLE
Reviving DrainCredit(), adding back into Receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Added support in both `Sender` and `Receiver` to set the `desired-capabilities` in their ATTACH frames, using DesiredCapabilities in their respective Options.
+* Added Receiver.DrainCredit, which allows you to drain credits from a link.
 
 ### Bugs Fixed
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -1181,6 +1181,77 @@ func TestMultipleSendersSharedSession(t *testing.T) {
 	checkLeaks()
 }
 
+func TestDrainingLink(t *testing.T) {
+	if localBrokerAddr == "" {
+		t.Skip()
+	}
+
+	queue := fmt.Sprintf("TestDrainingLink-%d", rand.Int63())
+
+	conn, err := amqp.Dial(context.Background(), localBrokerAddr, nil)
+	require.NoError(t, err)
+
+	session, err := conn.NewSession(context.Background(), nil)
+	require.NoError(t, err)
+
+	receiver, err := session.NewReceiver(context.Background(), queue, &amqp.ReceiverOptions{
+		Credit:         -1,
+		SettlementMode: amqp.ReceiverSettleModeSecond.Ptr(),
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		err := receiver.Close(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// we'll send one message right now
+	send := func(count int) {
+		sender, err := session.NewSender(context.Background(), queue, nil)
+		require.NoError(t, err)
+
+		defer func() {
+			err := sender.Close(context.Background())
+			require.NoError(t, err)
+		}()
+
+		data := make([]byte, 1000)
+
+		for i := 0; i < count; i++ {
+			err = sender.Send(context.Background(), &amqp.Message{
+				Value: data,
+			}, nil)
+			require.NoError(t, err)
+		}
+	}
+
+	const totalSent = 1
+
+	// Send one message, but ask for two. This guarantees that we'll leave one active credit after
+	// we receive our single message.
+	send(totalSent)
+	err = receiver.IssueCredit(totalSent + 1) // request 2 messages, even though 1 is available. This will leave us with 1 extra credit.
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, 1, len(receiveAllPrefetched(receiver)), "we received the single message that was available")
+
+	// now we'll drain - there's a single active credit that will now get thrown away
+	err = receiver.DrainCredit(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, receiveAllPrefetched(receiver)) // there weren't any messages to send to us
+
+	// Our receiver should have _zero_ active credits at this point
+	// because we've completed drain. We'll send a message _but_ since we have no
+	// active credits nothing will be sent to _our_ receiver.
+	send(1)
+	time.Sleep(200 * time.Millisecond)
+
+	// we haven't issued any credits so we _shouldn't_ get anything here unless there's a bug in
+	// our receiver, or in the broker.
+	require.Empty(t, receiveAllPrefetched(receiver))
+}
+
 func TestSenderNullValue(t *testing.T) {
 	if localBrokerAddr == "" {
 		t.Skip()
@@ -1247,4 +1318,18 @@ func testClose(t testing.TB, close func(context.Context) error) {
 	if err != nil {
 		t.Errorf("error closing: %+v\n", err)
 	}
+}
+
+func receiveAllPrefetched(receiver *amqp.Receiver) []*amqp.Message {
+	var messages []*amqp.Message
+
+	for {
+		if msg := receiver.Prefetched(); msg == nil {
+			break
+		} else {
+			messages = append(messages, msg)
+		}
+	}
+
+	return messages
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1191,6 +1191,10 @@ func TestDrainingLink(t *testing.T) {
 	conn, err := amqp.Dial(context.Background(), localBrokerAddr, nil)
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
 	session, err := conn.NewSession(context.Background(), nil)
 	require.NoError(t, err)
 

--- a/receiver.go
+++ b/receiver.go
@@ -66,6 +66,29 @@ func (r *Receiver) IssueCredit(credit uint32) error {
 	return nil
 }
 
+// DrainCredit sets the drain flag on the next outbound FLOW frame and blocks until
+// the corresponding FLOW frame is received. While a drain is in progress, messages
+// can continue to arrive. After a drain completes, the Receiver will have
+// zero active credits. To begin receiving again, call IssueCredit() to add active credits
+// to your Receiver.
+//
+// You may only have a single Drain operation active, at a time.
+//
+// If the context passed to DrainCredit expires or is cancelled then the receiver's
+// issued credits should be considered ambiguous.
+//
+// Returns nil if the drain has completed, error otherwise.
+//
+// NOTE: The behavior of drain is optional, as per the AMQP spec. Check with your individual
+// broker's documentation for implementation details.
+func (r *Receiver) DrainCredit(ctx context.Context) error {
+	if r.autoSendFlow {
+		return errors.New("drain can only be used with receiver links using manual credit management")
+	}
+
+	return r.creditor.Drain(ctx, r)
+}
+
 // Prefetched returns the next message that is stored in the Receiver's
 // prefetch cache. It does NOT wait for the remote sender to send messages
 // and returns immediately if the prefetch cache is empty. To receive from the


### PR DESCRIPTION
We originally removed drain for https://github.com/Azure/go-amqp/issues/255, but it's functionality we do need for Service Bus again, for an upcoming fix.

The original reason for removal was about compliance to the spec, however, I think the broker in question (ActiveMQ) is actually _out_ of spec.

Here's the relevant section, from the FLOW frame documentation. I've added some line breaks, to make it more clear what each piece is:

> The drain flag indicates how the sender SHOULD behave when insufficient messages are available to consume the current link-credit. If set, the sender will:
>
> (after sending all available messages) 
>
> advance the delivery-count as much as possible, consuming all link-credit, 
>
> and send the flow state to the receiver. 

This is what the current implementation of drain does, and relies on, and thus seems compliant.

I'm still reviewing some of the tests, but I wanted to get a head start on reviewing this change.