### PR TITLE
Faster publishing and consumption (mostly thorugh async operations)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -22,10 +22,11 @@ import (
 
 // Default connection options
 const (
-	defaultIdleTimeout  = 1 * time.Minute
-	defaultMaxFrameSize = 65536
-	defaultMaxSessions  = 65536
-	defaultWriteTimeout = 30 * time.Second
+	defaultIdleTimeout     = 1 * time.Minute
+	defaultMaxFrameSize    = 65536
+	defaultMaxSessions     = 65536
+	defaultWriteTimeout    = 30 * time.Second
+	defaultWriteQueueDepth = 1
 )
 
 // ConnOptions contains the optional settings for configuring an AMQP connection.
@@ -84,6 +85,13 @@ type ConnOptions struct {
 	//
 	// Default: 30s
 	WriteTimeout time.Duration
+
+	// WriteQueueDepth sets the number of frames that can be queued for
+	// writing before the sender blocks. Larger values allow more
+	// batching of frames into fewer syscalls at the cost of memory.
+	//
+	// Default: 1.
+	WriteQueueDepth int
 
 	// test hook
 	dialer dialer
@@ -175,10 +183,11 @@ type Conn struct {
 	rxErr  error         // contains last error reading from c.net; DO NOT TOUCH outside of connReader until rxDone has been closed!
 
 	// connWriter
-	txFrame chan frameEnvelope // AMQP frames to be sent by connWriter
-	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
-	txDone  chan struct{}      // closed when connWriter exits
-	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	txFrame      chan frameEnvelope // AMQP frames to be sent by connWriter
+	txBuf        buffer.Buffer      // buffer for marshaling frames before transmitting
+	txDone       chan struct{}      // closed when connWriter exits
+	txErr        error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	batchTimeout time.Duration      // write deadline for the current batch, set by connWriter
 }
 
 // used to abstract the underlying dialer for testing purposes
@@ -253,6 +262,11 @@ func dialConn(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error
 }
 
 func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
+	writeQueueDepth := defaultWriteQueueDepth
+	if opts != nil && opts.WriteQueueDepth > 0 {
+		writeQueueDepth = opts.WriteQueueDepth
+	}
+
 	c := &Conn{
 		dialer:            defaultDialer{},
 		net:               netConn,
@@ -264,7 +278,7 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		done:              make(chan struct{}),
 		rxtxExit:          make(chan struct{}),
 		rxDone:            make(chan struct{}),
-		txFrame:           make(chan frameEnvelope),
+		txFrame:           make(chan frameEnvelope, writeQueueDepth),
 		txDone:            make(chan struct{}),
 		sessionsByChannel: map[uint16]*Session{},
 		writeTimeout:      defaultWriteTimeout,
@@ -808,6 +822,9 @@ func (c *Conn) connWriter() {
 		keepalive = ticker.C
 	}
 
+	// batch collects frameContexts so we can signal them after a successful flush
+	var batch []*frameContext
+
 	var err error
 	for {
 		if err != nil {
@@ -819,24 +836,35 @@ func (c *Conn) connWriter() {
 		select {
 		// frame write request
 		case env := <-c.txFrame:
-			timeout, ctxErr := c.getWriteTimeout(env.FrameCtx.Ctx)
-			if ctxErr != nil {
-				debug.Log(1, "TX (connWriter %p) getWriteTimeout: %s: %s", c, ctxErr.Error(), env.Frame)
-				if env.FrameCtx.Done != nil {
-					// the error MUST be set before closing the channel
-					env.FrameCtx.Err = ctxErr
-					close(env.FrameCtx.Done)
-				}
+			c.txBuf.Reset()
+			batch = batch[:0]
+
+			// marshal the first frame
+			if marshalErr := c.marshalFrame(&env, &batch); marshalErr != nil {
+				err = marshalErr
 				continue
 			}
 
-			debug.Log(0, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
-			err = c.writeFrame(timeout, env.Frame)
-			if err == nil && env.FrameCtx.Done != nil {
-				close(env.FrameCtx.Done)
+			// drain additional pending frames without blocking
+		DrainLoop:
+			for {
+				select {
+				case env := <-c.txFrame:
+					if marshalErr := c.marshalFrame(&env, &batch); marshalErr != nil {
+						err = marshalErr
+						break DrainLoop
+					}
+				default:
+					break DrainLoop
+				}
 			}
-			// in the event of write failure, Conn will close and a
-			// *ConnError will be propagated to all of the sessions/link.
+
+			if err != nil {
+				continue
+			}
+
+			// flush the entire batch in a single write
+			err = c.flushTxBuf(batch)
 
 		// keepalive timer
 		case <-keepalive:
@@ -845,20 +873,9 @@ func (c *Conn) connWriter() {
 			if _, err = c.net.Write(keepaliveFrame); err != nil {
 				err = &ConnError{inner: err}
 			}
-			// It would be slightly more efficient in terms of network
-			// resources to reset the timer each time a frame is sent.
-			// However, keepalives are small (8 bytes) and the interval
-			// is usually on the order of minutes. It does not seem
-			// worth it to add extra operations in the write path to
-			// avoid. (To properly reset a timer it needs to be stopped,
-			// possibly drained, then reset.)
 
 		// connection complete
 		case <-c.rxtxExit:
-			// send close performative.  note that the spec says we
-			// SHOULD wait for the ack but we don't HAVE to, in order
-			// to be resilient to bad actors etc.  so we just send
-			// the close performative and exit.
 			fr := frames.Frame{
 				Type: frames.TypeAMQP,
 				Body: &frames.PerformClose{},
@@ -868,6 +885,65 @@ func (c *Conn) connWriter() {
 			return
 		}
 	}
+}
+
+// marshalFrame serializes a single frame into c.txBuf for batched writing.
+// On context error, it signals the frameCtx and returns nil (skip this frame).
+// On marshal/size error, it returns a terminal error.
+func (c *Conn) marshalFrame(env *frameEnvelope, batch *[]*frameContext) error {
+	timeout, ctxErr := c.getWriteTimeout(env.FrameCtx.Ctx)
+	if ctxErr != nil {
+		debug.Log(1, "TX (connWriter %p) getWriteTimeout: %s: %s", c, ctxErr.Error(), env.Frame)
+		if env.FrameCtx.Done != nil {
+			env.FrameCtx.Err = ctxErr
+			close(env.FrameCtx.Done)
+		}
+		return nil
+	}
+
+	// remember the timeout from the first frame in the batch for the write deadline
+	if len(*batch) == 0 {
+		c.batchTimeout = timeout
+	}
+
+	startLen := c.txBuf.Len()
+	if writeErr := frames.Write(&c.txBuf, env.Frame); writeErr != nil {
+		return &ConnError{inner: writeErr}
+	}
+
+	frameSize := c.txBuf.Len() - startLen
+	if uint64(frameSize) > uint64(c.peerMaxFrameSize) {
+		return &ConnError{inner: fmt.Errorf("%T frame size %d larger than peer's max frame size %d", env.Frame, frameSize, c.peerMaxFrameSize)}
+	}
+
+	debug.Log(0, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+	*batch = append(*batch, env.FrameCtx)
+	return nil
+}
+
+// flushTxBuf writes the accumulated txBuf to the network and signals all batched frameContexts.
+func (c *Conn) flushTxBuf(batch []*frameContext) error {
+	if c.txBuf.Len() == 0 {
+		return nil
+	}
+
+	if c.batchTimeout == 0 {
+		_ = c.net.SetWriteDeadline(time.Time{})
+	} else {
+		_ = c.net.SetWriteDeadline(time.Now().Add(c.batchTimeout))
+	}
+
+	_, writeErr := c.net.Write(c.txBuf.Bytes())
+	if writeErr != nil {
+		return &ConnError{inner: writeErr}
+	}
+
+	for _, fc := range batch {
+		if fc.Done != nil {
+			close(fc.Done)
+		}
+	}
+	return nil
 }
 
 // writeFrame writes a frame to the network.

--- a/conn.go
+++ b/conn.go
@@ -22,10 +22,11 @@ import (
 
 // Default connection options
 const (
-	defaultIdleTimeout  = 1 * time.Minute
-	defaultMaxFrameSize = 65536
-	defaultMaxSessions  = 65536
-	defaultWriteTimeout = 30 * time.Second
+	defaultIdleTimeout     = 1 * time.Minute
+	defaultMaxFrameSize    = 65536
+	defaultMaxSessions     = 65536
+	defaultWriteTimeout    = 30 * time.Second
+	defaultWriteQueueDepth = 1
 )
 
 // ConnOptions contains the optional settings for configuring an AMQP connection.
@@ -84,6 +85,13 @@ type ConnOptions struct {
 	//
 	// Default: 30s
 	WriteTimeout time.Duration
+
+	// WriteQueueDepth sets the number of frames that can be queued for
+	// writing before the sender blocks. Larger values allow more
+	// batching of frames into fewer syscalls at the cost of memory.
+	//
+	// Default: 1.
+	WriteQueueDepth int
 
 	// test hook
 	dialer dialer
@@ -175,10 +183,11 @@ type Conn struct {
 	rxErr  error         // contains last error reading from c.net; DO NOT TOUCH outside of connReader until rxDone has been closed!
 
 	// connWriter
-	txFrame chan frameEnvelope // AMQP frames to be sent by connWriter
-	txBuf   buffer.Buffer      // buffer for marshaling frames before transmitting
-	txDone  chan struct{}      // closed when connWriter exits
-	txErr   error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	txFrame      chan frameEnvelope // AMQP frames to be sent by connWriter
+	txBuf        buffer.Buffer      // buffer for marshaling frames before transmitting
+	txDone       chan struct{}      // closed when connWriter exits
+	txErr        error              // contains last error writing to c.net; DO NOT TOUCH outside of connWriter until txDone has been closed!
+	batchTimeout time.Duration      // write deadline for the current batch, set by connWriter
 }
 
 // used to abstract the underlying dialer for testing purposes
@@ -253,6 +262,11 @@ func dialConn(ctx context.Context, addr string, opts *ConnOptions) (*Conn, error
 }
 
 func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
+	writeQueueDepth := defaultWriteQueueDepth
+	if opts != nil && opts.WriteQueueDepth > 0 {
+		writeQueueDepth = opts.WriteQueueDepth
+	}
+
 	c := &Conn{
 		dialer:            defaultDialer{},
 		net:               netConn,
@@ -264,7 +278,7 @@ func newConn(netConn net.Conn, opts *ConnOptions) (*Conn, error) {
 		done:              make(chan struct{}),
 		rxtxExit:          make(chan struct{}),
 		rxDone:            make(chan struct{}),
-		txFrame:           make(chan frameEnvelope),
+		txFrame:           make(chan frameEnvelope, writeQueueDepth),
 		txDone:            make(chan struct{}),
 		sessionsByChannel: map[uint16]*Session{},
 		writeTimeout:      defaultWriteTimeout,
@@ -811,6 +825,9 @@ func (c *Conn) connWriter() {
 		keepalive = ticker.C
 	}
 
+	// batch collects frameContexts so we can signal them after a successful flush
+	var batch []*frameContext
+
 	var err error
 	for {
 		if err != nil {
@@ -822,24 +839,35 @@ func (c *Conn) connWriter() {
 		select {
 		// frame write request
 		case env := <-c.txFrame:
-			timeout, ctxErr := c.getWriteTimeout(env.FrameCtx.Ctx)
-			if ctxErr != nil {
-				debug.Log(1, "TX (connWriter %p) getWriteTimeout: %s: %s", c, ctxErr.Error(), env.Frame)
-				if env.FrameCtx.Done != nil {
-					// the error MUST be set before closing the channel
-					env.FrameCtx.Err = ctxErr
-					close(env.FrameCtx.Done)
-				}
+			c.txBuf.Reset()
+			batch = batch[:0]
+
+			// marshal the first frame
+			if marshalErr := c.marshalFrame(&env, &batch); marshalErr != nil {
+				err = marshalErr
 				continue
 			}
 
-			debug.Log(0, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
-			err = c.writeFrame(timeout, env.Frame)
-			if err == nil && env.FrameCtx.Done != nil {
-				close(env.FrameCtx.Done)
+			// drain additional pending frames without blocking
+		DrainLoop:
+			for {
+				select {
+				case env := <-c.txFrame:
+					if marshalErr := c.marshalFrame(&env, &batch); marshalErr != nil {
+						err = marshalErr
+						break DrainLoop
+					}
+				default:
+					break DrainLoop
+				}
 			}
-			// in the event of write failure, Conn will close and a
-			// *ConnError will be propagated to all of the sessions/link.
+
+			if err != nil {
+				continue
+			}
+
+			// flush the entire batch in a single write
+			err = c.flushTxBuf(batch)
 
 		// keepalive timer
 		case <-keepalive:
@@ -848,20 +876,9 @@ func (c *Conn) connWriter() {
 			if _, err = c.net.Write(keepaliveFrame); err != nil {
 				err = &ConnError{inner: err}
 			}
-			// It would be slightly more efficient in terms of network
-			// resources to reset the timer each time a frame is sent.
-			// However, keepalives are small (8 bytes) and the interval
-			// is usually on the order of minutes. It does not seem
-			// worth it to add extra operations in the write path to
-			// avoid. (To properly reset a timer it needs to be stopped,
-			// possibly drained, then reset.)
 
 		// connection complete
 		case <-c.rxtxExit:
-			// send close performative.  note that the spec says we
-			// SHOULD wait for the ack but we don't HAVE to, in order
-			// to be resilient to bad actors etc.  so we just send
-			// the close performative and exit.
 			fr := frames.Frame{
 				Type: frames.TypeAMQP,
 				Body: &frames.PerformClose{},
@@ -871,6 +888,65 @@ func (c *Conn) connWriter() {
 			return
 		}
 	}
+}
+
+// marshalFrame serializes a single frame into c.txBuf for batched writing.
+// On context error, it signals the frameCtx and returns nil (skip this frame).
+// On marshal/size error, it returns a terminal error.
+func (c *Conn) marshalFrame(env *frameEnvelope, batch *[]*frameContext) error {
+	timeout, ctxErr := c.getWriteTimeout(env.FrameCtx.Ctx)
+	if ctxErr != nil {
+		debug.Log(1, "TX (connWriter %p) getWriteTimeout: %s: %s", c, ctxErr.Error(), env.Frame)
+		if env.FrameCtx.Done != nil {
+			env.FrameCtx.Err = ctxErr
+			close(env.FrameCtx.Done)
+		}
+		return nil
+	}
+
+	// remember the timeout from the first frame in the batch for the write deadline
+	if len(*batch) == 0 {
+		c.batchTimeout = timeout
+	}
+
+	startLen := c.txBuf.Len()
+	if writeErr := frames.Write(&c.txBuf, env.Frame); writeErr != nil {
+		return &ConnError{inner: writeErr}
+	}
+
+	frameSize := c.txBuf.Len() - startLen
+	if uint64(frameSize) > uint64(c.peerMaxFrameSize) {
+		return &ConnError{inner: fmt.Errorf("%T frame size %d larger than peer's max frame size %d", env.Frame, frameSize, c.peerMaxFrameSize)}
+	}
+
+	debug.Log(0, "TX (connWriter %p) timeout %s: %s", c, timeout, env.Frame)
+	*batch = append(*batch, env.FrameCtx)
+	return nil
+}
+
+// flushTxBuf writes the accumulated txBuf to the network and signals all batched frameContexts.
+func (c *Conn) flushTxBuf(batch []*frameContext) error {
+	if c.txBuf.Len() == 0 {
+		return nil
+	}
+
+	if c.batchTimeout == 0 {
+		_ = c.net.SetWriteDeadline(time.Time{})
+	} else {
+		_ = c.net.SetWriteDeadline(time.Now().Add(c.batchTimeout))
+	}
+
+	_, writeErr := c.net.Write(c.txBuf.Bytes())
+	if writeErr != nil {
+		return &ConnError{inner: writeErr}
+	}
+
+	for _, fc := range batch {
+		if fc.Done != nil {
+			close(fc.Done)
+		}
+	}
+	return nil
 }
 
 // writeFrame writes a frame to the network.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -68,10 +68,15 @@ func senderFrameHandler(channel uint16, ssm encoding.SenderSettleMode) frameHand
 func senderFrameHandlerNoUnhandled(channel uint16, ssm encoding.SenderSettleMode) frameHandler {
 	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
 		resp, err := senderFrameHandler(channel, ssm)(remoteChannel, req)
-		if resp.Payload == nil && err == nil {
+		if resp.Payload != nil || err != nil {
+			return resp, err
+		}
+		switch req.(type) {
+		case *fake.KeepAlive:
+			return fake.Response{}, nil
+		default:
 			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
 		}
-		return resp, err
 	}
 }
 

--- a/internal/fake/net_conn.go
+++ b/internal/fake/net_conn.go
@@ -40,7 +40,7 @@ func NewNetConn(resp func(remoteChannel uint16, fr frames.FrameBody) (Response, 
 		// used to serialize writes so the frames are returned in their specified order.
 		// buffering is necessary because write() will sleep when a write delay was
 		// specified and we don't want to stall Write(). the size was arbitrarily picked.
-		writeResp: make(chan Response, 10),
+		writeResp: make(chan Response, 100),
 		close:     make(chan struct{}),
 		readDL:    newNopTimer(), // default, no deadline
 	}
@@ -167,26 +167,30 @@ func (n *NetConn) Write(b []byte) (int, error) {
 		// no fake write error
 	}
 
-	remoteChannel, frame, err := decodeFrame(b)
-	if err != nil {
-		return 0, err
-	}
-	resp, err := n.resp(remoteChannel, frame)
-	if err != nil {
-		return 0, err
-	}
-	if resp.Payload != nil {
-		select {
-		case n.writeResp <- resp:
-			// resp was sent to write()
-		default:
-			// this means we incorrectly sized writeResp.
-			// we do this to ensure that we never stall
-			// waiting to write to writeResp.
-			panic("writeResp full")
+	total := len(b)
+	for len(b) > 0 {
+		remoteChannel, frame, consumed, err := decodeFrameWithSize(b)
+		if err != nil {
+			return 0, err
 		}
+		resp, err := n.resp(remoteChannel, frame)
+		if err != nil {
+			return 0, err
+		}
+		if resp.Payload != nil {
+			select {
+			case n.writeResp <- resp:
+				// resp was sent to write()
+			default:
+				// this means we incorrectly sized writeResp.
+				// we do this to ensure that we never stall
+				// waiting to write to writeResp.
+				panic("writeResp full")
+			}
+		}
+		b = b[consumed:]
 	}
-	return len(b), nil
+	return total, nil
 }
 
 func (n *NetConn) write() {
@@ -436,29 +440,34 @@ func EncodeFrame(t frames.Type, channel uint16, f frames.FrameBody) ([]byte, err
 }
 
 func decodeFrame(b []byte) (uint16, frames.FrameBody, error) {
+	ch, fr, _, err := decodeFrameWithSize(b)
+	return ch, fr, err
+}
+
+func decodeFrameWithSize(b []byte) (uint16, frames.FrameBody, int, error) {
 	if len(b) > 3 && b[0] == 'A' && b[1] == 'M' && b[2] == 'Q' && b[3] == 'P' {
-		return 0, &AMQPProto{}, nil
+		return 0, &AMQPProto{}, 8, nil
 	}
 	buf := buffer.New(b)
 	header, err := frames.ParseHeader(buf)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, 0, err
 	}
 	bodySize := int64(header.Size - frames.HeaderSize)
 	if bodySize == 0 {
 		// keep alive frame
-		return 0, &KeepAlive{}, nil
+		return 0, &KeepAlive{}, int(header.Size), nil
 	}
 	// parse the frame
-	b, ok := buf.Next(bodySize)
+	body, ok := buf.Next(bodySize)
 	if !ok {
-		return 0, nil, err
+		return 0, nil, 0, err
 	}
-	fr, err := frames.ParseBody(buffer.New(b))
+	fr, err := frames.ParseBody(buffer.New(body))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, 0, err
 	}
-	return header.Channel, fr, nil
+	return header.Channel, fr, int(header.Size), nil
 }
 
 func encodeMultiFrameTransfer(channel uint16, linkHandle, deliveryID uint32, payload []byte, edit func(int, *frames.PerformTransfer)) ([][]byte, error) {

--- a/internal/fake/net_conn.go
+++ b/internal/fake/net_conn.go
@@ -439,11 +439,6 @@ func EncodeFrame(t frames.Type, channel uint16, f frames.FrameBody) ([]byte, err
 	return raw, nil
 }
 
-func decodeFrame(b []byte) (uint16, frames.FrameBody, error) {
-	ch, fr, _, err := decodeFrameWithSize(b)
-	return ch, fr, err
-}
-
 func decodeFrameWithSize(b []byte) (uint16, frames.FrameBody, int, error) {
 	if len(b) > 3 && b[0] == 'A' && b[1] == 'M' && b[2] == 'Q' && b[3] == 'P' {
 		return 0, &AMQPProto{}, 8, nil

--- a/internal/frames/parsing.go
+++ b/internal/frames/parsing.go
@@ -131,6 +131,8 @@ func ParseBody(r *buffer.Buffer) (FrameBody, error) {
 // Write encodes fr into buf.
 // split out from conn.WriteFrame for testing purposes.
 func Write(buf *buffer.Buffer, fr Frame) error {
+	startLen := buf.Len()
+
 	// write header
 	buf.Append([]byte{
 		0, 0, 0, 0, // size, overwrite later
@@ -145,15 +147,15 @@ func Write(buf *buffer.Buffer, fr Frame) error {
 		return err
 	}
 
+	frameSize := buf.Len() - startLen
+
 	// validate size
-	if uint(buf.Len()) > math.MaxUint32 {
+	if uint(frameSize) > math.MaxUint32 {
 		return errors.New("frame too large")
 	}
 
-	// retrieve raw bytes
+	// retrieve raw bytes and write correct size at the frame's start offset
 	bufBytes := buf.Bytes()
-
-	// write correct size
-	binary.BigEndian.PutUint32(bufBytes, uint32(len(bufBytes)))
+	binary.BigEndian.PutUint32(bufBytes[startLen:], uint32(frameSize))
 	return nil
 }

--- a/link_options.go
+++ b/link_options.go
@@ -82,6 +82,39 @@ type SenderOptions struct {
 	//
 	// Default: 0.
 	TargetExpiryTimeout uint32
+
+	// Settlements receives settlement notifications in broker-arrival order
+	// when messages are sent via [Sender.SendWithReceipt]. Each [Settlement]
+	// is sent to this channel when the broker disposes a message.
+	//
+	// When set, settlement outcomes are delivered only through this channel (and
+	// not through [SendReceipt.Wait]: the receipt has no per-message settlement
+	// channel in that configuration, so [SendReceipt.Wait] would block until the
+	// link closes or the context is canceled). Use [SendReceipt.DeliveryTag] to
+	// correlate entries on Settlements with the receipt returned from
+	// [Sender.SendWithReceipt].
+	//
+	// Default: nil (settlements are reported only via [SendReceipt.Wait]).
+	Settlements chan<- Settlement
+
+	// SettlementQueueDepth sets the depth of the sender's internal settlement
+	// queue used to forward [Settlement] values to Settlements.
+	//
+	// When the internal queue is full, settlement forwarding waits until
+	// capacity is available.
+	//
+	// Default: 1.
+	SettlementQueueDepth int
+}
+
+// Settlement contains the outcome of a message sent via [Sender.SendWithReceipt].
+type Settlement struct {
+	// DeliveryTag is the delivery tag of the settled message, as returned
+	// by [SendReceipt.DeliveryTag].
+	DeliveryTag []byte
+
+	// DeliveryState is the outcome reported by the broker.
+	DeliveryState DeliveryState
 }
 
 type ReceiverOptions struct {

--- a/link_options.go
+++ b/link_options.go
@@ -89,6 +89,39 @@ type SenderOptions struct {
 	//
 	// Default: 0.
 	TargetExpiryTimeout uint32
+
+	// Settlements receives settlement notifications in broker-arrival order
+	// when messages are sent via [Sender.SendWithReceipt]. Each [Settlement]
+	// is sent to this channel when the broker disposes a message.
+	//
+	// When set, settlement outcomes are delivered only through this channel (and
+	// not through [SendReceipt.Wait]: the receipt has no per-message settlement
+	// channel in that configuration, so [SendReceipt.Wait] would block until the
+	// link closes or the context is canceled). Use [SendReceipt.DeliveryTag] to
+	// correlate entries on Settlements with the receipt returned from
+	// [Sender.SendWithReceipt].
+	//
+	// Default: nil (settlements are reported only via [SendReceipt.Wait]).
+	Settlements chan<- Settlement
+
+	// SettlementQueueDepth sets the depth of the sender's internal settlement
+	// queue used to forward [Settlement] values to Settlements.
+	//
+	// When the internal queue is full, settlement forwarding waits until
+	// capacity is available.
+	//
+	// Default: 1.
+	SettlementQueueDepth int
+}
+
+// Settlement contains the outcome of a message sent via [Sender.SendWithReceipt].
+type Settlement struct {
+	// DeliveryTag is the delivery tag of the settled message, as returned
+	// by [SendReceipt.DeliveryTag].
+	DeliveryTag []byte
+
+	// DeliveryState is the outcome reported by the broker.
+	DeliveryState DeliveryState
 }
 
 type ReceiverOptions struct {

--- a/link_test.go
+++ b/link_test.go
@@ -19,6 +19,7 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 	for times := 0; times < 100; times++ {
 		l := newTestLink(t)
 		l.l.linkCredit = 2
+		l.initialCreditWindow = 2
 
 		waitForCredit := make(chan struct{})
 
@@ -34,7 +35,7 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 		err = l.IssueCredit(1)
 		require.Error(t, err, "issueCredit can only be used with receiver links using manual credit management")
 
-		// we've consumed half of the maximum credit we're allowed to have - reflow!
+		// Credit has dropped to half of the window — trigger replenishment.
 		l.l.linkCredit = 1
 		close(waitForCredit)
 
@@ -43,15 +44,11 @@ func TestLinkFlowThatNeedsToReplenishCredits(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	Loop:
 		for {
-			// the first flow frame we receive isn't always the one with the updated credit.
-			// to avoid the race, we continue to receive frames until we get the flow frame
-			// with the correct value, a wrong frame, or the context expires.
 			select {
 			case txFrame := <-l.l.session.tx:
 				switch frame := txFrame.FrameBody.(type) {
 				case *frames.PerformFlow:
 					require.False(t, frame.Drain)
-					// replenished credits: l.receiver.maxCredit-uint32(l.countUnsettled())
 					if *frame.LinkCredit == 2 {
 						break Loop
 					}
@@ -234,9 +231,7 @@ func newTestLink(t *testing.T) *Receiver {
 	l := &Receiver{
 		l: link{
 			source: &frames.Source{},
-			// adding just enough so the debug() print will still work...
-			// debug(1, "FLOW Link Mux half: source: %s, inflight: %d, credit: %d, deliveryCount: %d, messages: %d, unsettled: %d, maxCredit : %d, settleMode: %s", l.source.Address, l.receiver.inFlight.len(), l.l.linkCredit, l.deliveryCount, len(l.messages), l.countUnsettled(), l.receiver.maxCredit, l.receiverSettleMode.String())
-			done: make(chan struct{}),
+			done:   make(chan struct{}),
 			session: &Session{
 				tx:            make(chan frameBodyEnvelope, 100),
 				done:          make(chan struct{}),
@@ -246,9 +241,10 @@ func newTestLink(t *testing.T) *Receiver {
 			rxQ:   queue.NewHolder(queue.New[frames.FrameBody](100)),
 			close: make(chan struct{}),
 		},
-		autoSendFlow:  true,
-		inFlight:      inFlight{},
-		receiverReady: make(chan struct{}, 1),
+		autoSendFlow:        true,
+		initialCreditWindow: defaultLinkCredit,
+		inFlight:            inFlight{},
+		receiverReady:       make(chan struct{}, 1),
 	}
 
 	l.messagesQ = queue.NewHolder(queue.New[Message](100))

--- a/receiver.go
+++ b/receiver.go
@@ -647,6 +647,25 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 		case env := <-txDisposition:
 			r.l.txFrame(env.FrameCtx, env.FrameBody)
 
+			// After sending a disposition, immediately check whether credit
+			// should be replenished and send the FLOW right away. This keeps
+			// the disposition and FLOW close together in the session's tx
+			// queue, allowing the connection writer to batch them into fewer
+			// TCP writes and avoiding an extra mux loop round-trip.
+			if r.autoSendFlow {
+				if err := r.maybeIssueCredit(r.messagesQ.Len()); err != nil {
+					r.l.doneErr = err
+					return
+				}
+				drain, credits := r.creditor.FlowBits(r.l.linkCredit)
+				if drain || credits > 0 {
+					if err := r.muxFlow(credits, drain); err != nil {
+						r.l.doneErr = err
+						return
+					}
+				}
+			}
+
 		case <-r.receiverReady:
 			continue
 

--- a/receiver.go
+++ b/receiver.go
@@ -41,6 +41,7 @@ type Receiver struct {
 	settlementCountMu sync.Mutex // must be held when accessing settlementCount
 
 	autoSendFlow          bool                 // automatically send flow frames as credit becomes available
+	initialCreditWindow   uint32               // the initial link credit value, used as the target for replenishment
 	inFlight              inFlight             // used to track message disposition when rcv-settle-mode == second
 	creditor              creditor             // manages credits via calls to IssueCredit/DrainCredit
 	onLinkStateProperties func(map[string]any) // callback for when link props are set in the flow frame
@@ -418,10 +419,11 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	l.target = new(frames.Target)
 	l.linkCredit = defaultLinkCredit
 	r := &Receiver{
-		l:             l,
-		autoSendFlow:  true,
-		receiverReady: make(chan struct{}, 1),
-		txDisposition: make(chan frameBodyEnvelope),
+		l:                   l,
+		autoSendFlow:        true,
+		initialCreditWindow: defaultLinkCredit,
+		receiverReady:       make(chan struct{}, 1),
+		txDisposition:       make(chan frameBodyEnvelope),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -435,6 +437,16 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	}
 	if opts.Credit > 0 {
 		r.l.linkCredit = uint32(opts.Credit)
+		r.initialCreditWindow = uint32(opts.Credit)
+		// A credit window of 1 cannot pipeline: the broker must wait for a
+		// FLOW after every message. Internally use 2 so the broker always
+		// has 1 credit outstanding while the consumer settles the current
+		// message. This matches the effective behavior of Proton-based
+		// clients that coalesce the disposition and FLOW into one write.
+		if r.initialCreditWindow == 1 {
+			r.l.linkCredit = 2
+			r.initialCreditWindow = 2
+		}
 	} else if opts.Credit < 0 {
 		r.l.linkCredit = 0
 		r.autoSendFlow = false
@@ -582,38 +594,19 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 	for {
 		msgLen := r.messagesQ.Len()
 
-		r.settlementCountMu.Lock()
-		// counter that accumulates the settled delivery count.
-		// once the threshold has been reached, the counter is
-		// reset and a flow frame is sent.
-		previousSettlementCount := r.settlementCount
-		if previousSettlementCount >= r.l.linkCredit {
-			r.settlementCount = 0
-		}
-		r.settlementCountMu.Unlock()
-
-		// once we have pending credit equal to or greater than our available credit, reclaim it.
-		// we do this instead of settlementCount > 0 to prevent flow frames from being too chatty.
-		// NOTE: we compare the settlementCount against the current link credit instead of some
-		// fixed threshold to ensure credit is reclaimed in cases where the number of unsettled
-		// messages remains high for whatever reason.
-		if r.autoSendFlow && previousSettlementCount > 0 && previousSettlementCount >= r.l.linkCredit {
-			debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
-			r.l.doneErr = r.creditor.IssueCredit(previousSettlementCount)
-		} else if r.l.linkCredit == 0 {
-			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
-		}
-
 		if r.l.doneErr != nil {
+			return
+		}
+
+		if err := r.maybeIssueCredit(msgLen); err != nil {
+			r.l.doneErr = err
 			return
 		}
 
 		drain, credits := r.creditor.FlowBits(r.l.linkCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), r.l.receiverSettleMode.String())
 
 			// send a flow frame.
 			r.l.doneErr = r.muxFlow(credits, drain)
@@ -676,6 +669,54 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 			return
 		}
 	}
+}
+
+// maybeIssueCredit checks whether link credit should be replenished and, if so,
+// queues up the appropriate amount via the creditor.
+//
+// Credit is replenished when the current link credit has dropped to half or
+// below of the initial credit window. The top-up amount restores credit to the
+// initial window, accounting for messages already buffered in the prefetch
+// queue (they consume credit but haven't been settled yet).
+//
+// This strategy matches the approach used by the RabbitMQ AMQP Java client and
+// avoids the round-trip stall that occurs with small credit windows (e.g. 1)
+// under the previous strategy, which waited until all credits were exhausted.
+func (r *Receiver) maybeIssueCredit(msgQueueLen int) error {
+	if !r.autoSendFlow {
+		return nil
+	}
+
+	r.settlementCountMu.Lock()
+	sc := r.settlementCount
+	currentCredit := r.l.linkCredit
+	halfWindow := r.initialCreditWindow / 2
+
+	if sc > 0 && currentCredit <= halfWindow {
+		potentialPrefetch := currentCredit + uint32(msgQueueLen)
+		// Only replenish if the potential prefetch (credit + queued messages)
+		// is also at or below 70% of the window. This prevents over-granting
+		// when many messages are buffered but not yet settled.
+		threshold := r.initialCreditWindow*7/10 + 1
+		if potentialPrefetch <= threshold {
+			topUp := r.initialCreditWindow - potentialPrefetch
+			if topUp > 0 {
+				r.settlementCount = 0
+				r.settlementCountMu.Unlock()
+				debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, initialCredit: %d, deliveryCount: %d, unsettled: %d, settlementCount: %d, topUp: %d, settleMode: %s",
+					r, r.l.source.Address, r.inFlight.len(), currentCredit, r.initialCreditWindow, r.l.deliveryCount, r.countUnsettled(), sc, topUp, r.l.receiverSettleMode.String())
+				return r.creditor.IssueCredit(topUp)
+			}
+		}
+		r.settlementCountMu.Unlock()
+	} else {
+		if currentCredit == 0 {
+			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), currentCredit, r.l.deliveryCount, r.countUnsettled(), sc, r.l.receiverSettleMode.String())
+		}
+		r.settlementCountMu.Unlock()
+	}
+	return nil
 }
 
 // muxFlow sends tr to the session mux.

--- a/receiver.go
+++ b/receiver.go
@@ -277,19 +277,33 @@ func (r *Receiver) Close(ctx context.Context) error {
 	return r.l.closeLink(ctx)
 }
 
-// sendDisposition sends a disposition frame to the peer
-func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint32, state encoding.DeliveryState) error {
+// sendDisposition sends a disposition frame to the peer.
+// The frame is enqueued asynchronously; the caller does not wait for it to
+// be written to the network.  Any write error will close the connection and
+// will be surfaced the next time the link is used.  For ReceiverSettleModeSecond,
+// the error surfaces through the inFlight wait channel when the mux unwinds,
+// so there is no need to block on the write here either.
+func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.DeliveryState) error {
+	modeSecond := r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond
+
 	fr := &frames.PerformDisposition{
 		Role:    encoding.RoleReceiver,
 		First:   first,
 		Last:    last,
-		Settled: r.l.receiverSettleMode == nil || *r.l.receiverSettleMode == ReceiverSettleModeFirst,
+		Settled: !modeSecond,
 		State:   state,
 	}
 
+	// Use a background context and no Done channel so the caller returns as soon
+	// as the frame is enqueued, without blocking on the network write.  This
+	// matches the async transfer path introduced for senders.
+	//
+	// For mode-second, if the write fails the connection is closed, the mux
+	// unwinds, and inFlight.clear() delivers the error to the wait channel in
+	// messageDisposition — so the caller still sees the error.
 	frameCtx := frameContext{
-		Ctx:  ctx,
-		Done: make(chan struct{}),
+		Ctx:  context.Background(),
+		Done: nil,
 	}
 
 	select {
@@ -299,12 +313,7 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 		return r.l.doneErr
 	}
 
-	select {
-	case <-frameCtx.Done:
-		return frameCtx.Err
-	case <-r.l.done:
-		return r.l.doneErr
-	}
+	return nil
 }
 
 // messageDisposition is called via the *Receiver associated with a *Message.
@@ -329,7 +338,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		wait = r.inFlight.add(msg)
 	}
 
-	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
+	if err := r.sendDisposition(msg.deliveryID, nil, state); err != nil {
 		return err
 	}
 

--- a/receiver.go
+++ b/receiver.go
@@ -285,19 +285,33 @@ func (r *Receiver) Close(ctx context.Context) error {
 	return r.l.closeLink(ctx)
 }
 
-// sendDisposition sends a disposition frame to the peer
-func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint32, state encoding.DeliveryState) error {
+// sendDisposition sends a disposition frame to the peer.
+// The frame is enqueued asynchronously; the caller does not wait for it to
+// be written to the network.  Any write error will close the connection and
+// will be surfaced the next time the link is used.  For ReceiverSettleModeSecond,
+// the error surfaces through the inFlight wait channel when the mux unwinds,
+// so there is no need to block on the write here either.
+func (r *Receiver) sendDisposition(first uint32, last *uint32, state encoding.DeliveryState) error {
+	modeSecond := r.l.receiverSettleMode != nil && *r.l.receiverSettleMode == ReceiverSettleModeSecond
+
 	fr := &frames.PerformDisposition{
 		Role:    encoding.RoleReceiver,
 		First:   first,
 		Last:    last,
-		Settled: r.l.receiverSettleMode == nil || *r.l.receiverSettleMode == ReceiverSettleModeFirst,
+		Settled: !modeSecond,
 		State:   state,
 	}
 
+	// Use a background context and no Done channel so the caller returns as soon
+	// as the frame is enqueued, without blocking on the network write.  This
+	// matches the async transfer path introduced for senders.
+	//
+	// For mode-second, if the write fails the connection is closed, the mux
+	// unwinds, and inFlight.clear() delivers the error to the wait channel in
+	// messageDisposition — so the caller still sees the error.
 	frameCtx := frameContext{
-		Ctx:  ctx,
-		Done: make(chan struct{}),
+		Ctx:  context.Background(),
+		Done: nil,
 	}
 
 	select {
@@ -307,12 +321,7 @@ func (r *Receiver) sendDisposition(ctx context.Context, first uint32, last *uint
 		return r.l.doneErr
 	}
 
-	select {
-	case <-frameCtx.Done:
-		return frameCtx.Err
-	case <-r.l.done:
-		return r.l.doneErr
-	}
+	return nil
 }
 
 // messageDisposition is called via the *Receiver associated with a *Message.
@@ -346,7 +355,7 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 		wait = r.inFlight.add(msg)
 	}
 
-	if err := r.sendDisposition(ctx, msg.deliveryID, nil, state); err != nil {
+	if err := r.sendDisposition(msg.deliveryID, nil, state); err != nil {
 		return err
 	}
 

--- a/receiver.go
+++ b/receiver.go
@@ -41,6 +41,7 @@ type Receiver struct {
 	settlementCountMu sync.Mutex // must be held when accessing settlementCount
 
 	autoSendFlow          bool                 // automatically send flow frames as credit becomes available
+	initialCreditWindow   uint32               // the initial link credit value, used as the target for replenishment
 	inFlight              inFlight             // used to track message disposition when rcv-settle-mode == second
 	creditor              creditor             // manages credits via calls to IssueCredit/DrainCredit
 	onLinkStateProperties func(map[string]any) // callback for when link props are set in the flow frame
@@ -435,10 +436,11 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	l.target = new(frames.Target)
 	l.linkCredit = defaultLinkCredit
 	r := &Receiver{
-		l:             l,
-		autoSendFlow:  true,
-		receiverReady: make(chan struct{}, 1),
-		txDisposition: make(chan frameBodyEnvelope),
+		l:                   l,
+		autoSendFlow:        true,
+		initialCreditWindow: defaultLinkCredit,
+		receiverReady:       make(chan struct{}, 1),
+		txDisposition:       make(chan frameBodyEnvelope),
 	}
 
 	r.messagesQ = queue.NewHolder(queue.New[Message](int(session.incomingWindow)))
@@ -452,6 +454,16 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 	}
 	if opts.Credit > 0 {
 		r.l.linkCredit = uint32(opts.Credit)
+		r.initialCreditWindow = uint32(opts.Credit)
+		// A credit window of 1 cannot pipeline: the broker must wait for a
+		// FLOW after every message. Internally use 2 so the broker always
+		// has 1 credit outstanding while the consumer settles the current
+		// message. This matches the effective behavior of Proton-based
+		// clients that coalesce the disposition and FLOW into one write.
+		if r.initialCreditWindow == 1 {
+			r.l.linkCredit = 2
+			r.initialCreditWindow = 2
+		}
 	} else if opts.Credit < 0 {
 		r.l.linkCredit = 0
 		r.autoSendFlow = false
@@ -619,38 +631,19 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 	for {
 		msgLen := r.messagesQ.Len()
 
-		r.settlementCountMu.Lock()
-		// counter that accumulates the settled delivery count.
-		// once the threshold has been reached, the counter is
-		// reset and a flow frame is sent.
-		previousSettlementCount := r.settlementCount
-		if previousSettlementCount >= r.l.linkCredit {
-			r.settlementCount = 0
-		}
-		r.settlementCountMu.Unlock()
-
-		// once we have pending credit equal to or greater than our available credit, reclaim it.
-		// we do this instead of settlementCount > 0 to prevent flow frames from being too chatty.
-		// NOTE: we compare the settlementCount against the current link credit instead of some
-		// fixed threshold to ensure credit is reclaimed in cases where the number of unsettled
-		// messages remains high for whatever reason.
-		if r.autoSendFlow && previousSettlementCount > 0 && previousSettlementCount >= r.l.linkCredit {
-			debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
-			r.l.doneErr = r.creditor.IssueCredit(previousSettlementCount)
-		} else if r.l.linkCredit == 0 {
-			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
-		}
-
 		if r.l.doneErr != nil {
+			return
+		}
+
+		if err := r.maybeIssueCredit(msgLen); err != nil {
+			r.l.doneErr = err
 			return
 		}
 
 		drain, credits := r.creditor.FlowBits(r.l.linkCredit)
 		if drain || credits > 0 {
-			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
-				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), previousSettlementCount, r.l.receiverSettleMode.String())
+			debug.Log(1, "RX (Receiver %p) (flow): source: %q, inflight: %d, curLinkCredit: %d, newLinkCredit: %d, drain: %v, deliveryCount: %d, messages: %d, unsettled: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), r.l.linkCredit, credits, drain, r.l.deliveryCount, msgLen, r.countUnsettled(), r.l.receiverSettleMode.String())
 
 			// send a flow frame.
 			r.l.doneErr = r.muxFlow(credits, drain)
@@ -713,6 +706,54 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 			return
 		}
 	}
+}
+
+// maybeIssueCredit checks whether link credit should be replenished and, if so,
+// queues up the appropriate amount via the creditor.
+//
+// Credit is replenished when the current link credit has dropped to half or
+// below of the initial credit window. The top-up amount restores credit to the
+// initial window, accounting for messages already buffered in the prefetch
+// queue (they consume credit but haven't been settled yet).
+//
+// This strategy matches the approach used by the RabbitMQ AMQP Java client and
+// avoids the round-trip stall that occurs with small credit windows (e.g. 1)
+// under the previous strategy, which waited until all credits were exhausted.
+func (r *Receiver) maybeIssueCredit(msgQueueLen int) error {
+	if !r.autoSendFlow {
+		return nil
+	}
+
+	r.settlementCountMu.Lock()
+	sc := r.settlementCount
+	currentCredit := r.l.linkCredit
+	halfWindow := r.initialCreditWindow / 2
+
+	if sc > 0 && currentCredit <= halfWindow {
+		potentialPrefetch := currentCredit + uint32(msgQueueLen)
+		// Only replenish if the potential prefetch (credit + queued messages)
+		// is also at or below 70% of the window. This prevents over-granting
+		// when many messages are buffered but not yet settled.
+		threshold := r.initialCreditWindow*7/10 + 1
+		if potentialPrefetch <= threshold {
+			topUp := r.initialCreditWindow - potentialPrefetch
+			if topUp > 0 {
+				r.settlementCount = 0
+				r.settlementCountMu.Unlock()
+				debug.Log(1, "RX (Receiver %p) (auto): source: %q, inflight: %d, linkCredit: %d, initialCredit: %d, deliveryCount: %d, unsettled: %d, settlementCount: %d, topUp: %d, settleMode: %s",
+					r, r.l.source.Address, r.inFlight.len(), currentCredit, r.initialCreditWindow, r.l.deliveryCount, r.countUnsettled(), sc, topUp, r.l.receiverSettleMode.String())
+				return r.creditor.IssueCredit(topUp)
+			}
+		}
+		r.settlementCountMu.Unlock()
+	} else {
+		if currentCredit == 0 {
+			debug.Log(1, "RX (Receiver %p) (pause): source: %q, inflight: %d, linkCredit: %d, deliveryCount: %d, unsettled: %d, settlementCount: %d, settleMode: %s",
+				r, r.l.source.Address, r.inFlight.len(), currentCredit, r.l.deliveryCount, r.countUnsettled(), sc, r.l.receiverSettleMode.String())
+		}
+		r.settlementCountMu.Unlock()
+	}
+	return nil
 }
 
 // muxFlow sends tr to the session mux.

--- a/receiver.go
+++ b/receiver.go
@@ -684,6 +684,25 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 		case env := <-txDisposition:
 			r.l.txFrame(env.FrameCtx, env.FrameBody)
 
+			// After sending a disposition, immediately check whether credit
+			// should be replenished and send the FLOW right away. This keeps
+			// the disposition and FLOW close together in the session's tx
+			// queue, allowing the connection writer to batch them into fewer
+			// TCP writes and avoiding an extra mux loop round-trip.
+			if r.autoSendFlow {
+				if err := r.maybeIssueCredit(r.messagesQ.Len()); err != nil {
+					r.l.doneErr = err
+					return
+				}
+				drain, credits := r.creditor.FlowBits(r.l.linkCredit)
+				if drain || credits > 0 {
+					if err := r.muxFlow(credits, drain); err != nil {
+						r.l.doneErr = err
+						return
+					}
+				}
+			}
+
 		case <-r.receiverReady:
 			continue
 

--- a/sender.go
+++ b/sender.go
@@ -22,9 +22,13 @@ type Sender struct {
 	buf             buffer.Buffer
 	nextDeliveryTag uint64
 	rollback        chan struct{}
+	settlements     chan<- Settlement // optional channel for settlement notifications
+	settlementQ     chan Settlement
 
 	onLinkStateProperties func(map[string]any)
 }
+
+const defaultSettlementQueueDepth = 1
 
 // LinkName() is the name of the link used for this Sender.
 func (s *Sender) LinkName() string {
@@ -79,7 +83,7 @@ func (s *Sender) Send(ctx context.Context, msg *Message, opts *SendOptions) erro
 		// link is still active
 	}
 
-	receipt, err := s.send(ctx, msg, opts)
+	receipt, err := s.send(ctx, msg, opts, true)
 	if err != nil {
 		return err
 	}
@@ -125,6 +129,10 @@ func (s SendReceipt) DeliveryTag() []byte {
 //
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message is in an unknown state of settlement.
+//
+// If the [Sender] was created with [SenderOptions.Settlements] set, settlement
+// is delivered on that channel instead; in that case Wait does not receive a
+// delivery state and only returns when the link ends or ctx is done.
 func (s *SendReceipt) Wait(ctx context.Context) (DeliveryState, error) {
 	if s.state != nil {
 		return s.state, nil
@@ -161,6 +169,9 @@ type SendWithReceiptOptions struct {
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message is in an unknown state of transmission.
 //
+// If [SenderOptions.Settlements] is configured, read settlement from that channel;
+// [SendReceipt.Wait] does not report broker disposition in that mode (see [SendReceipt.Wait]).
+//
 // If the Sender has been configured with [SenderSettleModeSettled] an error is returned.
 //
 // SendWithReceipt is safe for concurrent use.
@@ -178,12 +189,14 @@ func (s *Sender) SendWithReceipt(ctx context.Context, msg *Message, opts *SendWi
 		// link is still active
 	}
 
-	return s.send(ctx, msg, nil)
+	return s.send(ctx, msg, nil, false)
 }
 
 // send is separated from Send so that the mutex unlock can be deferred without
 // locking the transfer confirmation that happens in Send.
-func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (SendReceipt, error) {
+// when waitForWrite is false, the caller does not block waiting for the frame
+// to be written to the network, allowing the pipeline to flow freely.
+func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions, waitForWrite bool) (SendReceipt, error) {
 	const (
 		maxDeliveryTagLength   = 32
 		maxTransferFrameHeader = 66 // determined by calcMaxTransferFrameHeader
@@ -253,19 +266,27 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (Sen
 			// mark final transfer as settled when sender mode is settled
 			fr.Settled = senderSettled
 
-			// set done on last frame
-			fr.Done = make(chan encoding.DeliveryState, 1)
+			// When the caller uses the Settlements channel, skip the
+			// per-message Done channel to avoid the allocation.
+			if s.settlementQ == nil {
+				fr.Done = make(chan encoding.DeliveryState, 1)
+			}
 		}
 
 		// NOTE: we MUST send a copy of fr here since we modify it post send
 
-		frameCtx := frameContext{
-			Ctx:  ctx,
-			Done: make(chan struct{}),
+		frameCtx := frameContext{Ctx: ctx}
+		if waitForWrite {
+			frameCtx.Done = make(chan struct{})
+		} else {
+			// when the caller doesn't wait for the write, use a background
+			// context for the write deadline so the frame is written even
+			// if the caller's context is cancelled after send returns.
+			frameCtx.Ctx = context.Background()
 		}
 
 		select {
-		case s.transfers <- transferEnvelope{FrameCtx: &frameCtx, InputHandle: s.l.inputHandle, Frame: fr}:
+		case s.transfers <- transferEnvelope{FrameCtx: &frameCtx, InputHandle: s.l.inputHandle, Frame: fr, Settlements: s.settlementQ}:
 			// frame was sent to our mux
 		case <-s.l.done:
 			return SendReceipt{}, s.l.doneErr
@@ -273,22 +294,24 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (Sen
 			return SendReceipt{}, &Error{Condition: ErrCondTransferLimitExceeded, Description: fmt.Sprintf("credit limit exceeded for sending link %s", s.l.key.name)}
 		}
 
-		select {
-		case <-frameCtx.Done:
-			if frameCtx.Err != nil {
-				if !fr.More {
-					select {
-					case s.rollback <- struct{}{}:
-						// the write never happened so signal the mux to roll back the delivery count and link credit
-					case <-s.l.close:
-						// the link is going down
+		if waitForWrite {
+			select {
+			case <-frameCtx.Done:
+				if frameCtx.Err != nil {
+					if !fr.More {
+						select {
+						case s.rollback <- struct{}{}:
+							// the write never happened so signal the mux to roll back the delivery count and link credit
+						case <-s.l.close:
+							// the link is going down
+						}
 					}
+					return SendReceipt{}, frameCtx.Err
 				}
-				return SendReceipt{}, frameCtx.Err
+				// frame was written to the network
+			case <-s.l.done:
+				return SendReceipt{}, s.l.doneErr
 			}
-			// frame was written to the network
-		case <-s.l.done:
-			return SendReceipt{}, s.l.doneErr
 		}
 
 		// clear values that are only required on first message
@@ -335,6 +358,11 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 
 	if opts == nil {
 		return s, nil
+	}
+
+	queueDepth := defaultSettlementQueueDepth
+	if opts.SettlementQueueDepth > 0 {
+		queueDepth = opts.SettlementQueueDepth
 	}
 
 	for _, v := range opts.Capabilities {
@@ -401,6 +429,10 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 	if opts.TargetExpiryTimeout != 0 {
 		s.l.target.Timeout = opts.TargetExpiryTimeout
 	}
+	s.settlements = opts.Settlements
+	if s.settlements != nil {
+		s.settlementQ = make(chan Settlement, queueDepth)
+	}
 	if opts.OnLinkStateProperties != nil {
 		s.onLinkStateProperties = opts.OnLinkStateProperties
 	}
@@ -428,8 +460,26 @@ func (s *Sender) attach(ctx context.Context) error {
 	}
 
 	s.transfers = make(chan transferEnvelope)
+	if s.settlementQ != nil {
+		go s.forwardSettlements()
+	}
 
 	return nil
+}
+
+func (s *Sender) forwardSettlements() {
+	for {
+		select {
+		case settlement := <-s.settlementQ:
+			select {
+			case s.settlements <- settlement:
+			case <-s.l.done:
+				return
+			}
+		case <-s.l.done:
+			return
+		}
+	}
 }
 
 type senderTestHooks struct {

--- a/sender.go
+++ b/sender.go
@@ -22,10 +22,14 @@ type Sender struct {
 	buf             buffer.Buffer
 	nextDeliveryTag uint64
 	rollback        chan struct{}
+	settlements     chan<- Settlement // optional channel for settlement notifications
+	settlementQ     chan Settlement
 
 	onLinkStateProperties  func(map[string]any)
 	onDeliveryStateChanged func(DeliveryState)
 }
+
+const defaultSettlementQueueDepth = 1
 
 // LinkName() is the name of the link used for this Sender.
 func (s *Sender) LinkName() string {
@@ -80,7 +84,7 @@ func (s *Sender) Send(ctx context.Context, msg *Message, opts *SendOptions) erro
 		// link is still active
 	}
 
-	receipt, err := s.send(ctx, msg, opts)
+	receipt, err := s.send(ctx, msg, opts, true)
 	if err != nil {
 		return err
 	}
@@ -126,6 +130,10 @@ func (s SendReceipt) DeliveryTag() []byte {
 //
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message is in an unknown state of settlement.
+//
+// If the [Sender] was created with [SenderOptions.Settlements] set, settlement
+// is delivered on that channel instead; in that case Wait does not receive a
+// delivery state and only returns when the link ends or ctx is done.
 func (s *SendReceipt) Wait(ctx context.Context) (DeliveryState, error) {
 	if s.state != nil {
 		return s.state, nil
@@ -162,6 +170,9 @@ type SendWithReceiptOptions struct {
 // If the context's deadline expires or is cancelled before the operation
 // completes, the message is in an unknown state of transmission.
 //
+// If [SenderOptions.Settlements] is configured, read settlement from that channel;
+// [SendReceipt.Wait] does not report broker disposition in that mode (see [SendReceipt.Wait]).
+//
 // If the Sender has been configured with [SenderSettleModeSettled] an error is returned.
 //
 // SendWithReceipt is safe for concurrent use.
@@ -179,12 +190,14 @@ func (s *Sender) SendWithReceipt(ctx context.Context, msg *Message, opts *SendWi
 		// link is still active
 	}
 
-	return s.send(ctx, msg, nil)
+	return s.send(ctx, msg, nil, false)
 }
 
 // send is separated from Send so that the mutex unlock can be deferred without
 // locking the transfer confirmation that happens in Send.
-func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (SendReceipt, error) {
+// when waitForWrite is false, the caller does not block waiting for the frame
+// to be written to the network, allowing the pipeline to flow freely.
+func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions, waitForWrite bool) (SendReceipt, error) {
 	const (
 		maxDeliveryTagLength   = 32
 		maxTransferFrameHeader = 66 // determined by calcMaxTransferFrameHeader
@@ -254,19 +267,27 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (Sen
 			// mark final transfer as settled when sender mode is settled
 			fr.Settled = senderSettled
 
-			// set done on last frame
-			fr.Done = make(chan encoding.DeliveryState, 1)
+			// When the caller uses the Settlements channel, skip the
+			// per-message Done channel to avoid the allocation.
+			if s.settlementQ == nil {
+				fr.Done = make(chan encoding.DeliveryState, 1)
+			}
 		}
 
 		// NOTE: we MUST send a copy of fr here since we modify it post send
 
-		frameCtx := frameContext{
-			Ctx:  ctx,
-			Done: make(chan struct{}),
+		frameCtx := frameContext{Ctx: ctx}
+		if waitForWrite {
+			frameCtx.Done = make(chan struct{})
+		} else {
+			// when the caller doesn't wait for the write, use a background
+			// context for the write deadline so the frame is written even
+			// if the caller's context is cancelled after send returns.
+			frameCtx.Ctx = context.Background()
 		}
 
 		select {
-		case s.transfers <- transferEnvelope{FrameCtx: &frameCtx, InputHandle: s.l.inputHandle, Frame: fr}:
+		case s.transfers <- transferEnvelope{FrameCtx: &frameCtx, InputHandle: s.l.inputHandle, Frame: fr, Settlements: s.settlementQ}:
 			// frame was sent to our mux
 		case <-s.l.done:
 			return SendReceipt{}, s.l.doneErr
@@ -274,22 +295,24 @@ func (s *Sender) send(ctx context.Context, msg *Message, opts *SendOptions) (Sen
 			return SendReceipt{}, &Error{Condition: ErrCondTransferLimitExceeded, Description: fmt.Sprintf("credit limit exceeded for sending link %s", s.l.key.name)}
 		}
 
-		select {
-		case <-frameCtx.Done:
-			if frameCtx.Err != nil {
-				if !fr.More {
-					select {
-					case s.rollback <- struct{}{}:
-						// the write never happened so signal the mux to roll back the delivery count and link credit
-					case <-s.l.close:
-						// the link is going down
+		if waitForWrite {
+			select {
+			case <-frameCtx.Done:
+				if frameCtx.Err != nil {
+					if !fr.More {
+						select {
+						case s.rollback <- struct{}{}:
+							// the write never happened so signal the mux to roll back the delivery count and link credit
+						case <-s.l.close:
+							// the link is going down
+						}
 					}
+					return SendReceipt{}, frameCtx.Err
 				}
-				return SendReceipt{}, frameCtx.Err
+				// frame was written to the network
+			case <-s.l.done:
+				return SendReceipt{}, s.l.doneErr
 			}
-			// frame was written to the network
-		case <-s.l.done:
-			return SendReceipt{}, s.l.doneErr
 		}
 
 		// clear values that are only required on first message
@@ -336,6 +359,11 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 
 	if opts == nil {
 		return s, nil
+	}
+
+	queueDepth := defaultSettlementQueueDepth
+	if opts.SettlementQueueDepth > 0 {
+		queueDepth = opts.SettlementQueueDepth
 	}
 
 	for _, v := range opts.Capabilities {
@@ -402,6 +430,10 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 	if opts.TargetExpiryTimeout != 0 {
 		s.l.target.Timeout = opts.TargetExpiryTimeout
 	}
+	s.settlements = opts.Settlements
+	if s.settlements != nil {
+		s.settlementQ = make(chan Settlement, queueDepth)
+	}
 	if opts.OnLinkStateProperties != nil {
 		s.onLinkStateProperties = opts.OnLinkStateProperties
 	}
@@ -432,8 +464,26 @@ func (s *Sender) attach(ctx context.Context) error {
 	}
 
 	s.transfers = make(chan transferEnvelope)
+	if s.settlementQ != nil {
+		go s.forwardSettlements()
+	}
 
 	return nil
+}
+
+func (s *Sender) forwardSettlements() {
+	for {
+		select {
+		case settlement := <-s.settlementQ:
+			select {
+			case s.settlements <- settlement:
+			case <-s.l.done:
+				return
+			}
+		case <-s.l.done:
+			return
+		}
+	}
 }
 
 type senderTestHooks struct {

--- a/sender_test.go
+++ b/sender_test.go
@@ -1613,20 +1613,20 @@ func TestSenderSendWithReceipt(t *testing.T) {
 
 			sendInitialFlowFrame(t, 0, netConn, 0, 100)
 
-			ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			receipt, err := snd.SendWithReceipt(ctx, NewMessage([]byte("test")), nil)
 			cancel()
 			require.NoError(t, err)
 			require.Equal(t, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, receipt.DeliveryTag())
 
-			ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			state, err := receipt.Wait(ctx)
 			cancel()
 			require.NoError(t, err)
 			require.Equal(t, test.state, state)
 
 			// subsequent calls should yield the same result
-			ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 			state, err = receipt.Wait(ctx)
 			cancel()
 			require.NoError(t, err)

--- a/sender_test.go
+++ b/sender_test.go
@@ -970,6 +970,106 @@ func TestSenderSendMultiTransfer(t *testing.T) {
 	require.NoError(t, client.Close())
 }
 
+func TestSenderSendMultiTransferWithSettlements(t *testing.T) {
+	var deliveryID uint32
+	transferCount := 0
+	const maxReceiverFrameSize = 128
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		switch tt := req.(type) {
+		case *fake.AMQPProto:
+			return newResponse(fake.ProtoHeader(fake.ProtoAMQP))
+		case *frames.PerformOpen:
+			b, err := fake.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformOpen{
+				ChannelMax:   65535,
+				ContainerID:  "container",
+				IdleTimeout:  time.Minute,
+				MaxFrameSize: maxReceiverFrameSize,
+			})
+			if err != nil {
+				return fake.Response{}, err
+			}
+			return fake.Response{Payload: b}, nil
+		case *frames.PerformBegin:
+			return newResponse(fake.PerformBegin(0, remoteChannel))
+		case *frames.PerformEnd:
+			return newResponse(fake.PerformEnd(0, nil))
+		case *frames.PerformAttach:
+			return newResponse(fake.SenderAttach(0, tt.Name, 0, SenderSettleModeUnsettled))
+		case *frames.PerformTransfer:
+			if tt.DeliveryID != nil {
+				if transferCount != 0 {
+					return fake.Response{}, fmt.Errorf("unexpected DeliveryID for frame number %d", transferCount)
+				}
+				deliveryID = *tt.DeliveryID
+			}
+			if tt.MessageFormat != nil && transferCount != 0 {
+				return fake.Response{}, fmt.Errorf("unexpected MessageFormat for frame number %d", transferCount)
+			} else if tt.MessageFormat == nil && transferCount == 0 {
+				return fake.Response{}, errors.New("unexpected nil MessageFormat")
+			}
+			if tt.More {
+				transferCount++
+				return fake.Response{}, nil
+			}
+			return newResponse(fake.PerformDisposition(encoding.RoleReceiver, 0, deliveryID, nil, &encoding.StateAccepted{}))
+		case *frames.PerformDetach:
+			return newResponse(fake.PerformDetach(0, 0, nil))
+		case *frames.PerformClose:
+			return newResponse(fake.PerformClose(nil))
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{
+		ChunkSize: 8,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	client, err := NewConn(ctx, netConn, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	session, err := client.NewSession(ctx, nil)
+	cancel()
+	require.NoError(t, err)
+
+	settlementsChan := make(chan Settlement, 10)
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		Settlements: settlementsChan,
+	})
+	cancel()
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, 0, netConn, 0, 100)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	payload := make([]byte, maxReceiverFrameSize*4)
+	for i := 0; i < maxReceiverFrameSize*4; i++ {
+		payload[i] = byte(i % 256)
+	}
+	receipt, err := snd.SendWithReceipt(ctx, NewMessage(payload), nil)
+	require.NoError(t, err)
+	cancel()
+
+	// wait for settlement
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	select {
+	case s := <-settlementsChan:
+		require.Equal(t, receipt.DeliveryTag(), s.DeliveryTag)
+		require.Equal(t, &StateAccepted{}, s.DeliveryState)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for settlement")
+	}
+
+	// split up into 8 transfers due to transfer frame header size (since the final frame completes the transfer)
+	require.Equal(t, 8, transferCount)
+
+	require.NoError(t, client.Close())
+}
+
 func TestSenderConnReaderError(t *testing.T) {
 	netConn := fake.NewNetConn(senderFrameHandlerNoUnhandled(0, SenderSettleModeUnsettled), fake.NetConnOptions{})
 

--- a/session.go
+++ b/session.go
@@ -16,7 +16,8 @@ import (
 
 // Default session options
 const (
-	defaultWindow = 5000
+	defaultWindow             = 5000
+	defaultTransferQueueDepth = 1
 )
 
 // SessionOptions contains the optional settings for configuring an AMQP session.
@@ -27,6 +28,13 @@ type SessionOptions struct {
 	// Minimum: 1.
 	// Default: 4294967295.
 	MaxLinks uint32
+
+	// TransferQueueDepth sets the number of transfer frames that can be
+	// queued for sending before the sender blocks. Larger values allow
+	// more pipelining at the cost of memory.
+	//
+	// Default: 1.
+	TransferQueueDepth int
 }
 
 // Session is an AMQP session.
@@ -72,11 +80,16 @@ type Session struct {
 }
 
 func newSession(c *Conn, channel uint16, opts *SessionOptions) *Session {
+	transferQueueDepth := defaultTransferQueueDepth
+	if opts != nil && opts.TransferQueueDepth > 0 {
+		transferQueueDepth = opts.TransferQueueDepth
+	}
+
 	s := &Session{
 		conn:           c,
 		channel:        channel,
 		tx:             make(chan frameBodyEnvelope),
-		txTransfer:     make(chan transferEnvelope),
+		txTransfer:     make(chan transferEnvelope, transferQueueDepth),
 		incomingWindow: defaultWindow,
 		outgoingWindow: defaultWindow,
 		handleMax:      math.MaxUint32 - 1,

--- a/session.go
+++ b/session.go
@@ -357,8 +357,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		// maps delivery IDs to output (our) handles. used for multi-frame transfers
 		deliveryIDFromOutputHandle = make(map[uint32]uint32)
 
-		// maps delivery IDs to the settlement state channel
-		settlementFromDeliveryID = make(map[uint32]chan encoding.DeliveryState)
+		// maps delivery IDs to pending settlement state
+		settlementFromDeliveryID = make(map[uint32]pendingSettlement)
 
 		// tracks the next delivery ID for outgoing transfers
 		nextDeliveryID uint32
@@ -464,13 +464,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					if body.Settled && body.Role == encoding.RoleReceiver {
 						// check if settlement confirmation was requested, if so
 						// confirm by closing channel (RSM == ModeFirst)
-						if done, ok := settlementFromDeliveryID[deliveryID]; ok {
+						if ps, ok := settlementFromDeliveryID[deliveryID]; ok {
 							delete(settlementFromDeliveryID, deliveryID)
-							select {
-							case done <- body.State:
-							default:
+							if ps.done != nil {
+								select {
+								case ps.done <- body.State:
+								default:
+								}
+								close(ps.done)
 							}
-							close(done)
+							if ps.settlements != nil {
+								ps.settlements <- Settlement{
+									DeliveryTag:   ps.deliveryTag,
+									DeliveryState: body.State,
+								}
+							}
 						}
 					}
 
@@ -691,21 +699,27 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 			s.txFrame(env.FrameCtx, fr)
 
-			select {
-			case <-env.FrameCtx.Done:
-				if env.FrameCtx.Err != nil {
-					// transfer wasn't sent, don't update state
+			if env.FrameCtx.Done != nil {
+				select {
+				case <-env.FrameCtx.Done:
+					if env.FrameCtx.Err != nil {
+						// transfer wasn't sent, don't update state
+						continue
+					}
+					// transfer was written to the network
+				case <-s.conn.done:
+					// the write failed, Conn is going down
 					continue
 				}
-				// transfer was written to the network
-			case <-s.conn.done:
-				// the write failed, Conn is going down
-				continue
 			}
 
-			// if not settled, add done chan to map
-			if !fr.Settled && fr.Done != nil {
-				settlementFromDeliveryID[deliveryID] = fr.Done
+			// if not settled, track pending settlement for disposition handling
+			if !fr.Settled && (fr.Done != nil || env.Settlements != nil) {
+				settlementFromDeliveryID[deliveryID] = pendingSettlement{
+					done:        fr.Done,
+					deliveryTag: fr.DeliveryTag,
+					settlements: env.Settlements,
+				}
 			} else if fr.Done != nil {
 				// sender-settled, close done now that the transfer has been sent
 				close(fr.Done)
@@ -737,13 +751,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					for deliveryID := start; deliveryID <= end; deliveryID++ {
 						// send delivery state to the channel and close it to signal
 						// that the delivery has completed (RSM == ModeSecond)
-						if done, ok := settlementFromDeliveryID[deliveryID]; ok {
+						if ps, ok := settlementFromDeliveryID[deliveryID]; ok {
 							delete(settlementFromDeliveryID, deliveryID)
-							select {
-							case done <- fr.State:
-							default:
+							if ps.done != nil {
+								select {
+								case ps.done <- fr.State:
+								default:
+								}
+								close(ps.done)
 							}
-							close(done)
+							if ps.settlements != nil {
+								ps.settlements <- Settlement{
+									DeliveryTag:   ps.deliveryTag,
+									DeliveryState: fr.State,
+								}
+							}
 						}
 					}
 				}
@@ -838,6 +860,16 @@ type transferEnvelope struct {
 	InputHandle uint32
 
 	Frame frames.PerformTransfer
+
+	// optional sender-owned queue for settlement notifications
+	Settlements chan<- Settlement
+}
+
+// pendingSettlement tracks the state needed to complete settlement of a sent message.
+type pendingSettlement struct {
+	done        chan encoding.DeliveryState
+	deliveryTag []byte
+	settlements chan<- Settlement
 }
 
 // frameBodyEnvelope is used by senders and receivers to send frames.

--- a/session.go
+++ b/session.go
@@ -719,11 +719,17 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 			// if not settled, track pending settlement for disposition handling
 			if !fr.Settled && (fr.Done != nil || env.Settlements != nil) {
-				settlementFromDeliveryID[deliveryID] = pendingSettlement{
-					done:        fr.Done,
-					deliveryTag: fr.DeliveryTag,
-					settlements: env.Settlements,
+				ps := settlementFromDeliveryID[deliveryID]
+				if ps.done == nil {
+					ps.done = fr.Done
 				}
+				if len(ps.deliveryTag) == 0 {
+					ps.deliveryTag = fr.DeliveryTag
+				}
+				if ps.settlements == nil {
+					ps.settlements = env.Settlements
+				}
+				settlementFromDeliveryID[deliveryID] = ps
 			} else if fr.Done != nil {
 				// sender-settled, close done now that the transfer has been sent
 				close(fr.Done)

--- a/session.go
+++ b/session.go
@@ -357,8 +357,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 		// maps delivery IDs to output (our) handles. used for multi-frame transfers
 		deliveryIDFromOutputHandle = make(map[uint32]uint32)
 
-		// maps delivery IDs to the settlement state channel
-		settlementFromDeliveryID = make(map[uint32]chan encoding.DeliveryState)
+		// maps delivery IDs to pending settlement state
+		settlementFromDeliveryID = make(map[uint32]pendingSettlement)
 
 		// tracks the next delivery ID for outgoing transfers
 		nextDeliveryID uint32
@@ -464,13 +464,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					if body.Settled && body.Role == encoding.RoleReceiver {
 						// check if settlement confirmation was requested, if so
 						// confirm by closing channel (RSM == ModeFirst)
-						if done, ok := settlementFromDeliveryID[deliveryID]; ok {
+						if ps, ok := settlementFromDeliveryID[deliveryID]; ok {
 							delete(settlementFromDeliveryID, deliveryID)
-							select {
-							case done <- body.State:
-							default:
+							if ps.done != nil {
+								select {
+								case ps.done <- body.State:
+								default:
+								}
+								close(ps.done)
 							}
-							close(done)
+							if ps.settlements != nil {
+								ps.settlements <- Settlement{
+									DeliveryTag:   ps.deliveryTag,
+									DeliveryState: body.State,
+								}
+							}
 						}
 					}
 
@@ -695,21 +703,27 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 			s.txFrame(env.FrameCtx, fr)
 
-			select {
-			case <-env.FrameCtx.Done:
-				if env.FrameCtx.Err != nil {
-					// transfer wasn't sent, don't update state
+			if env.FrameCtx.Done != nil {
+				select {
+				case <-env.FrameCtx.Done:
+					if env.FrameCtx.Err != nil {
+						// transfer wasn't sent, don't update state
+						continue
+					}
+					// transfer was written to the network
+				case <-s.conn.done:
+					// the write failed, Conn is going down
 					continue
 				}
-				// transfer was written to the network
-			case <-s.conn.done:
-				// the write failed, Conn is going down
-				continue
 			}
 
-			// if not settled, add done chan to map
-			if !fr.Settled && fr.Done != nil {
-				settlementFromDeliveryID[deliveryID] = fr.Done
+			// if not settled, track pending settlement for disposition handling
+			if !fr.Settled && (fr.Done != nil || env.Settlements != nil) {
+				settlementFromDeliveryID[deliveryID] = pendingSettlement{
+					done:        fr.Done,
+					deliveryTag: fr.DeliveryTag,
+					settlements: env.Settlements,
+				}
 			} else if fr.Done != nil {
 				// sender-settled, close done now that the transfer has been sent
 				close(fr.Done)
@@ -741,13 +755,21 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 					for deliveryID := start; deliveryID <= end; deliveryID++ {
 						// send delivery state to the channel and close it to signal
 						// that the delivery has completed (RSM == ModeSecond)
-						if done, ok := settlementFromDeliveryID[deliveryID]; ok {
+						if ps, ok := settlementFromDeliveryID[deliveryID]; ok {
 							delete(settlementFromDeliveryID, deliveryID)
-							select {
-							case done <- fr.State:
-							default:
+							if ps.done != nil {
+								select {
+								case ps.done <- fr.State:
+								default:
+								}
+								close(ps.done)
 							}
-							close(done)
+							if ps.settlements != nil {
+								ps.settlements <- Settlement{
+									DeliveryTag:   ps.deliveryTag,
+									DeliveryState: fr.State,
+								}
+							}
 						}
 					}
 				} else if fr.Role == encoding.RoleReceiver && fr.Settled {
@@ -854,6 +876,16 @@ type transferEnvelope struct {
 	InputHandle uint32
 
 	Frame frames.PerformTransfer
+
+	// optional sender-owned queue for settlement notifications
+	Settlements chan<- Settlement
+}
+
+// pendingSettlement tracks the state needed to complete settlement of a sent message.
+type pendingSettlement struct {
+	done        chan encoding.DeliveryState
+	deliveryTag []byte
+	settlements chan<- Settlement
 }
 
 // frameBodyEnvelope is used by senders and receivers to send frames.


### PR DESCRIPTION
Hi. This is the PR I mentioned earlier, which allows much higher publishing throughput and somewhat higher consumption throughput. I'm submitting as a draft to start a discussion about whether such changes would be desired in the first place and if yes - whether the implementation is ok.

I've split the changes into reasonable commits, but I'm also happy to split this into multiple PRs if you prefer.

Note that this work was quite heavily AI-assisted, but it was reviewed and more importantly - has been used successfully in [RabbitMQ's load testing tool (omq)](https://github.com/rabbitmq/omq) for around 2 months at this point. The main motivation for these changes was that, since `omq` is a load testing tool, we wanted to be able to saturate the broker, rather than be limited by what the client can do. Earlier, we used an [Ants pool](https://github.com/panjf2000/ants) to have multiple goroutines publish concurrently. However, it was not only harder to use, but also still limited (we needed multiple sender sessions to saturate the queue on the broker side, otherwise there was too much locking).

## Async Publishing (new API)
The most important change is the new API for publishing: nothing should change for existing senders, since `Send` and `SendWithReceipt` should work the same as before. However, there's a new publishing API, where messages are published asynchronously and there's a channel for receiving settlements. This significantly reduces the amount of (b)locking. For small messages published over the loopback interface, this allows publishing tens of thousands of messages per second, instead of a few thousands (obviously the exact results vary widely based on multiple factors).

When creating a sender, you can pass a channel, through which settlements will be received:
```go
		settlements = make(chan amqp.Settlement, MAX_IN_FLIGHT)
		sender, err := p.Session.NewSender(ctx, terminus, &amqp.SenderOptions{
			Settlements:      settlements,
		})
```
Then consume from the `settlements` channel to handle settlements from the broker.

## Benchmark

I've put together a [dedicated testing tool](https://github.com/mkuratczyk/go-amqp-perf) for testing these changes. Here are the results without this PR:
```
=== go-amqp throughput ===
lib=github.com/Azure/go-amqp v1.6.0
broker=amqp://guest:guest@127.0.0.1:5672/ queue=/queues/test stream=/queues/test sample=10s fill-stream=5s settlement-depth=4

benchmark                            msg/s (or noted)
--------------------------------------------------
Send (unsettled)                             2183
Send + receipt.Wait                          2374
Send + Settlements chan (settled/s)  n/a (not in this build)

Consume stream "/queues/test" (offset=first), msg/s:
recv credit           msg/s
----------------------------
0 (default)            3734
1                      3597
4                     11395
8                     17284
32                    32268
128                   33119
1024                  32342
```

And here are the results after the changes:
```
=== go-amqp throughput ===
lib=github.com/Azure/go-amqp v1.6.0 => github.com/mkuratczyk/go-amqp v0.0.0-20260427124521-653dc4726ba3
broker=amqp://guest:guest@127.0.0.1:5672/ queue=/queues/test stream=/queues/test sample=10s fill-stream=5s settlement-depth=4

benchmark                            msg/s (or noted)
--------------------------------------------------
Send (unsettled)                             2389
Send + receipt.Wait                          2349
Send + Settlements chan (settled/s)         71782

Consume stream "/queues/test" (offset=first), msg/s:
recv credit           msg/s
----------------------------
0 (default)            3422
1                      7005
4                     11280
8                     18876
32                    36770
128                   48996
1024                  55341
```
If you want to run this tool yourself, modify comment/uncomment the `replace` clause go.mod to pick which version of the library you want to build with.

I'm looking forward to your feedback.

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to [CHANGELOG.md][] are included.
- [ ] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
