### PR TITLE
Add a callback for link props in flow frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.6.0 (TBD)
+## 1.6.0 (2026-04-22)
 
 * Add SourceDistributionMode to ReceiverOptions
+* Add a callback for link state properties in the flow frame. This allows applications to react to the
+  properties sent by the broker.
 
 ## 1.5.1 (2026-01-07)
 

--- a/link_options.go
+++ b/link_options.go
@@ -44,6 +44,9 @@ type SenderOptions struct {
 	// Properties sets an entry in the link properties map sent to the server.
 	Properties map[string]any
 
+	// OnLinkStateProperties is called when a flow frame with link state properties is received.
+	OnLinkStateProperties func(map[string]any)
+
 	// RequestedReceiverSettleMode sets the requested receiver settlement mode.
 	//
 	// If a settlement mode is explicitly set and the server does not
@@ -147,6 +150,9 @@ type ReceiverOptions struct {
 
 	// Properties sets an entry in the link properties map sent to the server.
 	Properties map[string]any
+
+	// OnLinkStateProperties is called when a flow frame with link state properties is received.
+	OnLinkStateProperties func(map[string]any)
 
 	// RequestedSenderSettleMode sets the requested sender settlement mode.
 	//

--- a/receiver.go
+++ b/receiver.go
@@ -40,9 +40,10 @@ type Receiver struct {
 	settlementCount   uint32     // the count of settled messages
 	settlementCountMu sync.Mutex // must be held when accessing settlementCount
 
-	autoSendFlow bool     // automatically send flow frames as credit becomes available
-	inFlight     inFlight // used to track message disposition when rcv-settle-mode == second
-	creditor     creditor // manages credits via calls to IssueCredit/DrainCredit
+	autoSendFlow          bool                 // automatically send flow frames as credit becomes available
+	inFlight              inFlight             // used to track message disposition when rcv-settle-mode == second
+	creditor              creditor             // manages credits via calls to IssueCredit/DrainCredit
+	onLinkStateProperties func(map[string]any) // callback for when link props are set in the flow frame
 }
 
 // IssueCredit adds credits to be requested in the next flow request.
@@ -502,6 +503,7 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	if opts.SourceDistributionMode != "" {
 		r.l.source.DistributionMode = opts.SourceDistributionMode
 	}
+	r.onLinkStateProperties = opts.OnLinkStateProperties
 	return r, nil
 }
 
@@ -713,6 +715,14 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 
 	// flow control frame
 	case *frames.PerformFlow:
+		if fr.Properties != nil && r.onLinkStateProperties != nil {
+			props := make(map[string]any)
+			for k, v := range fr.Properties {
+				props[string(k)] = v
+			}
+			r.onLinkStateProperties(props)
+		}
+
 		if !fr.Echo {
 			// if the 'drain' flag has been set in the frame sent to the _receiver_ then
 			// we signal whomever is waiting (the service has seen and acknowledged our drain)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1528,6 +1528,86 @@ func TestReceiverProperties(t *testing.T) {
 	require.NoError(t, conn.Close())
 }
 
+func TestReceiverOnLinkStateProperties(t *testing.T) {
+	var netConn *fake.NetConn
+
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		switch ff := req.(type) {
+		case *fake.AMQPProto:
+			return newResponse(fake.ProtoHeader(fake.ProtoAMQP))
+		case *frames.PerformOpen:
+			return newResponse(fake.PerformOpen("test"))
+		case *frames.PerformBegin:
+			return newResponse(fake.PerformBegin(0, remoteChannel))
+		case *frames.PerformAttach:
+			return newResponse(fake.ReceiverAttach(0, ff.Name, 0, encoding.ReceiverSettleModeFirst, ff.Source.Filter))
+		case *frames.PerformFlow:
+			// after the receiver sends its initial flow, send back a flow with properties
+			if ff.Handle != nil {
+				flowWithProps := &frames.PerformFlow{
+					NextIncomingID: ff.NextIncomingID,
+					IncomingWindow: 1000,
+					NextOutgoingID: 0,
+					OutgoingWindow: 1000,
+					Handle:         ff.Handle,
+					DeliveryCount:  ff.DeliveryCount,
+					LinkCredit:     ff.LinkCredit,
+					Properties: map[encoding.Symbol]any{
+						"foo:active": true,
+					},
+				}
+				b, err := fake.EncodeFrame(frames.TypeAMQP, 0, flowWithProps)
+				if err != nil {
+					return fake.Response{}, err
+				}
+				netConn.SendFrame(b)
+			}
+			return fake.Response{}, nil
+		case *fake.KeepAlive:
+			return fake.Response{}, nil
+		case *frames.PerformDetach:
+			return newResponse(fake.PerformDetach(0, ff.Handle, nil))
+		case *frames.PerformClose:
+			return newResponse(fake.PerformClose(nil))
+		case *frames.PerformEnd:
+			return newResponse(fake.PerformEnd(0, nil))
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+
+	received := make(chan map[string]any, 1)
+	netConn = fake.NewNetConn(responder, fake.NetConnOptions{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	_, err = session.NewReceiver(ctx, "source", &ReceiverOptions{
+		OnLinkStateProperties: func(props map[string]any) {
+			received <- props
+		},
+	})
+	cancel()
+	require.NoError(t, err)
+
+	select {
+	case props := <-received:
+		require.Equal(t, map[string]any{"foo:active": true}, props)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for link state properties callback")
+	}
+
+	require.NoError(t, netConn.Close())
+}
+
 func TestReceiverAttachDesiredCapabilities(t *testing.T) {
 	t.Run("NilDesiredCaps", func(t *testing.T) {
 		require.Nil(t, runToAttachWithOptions(t, ReceiverOptions{

--- a/sender.go
+++ b/sender.go
@@ -22,6 +22,8 @@ type Sender struct {
 	buf             buffer.Buffer
 	nextDeliveryTag uint64
 	rollback        chan struct{}
+
+	onLinkStateProperties func(map[string]any)
 }
 
 // LinkName() is the name of the link used for this Sender.
@@ -399,6 +401,9 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 	if opts.TargetExpiryTimeout != 0 {
 		s.l.target.Timeout = opts.TargetExpiryTimeout
 	}
+	if opts.OnLinkStateProperties != nil {
+		s.onLinkStateProperties = opts.OnLinkStateProperties
+	}
 	return s, nil
 }
 
@@ -535,6 +540,14 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 	switch fr := fr.(type) {
 	// flow control frame
 	case *frames.PerformFlow:
+		if fr.Properties != nil && s.onLinkStateProperties != nil {
+			props := make(map[string]any)
+			for k, v := range fr.Properties {
+				props[string(k)] = v
+			}
+			s.onLinkStateProperties(props)
+		}
+
 		// the sender's link-credit variable MUST be set according to this formula when flow information is given by the receiver:
 		// link-credit(snd) := delivery-count(rcv) + link-credit(rcv) - delivery-count(snd)
 		linkCredit := *fr.LinkCredit - s.l.deliveryCount

--- a/sender_test.go
+++ b/sender_test.go
@@ -1457,6 +1457,72 @@ func TestSenderProperties(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
+func TestSenderOnLinkStateProperties(t *testing.T) {
+	linkCredit := uint32(1)
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow, *fake.KeepAlive:
+			return fake.Response{}, nil
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+
+	received := make(chan map[string]any, 1)
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	sender, err := session.NewSender(ctx, "target", &SenderOptions{
+		OnLinkStateProperties: func(props map[string]any) {
+			received <- props
+		},
+	})
+	cancel()
+	require.NoError(t, err)
+
+	nextIncomingID := uint32(1)
+	b, err := fake.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformFlow{
+		Handle:         &sender.l.outputHandle,
+		NextIncomingID: &nextIncomingID,
+		IncomingWindow: 100,
+		OutgoingWindow: 100,
+		NextOutgoingID: 1,
+		LinkCredit:     &linkCredit,
+		Properties: map[encoding.Symbol]any{
+			"foo:active": true,
+		},
+	})
+	require.NoError(t, err)
+	netConn.SendFrame(b)
+
+	select {
+	case props := <-received:
+		require.Equal(t, map[string]any{"foo:active": true}, props)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for link state properties callback")
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = sender.Close(ctx)
+	cancel()
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
+}
+
 func TestSenderSendWithReceipt(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
The flow frame may contain a map with link state properties. To allow applications to react to that information, this commit introduces a callback, which is fired, when link properties are set in the flow frame.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
