### PR TITLE
Add OnDeliveryStateChanged callback to Sender and Receiver (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.7.0
+
+* Add OnDeliveryStateChanged callback to Sender and Receiver
+
+
 ## 1.6.0 (2026-04-22)
 
 * Add SourceDistributionMode to ReceiverOptions

--- a/link.go
+++ b/link.go
@@ -77,6 +77,11 @@ type link struct {
 	dynamicAddr     bool // request a dynamic link address from the server
 
 	desiredCapabilities encoding.MultiSymbol // maps to the ATTACH frame's desired-capabilities field
+
+	// trackIncomingDeliveries causes the session to register every incoming transfer delivery ID
+	// in inputHandleFromRemoteDeliveryID so that unsolicited disposition frames from the peer
+	// (e.g. broker-side consumer timeouts) can be routed to this link's mux.
+	trackIncomingDeliveries bool
 }
 
 func newLink(s *Session, r encoding.Role) link {

--- a/link_options.go
+++ b/link_options.go
@@ -47,6 +47,13 @@ type SenderOptions struct {
 	// OnLinkStateProperties is called when a flow frame with link state properties is received.
 	OnLinkStateProperties func(map[string]any)
 
+	// OnDeliveryStateChanged is called when the peer changes the delivery state of a sent message.
+	// state is the new delivery state reported by the peer.
+	//
+	// This callback is invoked from the link's mux goroutine.
+	// Blocking operations must not be performed inside this callback.
+	OnDeliveryStateChanged func(state DeliveryState)
+
 	// RequestedReceiverSettleMode sets the requested receiver settlement mode.
 	//
 	// If a settlement mode is explicitly set and the server does not
@@ -153,6 +160,17 @@ type ReceiverOptions struct {
 
 	// OnLinkStateProperties is called when a flow frame with link state properties is received.
 	OnLinkStateProperties func(map[string]any)
+
+	// OnDeliveryStateChanged is called when the peer changes the delivery state of a received message.
+	// msg is the message whose delivery state changed; state is the new delivery state.
+	//
+	// The msg pointer is a copy of the originally received message, including its delivery tag and
+	// settlement handle. User code must not call AcceptMessage/RejectMessage/etc. on msg if the
+	// message has already been settled via a previous disposition call.
+	//
+	// This callback is invoked from the link's mux goroutine.
+	// Blocking operations must not be performed inside this callback.
+	OnDeliveryStateChanged func(msg *Message, state DeliveryState)
 
 	// RequestedSenderSettleMode sets the requested sender settlement mode.
 	//

--- a/receiver.go
+++ b/receiver.go
@@ -44,6 +44,14 @@ type Receiver struct {
 	inFlight              inFlight             // used to track message disposition when rcv-settle-mode == second
 	creditor              creditor             // manages credits via calls to IssueCredit/DrainCredit
 	onLinkStateProperties func(map[string]any) // callback for when link props are set in the flow frame
+
+	// onDeliveryStateChanged is the user-supplied callback for peer-initiated delivery state changes.
+	onDeliveryStateChanged func(*Message, DeliveryState)
+	// incomingDeliveries tracks unsettled received messages by delivery ID.
+	// It is only populated when onDeliveryStateChanged is set.
+	// Access must be guarded by incomingDeliveriesMu.
+	incomingDeliveries   map[uint32]*Message
+	incomingDeliveriesMu sync.Mutex
 }
 
 // IssueCredit adds credits to be requested in the next flow request.
@@ -319,6 +327,15 @@ func (r *Receiver) messageDisposition(ctx context.Context, msg *Message, state e
 
 	debug.Assert(r != nil)
 
+	// Remove from incoming delivery tracking so that a subsequent peer disposition for this
+	// delivery does not trigger the OnDeliveryStateChanged callback after the user has already
+	// settled the message.
+	if r.onDeliveryStateChanged != nil {
+		r.incomingDeliveriesMu.Lock()
+		delete(r.incomingDeliveries, msg.deliveryID)
+		r.incomingDeliveriesMu.Unlock()
+	}
+
 	// NOTE: we MUST add to the in-flight map before sending the disposition. if not, it's possible
 	// to receive the ack'ing disposition frame *before* the in-flight map has been updated which
 	// will cause the below <-wait to never trigger.
@@ -504,6 +521,11 @@ func newReceiver(source string, session *Session, opts *ReceiverOptions) (*Recei
 		r.l.source.DistributionMode = opts.SourceDistributionMode
 	}
 	r.onLinkStateProperties = opts.OnLinkStateProperties
+	if opts.OnDeliveryStateChanged != nil {
+		r.onDeliveryStateChanged = opts.OnDeliveryStateChanged
+		r.incomingDeliveries = make(map[uint32]*Message)
+		r.l.trackIncomingDeliveries = true
+	}
 	return r, nil
 }
 
@@ -555,6 +577,12 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 	defer func() {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
+
+		if r.onDeliveryStateChanged != nil {
+			r.incomingDeliveriesMu.Lock()
+			r.incomingDeliveries = make(map[uint32]*Message)
+			r.incomingDeliveriesMu.Unlock()
+		}
 
 		if !r.autoSendFlow {
 			// unblock any pending drain requests
@@ -773,6 +801,26 @@ func (r *Receiver) muxHandleFrame(fr frames.FrameBody) error {
 		})
 		r.onSettlement(count)
 
+		// fire the peer-initiated delivery state change callback for any tracked deliveries
+		// that were not already handled by the in-flight RSM==second path.
+		if r.onDeliveryStateChanged != nil {
+			end := fr.First
+			if fr.Last != nil {
+				end = *fr.Last
+			}
+			for deliveryID := fr.First; deliveryID <= end; deliveryID++ {
+				r.incomingDeliveriesMu.Lock()
+				msg, ok := r.incomingDeliveries[deliveryID]
+				if ok {
+					delete(r.incomingDeliveries, deliveryID)
+				}
+				r.incomingDeliveriesMu.Unlock()
+				if ok {
+					r.onDeliveryStateChanged(msg, fr.State)
+				}
+			}
+		}
+
 	default:
 		return r.l.muxHandleFrame(fr)
 	}
@@ -877,6 +925,15 @@ func (r *Receiver) muxReceive(fr frames.PerformTransfer) {
 		r.addUnsettled()
 		r.msg.rcv = r
 		debug.Log(3, "RX (Receiver %p): add unsettled delivery ID %d", r, r.msg.deliveryID)
+	}
+
+	// Record a shallow copy of the message for peer-initiated delivery state change notifications.
+	// The copy is made before the queue enqueue so that we capture rcv and deliveryID.
+	if r.onDeliveryStateChanged != nil && !r.msg.settled {
+		msgCopy := r.msg
+		r.incomingDeliveriesMu.Lock()
+		r.incomingDeliveries[r.msg.deliveryID] = &msgCopy
+		r.incomingDeliveriesMu.Unlock()
 	}
 
 	q := r.messagesQ.Acquire()

--- a/receiver.go
+++ b/receiver.go
@@ -578,6 +578,15 @@ func (r *Receiver) mux(hooks receiverTestHooks) {
 		// unblock any in flight message dispositions
 		r.inFlight.clear(r.l.doneErr)
 
+		// When a link shuts down, any messages stored in incomingDeliveries that never received
+		// a peer Disposition frame would keep their *Message pointers alive indefinitely,
+		// causing a memory leak. Replacing the map with make(map[uint32]*Message)
+		// on defer releases all those references,
+		// allowing the GC to reclaim them. Using make(...)
+		// instead of nil also prevents nil-map panics in case concurrent code
+		// (guarded by the mutex) accesses the map after the mux loop exits.
+		// In essence: it's a defensive memory cleanup that prevents leaked message
+		// references when the link closes.
 		if r.onDeliveryStateChanged != nil {
 			r.incomingDeliveriesMu.Lock()
 			r.incomingDeliveries = make(map[uint32]*Message)

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1630,3 +1630,204 @@ func TestReceiverAttachDesiredCapabilities(t *testing.T) {
 }
 
 // TODO: add unit tests for manual credit management
+
+// receiverOnDeliveryStateChangedResponder returns a responder suitable for
+// OnDeliveryStateChanged tests. It handles the standard connection/session/link
+// lifecycle; PerformFlow and PerformDisposition are silently consumed.
+func receiverOnDeliveryStateChangedResponder(t *testing.T, rsm ReceiverSettleMode) func(uint16, frames.FrameBody) (fake.Response, error) {
+	t.Helper()
+	return func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := receiverFrameHandler(0, rsm)(remoteChannel, req)
+		if resp.Payload != nil || err != nil {
+			return resp, err
+		}
+		switch req.(type) {
+		case *frames.PerformFlow, *frames.PerformDisposition, *fake.KeepAlive:
+			return fake.Response{}, nil
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+}
+
+func TestReceiverOnDeliveryStateChangedUnsolicitedDisposition(t *testing.T) {
+	// Simulate a broker-side consumer timeout: the broker sends an unsolicited
+	// Disposition(Role=Sender, State=Released) for a message the receiver has not
+	// yet settled.  OnDeliveryStateChanged must fire with the message and state.
+	const (
+		linkHandle = uint32(0)
+		deliveryID = uint32(1)
+	)
+
+	conn := fake.NewNetConn(receiverOnDeliveryStateChangedResponder(t, ReceiverSettleModeFirst), fake.NetConnOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := NewConn(ctx, conn, nil)
+	require.NoError(t, err)
+
+	session, err := client.NewSession(ctx, nil)
+	require.NoError(t, err)
+
+	type callbackResult struct {
+		tag   []byte
+		state DeliveryState
+	}
+	callbackCh := make(chan callbackResult, 1)
+
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeFirst.Ptr(),
+		OnDeliveryStateChanged: func(msg *Message, state DeliveryState) {
+			callbackCh <- callbackResult{msg.DeliveryTag, state}
+		},
+	})
+	require.NoError(t, err)
+
+	// Inject a transfer directly — the receiver has been fully attached.
+	b, err := fake.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	msg, err := r.Receive(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+
+	// Broker sends an unsolicited settled disposition (consumer timeout → Released).
+	b, err = fake.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateReleased{})
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	select {
+	case result := <-callbackCh:
+		require.Equal(t, msg.DeliveryTag, result.tag)
+		require.IsType(t, &StateReleased{}, result.state)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnDeliveryStateChanged callback")
+	}
+
+	require.NoError(t, client.Close())
+}
+
+func TestReceiverOnDeliveryStateChangedRange(t *testing.T) {
+	// A single Disposition frame can cover a contiguous range of delivery IDs.
+	// The callback must fire once for each delivery ID within [first, last].
+	const (
+		linkHandle = uint32(0)
+		firstID    = uint32(1)
+		lastID     = uint32(3)
+	)
+
+	conn := fake.NewNetConn(receiverOnDeliveryStateChangedResponder(t, ReceiverSettleModeFirst), fake.NetConnOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := NewConn(ctx, conn, nil)
+	require.NoError(t, err)
+
+	session, err := client.NewSession(ctx, nil)
+	require.NoError(t, err)
+
+	type callbackResult struct {
+		tag   []byte
+		state DeliveryState
+	}
+	callbackCh := make(chan callbackResult, 10)
+
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeFirst.Ptr(),
+		Credit:         int32(lastID - firstID + 1),
+		OnDeliveryStateChanged: func(msg *Message, state DeliveryState) {
+			callbackCh <- callbackResult{msg.DeliveryTag, state}
+		},
+	})
+	require.NoError(t, err)
+
+	// Inject three transfers.
+	for i := firstID; i <= lastID; i++ {
+		b, err := fake.PerformTransfer(0, linkHandle, i, []byte("hello"))
+		require.NoError(t, err)
+		conn.SendFrame(b)
+	}
+
+	// Receive all three messages so they are tracked in incomingDeliveries.
+	for i := firstID; i <= lastID; i++ {
+		msg, err := r.Receive(ctx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+	}
+
+	// Broker sends one disposition covering the whole range.
+	last := lastID
+	b, err := fake.PerformDisposition(encoding.RoleSender, 0, firstID, &last, &encoding.StateModified{DeliveryFailed: true})
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	// Expect one callback per delivery ID in the range.
+	for i := firstID; i <= lastID; i++ {
+		select {
+		case result := <-callbackCh:
+			require.IsType(t, &StateModified{}, result.state)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for OnDeliveryStateChanged callback (delivery %d)", i)
+		}
+	}
+
+	require.NoError(t, client.Close())
+}
+
+func TestReceiverOnDeliveryStateChangedNotFiredAfterSettle(t *testing.T) {
+	// Once the receiver has settled a message (AcceptMessage), a subsequent
+	// unsolicited Disposition from the broker must NOT trigger the callback.
+	// Correctness relies on two independent guards:
+	//   1. incomingDeliveries is cleared synchronously inside messageDisposition.
+	//   2. inputHandleFromRemoteDeliveryID is cleaned up before AcceptMessage returns.
+	const (
+		linkHandle = uint32(0)
+		deliveryID = uint32(1)
+	)
+
+	conn := fake.NewNetConn(receiverOnDeliveryStateChangedResponder(t, ReceiverSettleModeFirst), fake.NetConnOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := NewConn(ctx, conn, nil)
+	require.NoError(t, err)
+
+	session, err := client.NewSession(ctx, nil)
+	require.NoError(t, err)
+
+	callbackCh := make(chan struct{}, 1)
+
+	r, err := session.NewReceiver(ctx, "source", &ReceiverOptions{
+		SettlementMode: ReceiverSettleModeFirst.Ptr(),
+		OnDeliveryStateChanged: func(_ *Message, _ DeliveryState) {
+			callbackCh <- struct{}{}
+		},
+	})
+	require.NoError(t, err)
+
+	b, err := fake.PerformTransfer(0, linkHandle, deliveryID, []byte("hello"))
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	msg, err := r.Receive(ctx, nil)
+	require.NoError(t, err)
+
+	// Settle the message.  When AcceptMessage returns both incomingDeliveries and
+	// inputHandleFromRemoteDeliveryID have been cleaned up for deliveryID.
+	require.NoError(t, r.AcceptMessage(ctx, msg))
+
+	// Now inject a late broker disposition for the same delivery ID.
+	b, err = fake.PerformDisposition(encoding.RoleSender, 0, deliveryID, nil, &encoding.StateReleased{})
+	require.NoError(t, err)
+	conn.SendFrame(b)
+
+	select {
+	case <-callbackCh:
+		t.Fatal("OnDeliveryStateChanged must not fire after message is already settled")
+	case <-time.After(200 * time.Millisecond):
+		// expected: no callback
+	}
+
+	require.NoError(t, client.Close())
+}

--- a/sender.go
+++ b/sender.go
@@ -23,7 +23,8 @@ type Sender struct {
 	nextDeliveryTag uint64
 	rollback        chan struct{}
 
-	onLinkStateProperties func(map[string]any)
+	onLinkStateProperties  func(map[string]any)
+	onDeliveryStateChanged func(DeliveryState)
 }
 
 // LinkName() is the name of the link used for this Sender.
@@ -404,6 +405,9 @@ func newSender(target string, session *Session, opts *SenderOptions) (*Sender, e
 	if opts.OnLinkStateProperties != nil {
 		s.onLinkStateProperties = opts.OnLinkStateProperties
 	}
+	if opts.OnDeliveryStateChanged != nil {
+		s.onDeliveryStateChanged = opts.OnDeliveryStateChanged
+	}
 	return s, nil
 }
 
@@ -587,12 +591,19 @@ func (s *Sender) muxHandleFrame(fr frames.FrameBody) error {
 
 	case *frames.PerformDisposition:
 		if fr.Settled {
+			if s.onDeliveryStateChanged != nil {
+				s.onDeliveryStateChanged(fr.State)
+			}
 			return nil
 		}
 
 		// peer is in mode second, so we must send confirmation of disposition.
 		// NOTE: the ack must be sent through the session so it can close out
 		// the in-flight disposition.
+		if s.onDeliveryStateChanged != nil {
+			s.onDeliveryStateChanged(fr.State)
+		}
+
 		dr := &frames.PerformDisposition{
 			Role:    encoding.RoleSender,
 			First:   fr.First,

--- a/sender_test.go
+++ b/sender_test.go
@@ -1664,3 +1664,130 @@ func TestSenderSendWithReceipt_SenderSettleModeSettled(t *testing.T) {
 	require.Zero(t, receipt)
 	require.NoError(t, client.Close())
 }
+
+func TestSenderOnDeliveryStateChangedSettled(t *testing.T) {
+	// Verify that OnDeliveryStateChanged fires when the peer sends a settled
+	// Disposition (the common RSM=First acknowledgement path).
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
+		if err != nil || resp.Payload != nil {
+			return resp, err
+		}
+		switch tt := req.(type) {
+		case *frames.PerformTransfer:
+			// Broker acks immediately with a settled Accepted disposition.
+			return newResponse(fake.PerformDisposition(encoding.RoleReceiver, 0, *tt.DeliveryID, nil, &encoding.StateAccepted{}))
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := NewConn(ctx, netConn, nil)
+	require.NoError(t, err)
+
+	session, err := client.NewSession(ctx, nil)
+	require.NoError(t, err)
+
+	callbackCh := make(chan DeliveryState, 1)
+
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		OnDeliveryStateChanged: func(state DeliveryState) {
+			callbackCh <- state
+		},
+	})
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, 0, netConn, 0, 100)
+
+	require.NoError(t, snd.Send(ctx, NewMessage([]byte("test")), nil))
+
+	// Send() returns after the session closes the done channel (step before muxFrameToLink).
+	// The callback fires in the sender's mux goroutine shortly after.
+	select {
+	case state := <-callbackCh:
+		require.IsType(t, &StateAccepted{}, state)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnDeliveryStateChanged callback")
+	}
+
+	require.NoError(t, client.Close())
+}
+
+func TestSenderOnDeliveryStateChangedUnsettled(t *testing.T) {
+	// Simulate RSM=Second: the peer first sends an UNSETTLED Disposition, then the
+	// sender acks with a settled Disposition.  OnDeliveryStateChanged must fire on
+	// the unsettled disposition before the two-phase settlement completes.
+	responder := func(remoteChannel uint16, req frames.FrameBody) (fake.Response, error) {
+		resp, err := senderFrameHandler(0, SenderSettleModeUnsettled)(remoteChannel, req)
+		if err != nil || resp.Payload != nil {
+			return resp, err
+		}
+		switch tt := req.(type) {
+		case *frames.PerformTransfer:
+			// Peer sends an unsettled disposition (Settled=false) to begin RSM=Second.
+			b, e := fake.EncodeFrame(frames.TypeAMQP, 0, &frames.PerformDisposition{
+				Role:    encoding.RoleReceiver,
+				First:   *tt.DeliveryID,
+				Settled: false,
+				State:   &encoding.StateAccepted{},
+			})
+			return fake.Response{Payload: b}, e
+		case *frames.PerformDisposition:
+			// Sender's settled ack — no further response needed.
+			return fake.Response{}, nil
+		default:
+			return fake.Response{}, fmt.Errorf("unhandled frame %T", req)
+		}
+	}
+
+	netConn := fake.NewNetConn(responder, fake.NetConnOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, err := NewConn(ctx, netConn, nil)
+	require.NoError(t, err)
+
+	session, err := client.NewSession(ctx, nil)
+	require.NoError(t, err)
+
+	callbackCh := make(chan DeliveryState, 1)
+
+	snd, err := session.NewSender(ctx, "target", &SenderOptions{
+		OnDeliveryStateChanged: func(state DeliveryState) {
+			callbackCh <- state
+		},
+	})
+	require.NoError(t, err)
+
+	sendInitialFlowFrame(t, 0, netConn, 0, 100)
+
+	// Send in a goroutine: Send() blocks until the sender receives the broker's ack
+	// to the RSM=Second settlement confirmation it sends after the callback fires.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- snd.Send(ctx, NewMessage([]byte("test")), nil)
+	}()
+
+	// Callback must fire when the unsettled disposition arrives.
+	select {
+	case state := <-callbackCh:
+		require.IsType(t, &StateAccepted{}, state)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnDeliveryStateChanged callback")
+	}
+
+	// After the callback fires the sender sends its ack, which closes the done
+	// channel and unblocks Send().
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Send to return")
+	}
+
+	require.NoError(t, client.Close())
+}

--- a/session.go
+++ b/session.go
@@ -581,8 +581,8 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 				s.muxFrameToLink(link, fr)
 
 				// Track remote delivery IDs when RSM == second (so we can route the ack disposition back
-			// to the receiver) or when the link has requested full delivery tracking (so that
-			// unsolicited peer dispositions — e.g. broker consumer timeouts — can be routed back).
+				// to the receiver) or when the link has requested full delivery tracking (so that
+				// unsolicited peer dispositions — e.g. broker consumer timeouts — can be routed back).
 				if !body.Settled && body.DeliveryID != nil &&
 					((link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond) ||
 						link.trackIncomingDeliveries) {

--- a/session.go
+++ b/session.go
@@ -580,8 +580,12 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 
 				s.muxFrameToLink(link, fr)
 
-				// if this message is received unsettled and link rcv-settle-mode == second, add to handlesByRemoteDeliveryID
-				if !body.Settled && body.DeliveryID != nil && link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond {
+				// Track remote delivery IDs when RSM == second (so we can route the ack disposition back
+			// to the receiver) or when the link has requested full delivery tracking (so that
+			// unsolicited peer dispositions — e.g. broker consumer timeouts — can be routed back).
+				if !body.Settled && body.DeliveryID != nil &&
+					((link.receiverSettleMode != nil && *link.receiverSettleMode == ReceiverSettleModeSecond) ||
+						link.trackIncomingDeliveries) {
 					debug.Log(1, "RX (Session %p): adding handle %d to inputHandleFromRemoteDeliveryID. remote delivery ID: %d", s, body.Handle, *body.DeliveryID)
 					inputHandleFromRemoteDeliveryID[*body.DeliveryID] = body.Handle
 				}
@@ -732,6 +736,18 @@ func (s *Session) mux(remoteBegin *frames.PerformBegin) {
 							}
 							close(done)
 						}
+					}
+				} else if fr.Role == encoding.RoleReceiver && fr.Settled {
+					// The receiver is settling with RSM == first (immediate settlement).
+					// Remove the delivery IDs from the remote-delivery tracking map so that
+					// memory is reclaimed even if the peer never sends a confirming disposition.
+					start := fr.First
+					end := start
+					if fr.Last != nil {
+						end = *fr.Last
+					}
+					for deliveryID := start; deliveryID <= end; deliveryID++ {
+						delete(inputHandleFromRemoteDeliveryID, deliveryID)
 					}
 				}
 				s.txFrame(env.FrameCtx, fr)


### PR DESCRIPTION
Proposal for #376


Expose a new OnDeliveryStateChanged option on ReceiverOptions and SenderOptions so callers can be notified when the peer changes the delivery state of an in-flight message.

Previously, unsolicited disposition frames from the broker (e.g. a RabbitMQ consumer-timeout releasing a message the client had not yet settled) were silently discarded because the session mux only registered incoming transfer delivery IDs in inputHandleFromRemoteDeliveryID when the receiver settlement mode was Second.  This change fixes that by:

- Adding a trackIncomingDeliveries flag to the link struct.  When set, the session registers every incoming transfer delivery ID so that peer disposition frames can always be routed to the correct link.
- Cleaning up those entries from the tracking map when the receiver sends a settled outgoing disposition (RSM=First), preventing leaks.
- Firing ReceiverOptions.OnDeliveryStateChanged with a copy of the original message and the new DeliveryState whenever the peer sends a matching disposition.
- Firing SenderOptions.OnDeliveryStateChanged with the new DeliveryState whenever the peer acknowledges or changes the state of a sent message.

Closes #376

<!--
Thank you for contributing to go-amqp.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to [CHANGELOG.md][] are included.
- [x] MIT license headers are included in each file.

[CHANGELOG.md]: https://github.com/Azure/go-amqp/blob/main/CHANGELOG.md
