### PR TITLE
Fix/array count bounds check

### DIFF
--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -332,12 +332,34 @@ func readCompositeHeader(r *buffer.Buffer) (_ AMQPType, fields int64, _ error) {
 	return AMQPType(v), fields, err
 }
 
-// maxCompoundCount caps the COUNT field of an AMQP compound type
-// (array, list, map) at decode time. AMQP COUNT is attacker-controlled
-// (up to 2^32-1 for the 32-bit form), and combined with zero-width or
-// 1-byte element constructors can drive unbounded allocation or loop
-// iteration. Legitimate Service Bus / Event Hubs traffic is far below
-// this limit.
+// maxCompoundCount caps the COUNT field of an AMQP 1.0 compound type
+// (array, list, map) at decode time.
+//
+// Per AMQP 1.0 §1.6.22-§1.6.24 the wire format of each compound type is
+//
+//	[type code] [SIZE] [COUNT] [body]
+//
+// where SIZE is the byte length of everything after SIZE itself and
+// COUNT is the number of elements (or, for map, of key+value items).
+// Both fields are peer-supplied and, in the 32-bit forms, can range
+// up to 2^32-1.
+//
+// Without an upper bound, two attacker-controlled COUNT shapes are
+// dangerous:
+//
+//  1. Array with a zero-width element constructor (TypeCodeNull,
+//     TypeCodeBoolTrue/False, TypeCodeUint0, TypeCodeUlong0, ...).
+//     Per-element body cost is 0, so a tiny frame can declare billions
+//     of elements. Typed Unmarshal callers (e.g. arrayUint32) then call
+//     make([]T, COUNT), which OOMs the process.
+//  2. List/map with 1-byte-per-element constructors. COUNT is bounded
+//     by the buffer here, but a multi-megabyte frame can still pin the
+//     decoder in a long loop.
+//
+// 65536 is well above any legitimate compound emitted by Azure Service
+// Bus, Event Hubs, or any other AMQP 1.0 broker we are aware of, and
+// matches the bound used in the corresponding C library fix
+// (azure-uamqp-c).
 const maxCompoundCount = 65536
 
 func readListHeader(r *buffer.Buffer) (length int64, _ error) {
@@ -437,9 +459,19 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 	if length > maxCompoundCount {
 		return 0, fmt.Errorf("array count %d exceeds maximum %d", length, maxCompoundCount)
 	}
-	// Body remaining after the COUNT field equals size - countFieldBytes.
-	// COUNT cannot exceed that remaining byte budget; this catches Array
-	// frames that pair a huge COUNT with a zero-width element constructor.
+	// Body-length check.
+	//
+	// SIZE covers [COUNT field][element constructor][elements...].
+	// After subtracting the COUNT field itself, the remaining budget
+	// must fit the constructor (>=1 byte) plus all elements, so COUNT
+	// cannot exceed (size - countFieldBytes).
+	//
+	// For zero-width element constructors (e.g. TypeCodeUint0) a single
+	// element occupies 0 body bytes, so this check effectively forbids
+	// any non-empty zero-width-element array. That encoding is legal
+	// per the spec but redundant in practice (the same payload encodes
+	// in fewer bytes as repeated single values), and rejecting it is
+	// what closes the OOM vector even if maxCompoundCount were raised.
 	if size < countFieldBytes || length > size-countFieldBytes {
 		return 0, fmt.Errorf("array count %d exceeds body length %d", length, size-countFieldBytes)
 	}
@@ -1204,9 +1236,12 @@ func readMap8Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = uint32(buf[1])
 
+	// Hard cap on attacker-controlled COUNT; see maxCompoundCount.
 	if count > maxCompoundCount {
 		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
 	}
+	// Each map item carries its own constructor (>=1 byte), so COUNT
+	// must fit in the remaining buffer.
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}
@@ -1228,9 +1263,12 @@ func readMap32Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = binary.BigEndian.Uint32(buf[4:8])
 
+	// Hard cap on attacker-controlled COUNT; see maxCompoundCount.
 	if count > maxCompoundCount {
 		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
 	}
+	// Each map item carries its own constructor (>=1 byte), so COUNT
+	// must fit in the remaining buffer.
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}

--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -332,6 +332,14 @@ func readCompositeHeader(r *buffer.Buffer) (_ AMQPType, fields int64, _ error) {
 	return AMQPType(v), fields, err
 }
 
+// maxCompoundCount caps the COUNT field of an AMQP compound type
+// (array, list, map) at decode time. AMQP COUNT is attacker-controlled
+// (up to 2^32-1 for the 32-bit form), and combined with zero-width or
+// 1-byte element constructors can drive unbounded allocation or loop
+// iteration. Legitimate Service Bus / Event Hubs traffic is far below
+// this limit.
+const maxCompoundCount = 65536
+
 func readListHeader(r *buffer.Buffer) (length int64, _ error) {
 	type_, err := readType(r)
 	if err != nil {
@@ -340,6 +348,7 @@ func readListHeader(r *buffer.Buffer) (length int64, _ error) {
 
 	listLength := r.Len()
 
+	var size, countFieldBytes int64
 	switch type_ {
 	case TypeCodeList0:
 		return 0, nil
@@ -350,11 +359,12 @@ func readListHeader(r *buffer.Buffer) (length int64, _ error) {
 		}
 		_ = buf[1]
 
-		size := int(buf[0])
-		if size > listLength-1 {
+		size = int64(buf[0])
+		if size > int64(listLength-1) {
 			return 0, errors.New("invalid length")
 		}
 		length = int64(buf[1])
+		countFieldBytes = 1
 	case TypeCodeList32:
 		buf, ok := r.Next(8)
 		if !ok {
@@ -362,13 +372,23 @@ func readListHeader(r *buffer.Buffer) (length int64, _ error) {
 		}
 		_ = buf[7]
 
-		size := int(binary.BigEndian.Uint32(buf[:4]))
-		if size > listLength-4 {
+		size = int64(binary.BigEndian.Uint32(buf[:4]))
+		if size > int64(listLength-4) {
 			return 0, errors.New("invalid length")
 		}
 		length = int64(binary.BigEndian.Uint32(buf[4:8]))
+		countFieldBytes = 4
 	default:
 		return 0, fmt.Errorf("type code %#02x is not a recognized list type", type_)
+	}
+
+	if length > maxCompoundCount {
+		return 0, fmt.Errorf("list count %d exceeds maximum %d", length, maxCompoundCount)
+	}
+	// Each list element carries its own constructor (>=1 byte), so COUNT
+	// cannot exceed the encoded body size minus the COUNT field itself.
+	if size < countFieldBytes || length > size-countFieldBytes {
+		return 0, fmt.Errorf("list count %d exceeds body length %d", length, size-countFieldBytes)
 	}
 
 	return length, nil
@@ -382,6 +402,7 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 
 	arrayLength := r.Len()
 
+	var size, countFieldBytes int64
 	switch type_ {
 	case TypeCodeArray8:
 		buf, ok := r.Next(2)
@@ -390,11 +411,12 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 		}
 		_ = buf[1]
 
-		size := int(buf[0])
-		if size > arrayLength-1 {
+		size = int64(buf[0])
+		if size > int64(arrayLength-1) {
 			return 0, errors.New("invalid length")
 		}
 		length = int64(buf[1])
+		countFieldBytes = 1
 	case TypeCodeArray32:
 		buf, ok := r.Next(8)
 		if !ok {
@@ -402,13 +424,24 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 		}
 		_ = buf[7]
 
-		size := binary.BigEndian.Uint32(buf[:4])
-		if int(size) > arrayLength-4 {
+		size = int64(binary.BigEndian.Uint32(buf[:4]))
+		if size > int64(arrayLength-4) {
 			return 0, fmt.Errorf("invalid length for type %02x", type_)
 		}
 		length = int64(binary.BigEndian.Uint32(buf[4:8]))
+		countFieldBytes = 4
 	default:
 		return 0, fmt.Errorf("type code %#02x is not a recognized array type", type_)
+	}
+
+	if length > maxCompoundCount {
+		return 0, fmt.Errorf("array count %d exceeds maximum %d", length, maxCompoundCount)
+	}
+	// Body remaining after the COUNT field equals size - countFieldBytes.
+	// COUNT cannot exceed that remaining byte budget; this catches Array
+	// frames that pair a huge COUNT with a zero-width element constructor.
+	if size < countFieldBytes || length > size-countFieldBytes {
+		return 0, fmt.Errorf("array count %d exceeds body length %d", length, size-countFieldBytes)
 	}
 	return length, nil
 }
@@ -1171,6 +1204,9 @@ func readMap8Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = uint32(buf[1])
 
+	if count > maxCompoundCount {
+		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
+	}
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}
@@ -1192,6 +1228,9 @@ func readMap32Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = binary.BigEndian.Uint32(buf[4:8])
 
+	if count > maxCompoundCount {
+		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
+	}
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}

--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -332,34 +332,14 @@ func readCompositeHeader(r *buffer.Buffer) (_ AMQPType, fields int64, _ error) {
 	return AMQPType(v), fields, err
 }
 
-// maxCompoundCount caps the COUNT field of an AMQP 1.0 compound type
-// (array, list, map) at decode time.
-//
-// Per AMQP 1.0 §1.6.22-§1.6.24 the wire format of each compound type is
-//
-//	[type code] [SIZE] [COUNT] [body]
-//
-// where SIZE is the byte length of everything after SIZE itself and
-// COUNT is the number of elements (or, for map, of key+value items).
-// Both fields are peer-supplied and, in the 32-bit forms, can range
-// up to 2^32-1.
-//
-// Without an upper bound, two attacker-controlled COUNT shapes are
-// dangerous:
-//
-//  1. Array with a zero-width element constructor (TypeCodeNull,
-//     TypeCodeBoolTrue/False, TypeCodeUint0, TypeCodeUlong0, ...).
-//     Per-element body cost is 0, so a tiny frame can declare billions
-//     of elements. Typed Unmarshal callers (e.g. arrayUint32) then call
-//     make([]T, COUNT), which OOMs the process.
-//  2. List/map with 1-byte-per-element constructors. COUNT is bounded
-//     by the buffer here, but a multi-megabyte frame can still pin the
-//     decoder in a long loop.
-//
-// 65536 is well above any legitimate compound emitted by Azure Service
-// Bus, Event Hubs, or any other AMQP 1.0 broker we are aware of, and
-// matches the bound used in the corresponding C library fix
-// (azure-uamqp-c).
+// maxCompoundCount caps the element count of an AMQP 1.0 compound type
+// (array, list, map) at decode time. Per AMQP 1.0 §1.6.22-§1.6.24, the
+// 32-bit forms can declare counts up to 2^32-1. Two attacker shapes are
+// then dangerous: a zero-width array constructor lets a tiny frame
+// claim billions of elements (typed decoders then make([]T, count) and
+// OOM); a 1-byte-per-element list/map is bounded by the buffer but
+// still pins the decoder in a long loop. 65536 sits well above any
+// legitimate compound observed on real brokers.
 const maxCompoundCount = 65536
 
 func readListHeader(r *buffer.Buffer) (length int64, _ error) {
@@ -407,8 +387,8 @@ func readListHeader(r *buffer.Buffer) (length int64, _ error) {
 	if length > maxCompoundCount {
 		return 0, fmt.Errorf("list count %d exceeds maximum %d", length, maxCompoundCount)
 	}
-	// Each list element carries its own constructor (>=1 byte), so COUNT
-	// cannot exceed the encoded body size minus the COUNT field itself.
+	// Each list element carries a constructor (>=1 byte), so the count
+	// can't exceed the body size minus the count field itself.
 	if size < countFieldBytes || length > size-countFieldBytes {
 		return 0, fmt.Errorf("list count %d exceeds body length %d", length, size-countFieldBytes)
 	}
@@ -459,13 +439,10 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 	if length > maxCompoundCount {
 		return 0, fmt.Errorf("array count %d exceeds maximum %d", length, maxCompoundCount)
 	}
-	// Cheap pre-allocation bound: compare COUNT (element count) against
-	// the remaining body SIZE in bytes. Units intentionally don't match —
-	// this is an over-approximation that assumes a >=1-byte-per-element
-	// floor, which holds for every non-zero-width constructor. The
-	// constructor isn't known yet, so a precise per-element check has to
-	// wait until we actually read each element; this guard just keeps an
-	// attacker from making us allocate a COUNT-sized slice up front.
+	// Cheap pre-allocation bound: element count can't exceed remaining
+	// body bytes. Units differ, but every non-zero-width element is at
+	// least one byte, so the over-approximation is safe. Per-element
+	// validation happens at decode time.
 	if size < countFieldBytes || length > size-countFieldBytes {
 		return 0, fmt.Errorf("array count %d exceeds body length %d", length, size-countFieldBytes)
 	}
@@ -1230,12 +1207,12 @@ func readMap8Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = uint32(buf[1])
 
-	// Hard cap on attacker-controlled COUNT; see maxCompoundCount.
+	// Hard cap; see maxCompoundCount.
 	if count > maxCompoundCount {
 		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
 	}
-	// Each map item carries its own constructor (>=1 byte), so COUNT
-	// must fit in the remaining buffer.
+	// Each entry carries a constructor (>=1 byte), so the count must
+	// fit in the remaining buffer.
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}
@@ -1257,12 +1234,12 @@ func readMap32Header(r *buffer.Buffer) (count uint32, _ error) {
 	}
 	count = binary.BigEndian.Uint32(buf[4:8])
 
-	// Hard cap on attacker-controlled COUNT; see maxCompoundCount.
+	// Hard cap; see maxCompoundCount.
 	if count > maxCompoundCount {
 		return 0, fmt.Errorf("map count %d exceeds maximum %d", count, maxCompoundCount)
 	}
-	// Each map item carries its own constructor (>=1 byte), so COUNT
-	// must fit in the remaining buffer.
+	// Each entry carries a constructor (>=1 byte), so the count must
+	// fit in the remaining buffer.
 	if int(count) > r.Len() {
 		return 0, errors.New("invalid length")
 	}

--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -459,22 +459,13 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 	if length > maxCompoundCount {
 		return 0, fmt.Errorf("array count %d exceeds maximum %d", length, maxCompoundCount)
 	}
-	// Body-length sanity check.
-	//
-	// We compare COUNT (a number of elements) against bytes-of-body —
-	// a deliberate unit mismatch, but a sound lower bound: each element
-	// costs at least 1 byte (either its own value bytes or a share of
-	// the leading constructor). SIZE covers [COUNT field][element
-	// constructor][elements...], so after subtracting the COUNT field's
-	// own width the remaining body must hold the constructor plus all
-	// elements, giving COUNT <= (size - countFieldBytes).
-	//
-	// For arrays declared with a zero-width element constructor
-	// (e.g. TypeCodeUint0) a single element occupies 0 body bytes,
-	// so this check effectively forbids any non-empty zero-width
-	// array. That encoding is legal per the spec but redundant in
-	// practice, and rejecting it is what closes the OOM vector even
-	// if maxCompoundCount were raised.
+	// Cheap pre-allocation bound: compare COUNT (element count) against
+	// the remaining body SIZE in bytes. Units intentionally don't match —
+	// this is an over-approximation that assumes a >=1-byte-per-element
+	// floor, which holds for every non-zero-width constructor. The
+	// constructor isn't known yet, so a precise per-element check has to
+	// wait until we actually read each element; this guard just keeps an
+	// attacker from making us allocate a COUNT-sized slice up front.
 	if size < countFieldBytes || length > size-countFieldBytes {
 		return 0, fmt.Errorf("array count %d exceeds body length %d", length, size-countFieldBytes)
 	}

--- a/internal/encoding/decode.go
+++ b/internal/encoding/decode.go
@@ -459,19 +459,22 @@ func readArrayHeader(r *buffer.Buffer) (length int64, _ error) {
 	if length > maxCompoundCount {
 		return 0, fmt.Errorf("array count %d exceeds maximum %d", length, maxCompoundCount)
 	}
-	// Body-length check.
+	// Body-length sanity check.
 	//
-	// SIZE covers [COUNT field][element constructor][elements...].
-	// After subtracting the COUNT field itself, the remaining budget
-	// must fit the constructor (>=1 byte) plus all elements, so COUNT
-	// cannot exceed (size - countFieldBytes).
+	// We compare COUNT (a number of elements) against bytes-of-body —
+	// a deliberate unit mismatch, but a sound lower bound: each element
+	// costs at least 1 byte (either its own value bytes or a share of
+	// the leading constructor). SIZE covers [COUNT field][element
+	// constructor][elements...], so after subtracting the COUNT field's
+	// own width the remaining body must hold the constructor plus all
+	// elements, giving COUNT <= (size - countFieldBytes).
 	//
-	// For zero-width element constructors (e.g. TypeCodeUint0) a single
-	// element occupies 0 body bytes, so this check effectively forbids
-	// any non-empty zero-width-element array. That encoding is legal
-	// per the spec but redundant in practice (the same payload encodes
-	// in fewer bytes as repeated single values), and rejecting it is
-	// what closes the OOM vector even if maxCompoundCount were raised.
+	// For arrays declared with a zero-width element constructor
+	// (e.g. TypeCodeUint0) a single element occupies 0 body bytes,
+	// so this check effectively forbids any non-empty zero-width
+	// array. That encoding is legal per the spec but redundant in
+	// practice, and rejecting it is what closes the OOM vector even
+	// if maxCompoundCount were raised.
 	if size < countFieldBytes || length > size-countFieldBytes {
 		return 0, fmt.Errorf("array count %d exceeds body length %d", length, size-countFieldBytes)
 	}

--- a/internal/encoding/types_test.go
+++ b/internal/encoding/types_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 	"time"
@@ -83,4 +84,118 @@ func TestDecodeSmallInts(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int32(-1), val)
 	})
+}
+
+func TestArray32CountExceedingMaxIsRejected(t *testing.T) {
+	// Array32 with COUNT 0x7FFFFFFF — far above any legitimate value.
+	// Body padding makes the (correct) size-vs-buffer check pass so the
+	// COUNT cap is what fires. Decoder must reject before allocating
+	// or iterating.
+	const size = 9
+	frame := make([]byte, 0, 1+4+size)
+	frame = append(frame, byte(TypeCodeArray32))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
+	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = append(frame, byte(TypeCodeNull))
+	frame = append(frame, make([]byte, size-4-1)...)
+
+	buff := buffer.New(frame)
+	done := make(chan error, 1)
+	go func() {
+		_, err := readArrayHeader(buff)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	case <-time.After(time.Second):
+		t.Fatal("readArrayHeader did not return promptly on malicious COUNT")
+	}
+}
+
+func TestArray32CountExceedingBodyIsRejected(t *testing.T) {
+	// COUNT (=100) is below maxCompoundCount but exceeds the
+	// remaining body budget after the COUNT field. Element type
+	// 0x40 (Null) is zero-width, mirroring the canonical exploit
+	// shape that the body-length check is meant to catch.
+	const size = 10
+	const count = 100
+	frame := make([]byte, 0, 1+4+size)
+	frame = append(frame, byte(TypeCodeArray32))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(count))
+	frame = append(frame, byte(TypeCodeNull))
+	frame = append(frame, make([]byte, size-4-1)...) // pad to declared size
+	buff := buffer.New(frame)
+
+	_, err := readArrayHeader(buff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds body length")
+}
+
+func TestArray32AtMaxCountSucceeds(t *testing.T) {
+	// Exactly maxCompoundCount elements, each one byte
+	// (TypeCodeSmallUint). Header should decode cleanly.
+	const count = 65536
+	const size = 4 + 1 + count
+	frame := make([]byte, 0, 1+4+size)
+	frame = append(frame, byte(TypeCodeArray32))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(count))
+	frame = append(frame, byte(TypeCodeSmallUint))
+	frame = append(frame, make([]byte, count)...)
+	buff := buffer.New(frame)
+
+	n, err := readArrayHeader(buff)
+	require.NoError(t, err)
+	require.EqualValues(t, count, n)
+}
+
+func TestArray8CountChecksApplied(t *testing.T) {
+	// Array8 max COUNT is 255, so the maxCompoundCount cap is
+	// effectively a no-op for this code, but the body-length
+	// check still matters: COUNT=200 with body remaining=4 bytes
+	// must be rejected.
+	frame := []byte{
+		byte(TypeCodeArray8),
+		0x05,             // size: 1 (count) + 1 (constructor) + 3 (padding)
+		200,              // count
+		byte(TypeCodeNull),
+		0x00, 0x00, 0x00, // padding to declared size
+	}
+	buff := buffer.New(frame)
+	_, err := readArrayHeader(buff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds body length")
+}
+
+func TestList32CountBoundsChecked(t *testing.T) {
+	// COUNT 0x7FFFFFFF on a List32 must be rejected by the cap.
+	const size = 9
+	frame := make([]byte, 0, 1+4+size)
+	frame = append(frame, byte(TypeCodeList32))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
+	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = append(frame, make([]byte, size-4)...)
+
+	buff := buffer.New(frame)
+	_, err := readListHeader(buff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestMap32CountBoundsChecked(t *testing.T) {
+	// COUNT 0x7FFFFFFF on a Map32 must be rejected by the cap.
+	const size = 9
+	frame := make([]byte, 0, 1+4+size)
+	frame = append(frame, byte(TypeCodeMap32))
+	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
+	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = append(frame, make([]byte, size-4)...)
+
+	buff := buffer.New(frame)
+	_, err := readMapHeader(buff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
 }

--- a/internal/encoding/types_test.go
+++ b/internal/encoding/types_test.go
@@ -93,10 +93,8 @@ func TestDecodeSmallInts(t *testing.T) {
 }
 
 func TestArray32CountExceedingMaxIsRejected(t *testing.T) {
-	// Array32 with COUNT 0x7FFFFFFF — far above any legitimate value.
-	// Body padding makes the (correct) size-vs-buffer check pass so the
-	// COUNT cap is what fires. Decoder must reject before allocating
-	// or iterating.
+	// Array32 with count 0x7FFFFFFF. Body padding makes the size check
+	// pass, so the count cap is what must fire.
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeArray32))
@@ -112,10 +110,9 @@ func TestArray32CountExceedingMaxIsRejected(t *testing.T) {
 }
 
 func TestArray32CountExceedingBodyIsRejected(t *testing.T) {
-	// COUNT (=100) is below maxCompoundCount but exceeds the
-	// remaining body budget after the COUNT field. Element type
-	// 0x40 (Null) is zero-width, mirroring the canonical exploit
-	// shape that the body-length check is meant to catch.
+	// count=100 is below maxCompoundCount but exceeds the body budget
+	// after the count field. Zero-width Null element mirrors the
+	// exploit shape the body-length check targets.
 	const size = 10
 	const count = 100
 	frame := make([]byte, 0, 1+4+size)
@@ -150,10 +147,9 @@ func TestArray32AtMaxCountSucceeds(t *testing.T) {
 }
 
 func TestArray8CountChecksApplied(t *testing.T) {
-	// Array8 max COUNT is 255, so the maxCompoundCount cap is
-	// effectively a no-op for this code, but the body-length
-	// check still matters: COUNT=200 with body remaining=4 bytes
-	// must be rejected.
+	// Array8's max count is 255, so maxCompoundCount is a no-op here;
+	// the body-length check is what must reject count=200 with only
+	// 4 bytes of body remaining.
 	frame := []byte{
 		byte(TypeCodeArray8),
 		0x05, // size: 1 (count) + 1 (constructor) + 3 (padding)
@@ -168,7 +164,7 @@ func TestArray8CountChecksApplied(t *testing.T) {
 }
 
 func TestList32CountBoundsChecked(t *testing.T) {
-	// COUNT 0x7FFFFFFF on a List32 must be rejected by the cap.
+	// count 0x7FFFFFFF on a List32 must be rejected by the cap.
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeList32))
@@ -183,7 +179,7 @@ func TestList32CountBoundsChecked(t *testing.T) {
 }
 
 func TestMap32CountBoundsChecked(t *testing.T) {
-	// COUNT 0x7FFFFFFF on a Map32 must be rejected by the cap.
+	// count 0x7FFFFFFF on a Map32 must be rejected by the cap.
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeMap32))

--- a/internal/encoding/types_test.go
+++ b/internal/encoding/types_test.go
@@ -159,8 +159,8 @@ func TestArray8CountChecksApplied(t *testing.T) {
 	// must be rejected.
 	frame := []byte{
 		byte(TypeCodeArray8),
-		0x05,             // size: 1 (count) + 1 (constructor) + 3 (padding)
-		200,              // count
+		0x05, // size: 1 (count) + 1 (constructor) + 3 (padding)
+		200,  // count
 		byte(TypeCodeNull),
 		0x00, 0x00, 0x00, // padding to declared size
 	}

--- a/internal/encoding/types_test.go
+++ b/internal/encoding/types_test.go
@@ -12,6 +12,12 @@ import (
 
 const amqpArrayHeaderLength = 4
 
+func appendUint32BE(b []byte, v uint32) []byte {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], v)
+	return append(b, buf[:]...)
+}
+
 func TestEncodeDecodeTimestamp(t *testing.T) {
 	// this is DateTime.MaxValue from .NET
 	dotnetMaxTime := time.UnixMilli(int64(253402300799999)).UTC()
@@ -94,8 +100,8 @@ func TestArray32CountExceedingMaxIsRejected(t *testing.T) {
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeArray32))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
-	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = appendUint32BE(frame, uint32(size))
+	frame = appendUint32BE(frame, 0x7fffffff)
 	frame = append(frame, byte(TypeCodeNull))
 	frame = append(frame, make([]byte, size-4-1)...)
 
@@ -123,8 +129,8 @@ func TestArray32CountExceedingBodyIsRejected(t *testing.T) {
 	const count = 100
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeArray32))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(count))
+	frame = appendUint32BE(frame, uint32(size))
+	frame = appendUint32BE(frame, uint32(count))
 	frame = append(frame, byte(TypeCodeNull))
 	frame = append(frame, make([]byte, size-4-1)...) // pad to declared size
 	buff := buffer.New(frame)
@@ -141,8 +147,8 @@ func TestArray32AtMaxCountSucceeds(t *testing.T) {
 	const size = 4 + 1 + count
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeArray32))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(count))
+	frame = appendUint32BE(frame, uint32(size))
+	frame = appendUint32BE(frame, uint32(count))
 	frame = append(frame, byte(TypeCodeSmallUint))
 	frame = append(frame, make([]byte, count)...)
 	buff := buffer.New(frame)
@@ -175,8 +181,8 @@ func TestList32CountBoundsChecked(t *testing.T) {
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeList32))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
-	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = appendUint32BE(frame, uint32(size))
+	frame = appendUint32BE(frame, 0x7fffffff)
 	frame = append(frame, make([]byte, size-4)...)
 
 	buff := buffer.New(frame)
@@ -190,8 +196,8 @@ func TestMap32CountBoundsChecked(t *testing.T) {
 	const size = 9
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeMap32))
-	frame = binary.BigEndian.AppendUint32(frame, uint32(size))
-	frame = binary.BigEndian.AppendUint32(frame, 0x7fffffff)
+	frame = appendUint32BE(frame, uint32(size))
+	frame = appendUint32BE(frame, 0x7fffffff)
 	frame = append(frame, make([]byte, size-4)...)
 
 	buff := buffer.New(frame)

--- a/internal/encoding/types_test.go
+++ b/internal/encoding/types_test.go
@@ -101,23 +101,14 @@ func TestArray32CountExceedingMaxIsRejected(t *testing.T) {
 	frame := make([]byte, 0, 1+4+size)
 	frame = append(frame, byte(TypeCodeArray32))
 	frame = appendUint32BE(frame, uint32(size))
-	frame = appendUint32BE(frame, 0x7fffffff)
-	frame = append(frame, byte(TypeCodeNull))
-	frame = append(frame, make([]byte, size-4-1)...)
+	frame = appendUint32BE(frame, 0x7fffffff)        // pretend our zero-width array is HUGE
+	frame = append(frame, byte(TypeCodeNull))        // use a zero-width 'constructor' for the array
+	frame = append(frame, make([]byte, size-4-1)...) // note that the actual bytes sent is basically zero, for the body of the array. Totally legal, but would have caused us to allocate a 'count' sized array to represent it.
 
 	buff := buffer.New(frame)
-	done := make(chan error, 1)
-	go func() {
-		_, err := readArrayHeader(buff)
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeds maximum")
-	case <-time.After(time.Second):
-		t.Fatal("readArrayHeader did not return promptly on malicious COUNT")
-	}
+	_, err := readArrayHeader(buff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
 }
 
 func TestArray32CountExceedingBodyIsRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

  Validate the COUNT field of compound AMQP types (array / list / map) during decode in `internal/encoding/decode.go`. Without these checks a
  malicious peer can send an Array32 / List32 / Map32 whose header advertises a multi-billion element count paired with a zero-width or 1-byte
  element constructor, driving the decoder into an unbounded loop and/or excessive slice allocation before the body is even consumed.

  Two checks are applied:

  1. **Hard cap.** `maxCompoundCount = 65536` — well above any realistic Service Bus / Event Hubs frame (message-annotation maps,
  application-properties, delivery-annotations all sit in the low tens at most). Counts above this are rejected before allocation.
  2. **Body-length check.** COUNT is also rejected if it cannot physically fit in the remaining encoded body, which incidentally rejects the
  zero-width-element case (e.g. `Array32` of `null`/`true`/`false` constructors). This is intentional — the wire form has no legitimate reason to
  advertise more elements than bytes available, and accepting it is the cheapest way for a peer to weaponize the decoder.

  ### Commits

  1. **Bound AMQP array/list/map COUNT during decode** — adds the two checks across `readListHeader`, `readMapHeader`, and the array decode path,
  plus negative-path coverage in `internal/encoding/types_test.go` (oversize count, zero-width element type, count > body-length).
  2. **Document COUNT bounds-check rationale** — inline comments tying `maxCompoundCount` to the AMQP 1.0 wire layout (§1.6 / encoding.xml),
  enumerating the two attacker-controlled COUNT shapes (`fields[size=*, count=N]` and `array32[size=*, count=N, element-constructor]`), and calling
  out that the body-length check intentionally rejects zero-width-element arrays so a future maintainer doesn't "fix" it back into a vulnerability.

  ## Test plan

  - [x] `go test ./internal/encoding/...` — new bounds tests pass, existing tests unaffected
  - [x] No change to any successful decode path: the cap is orders of magnitude above legitimate compound sizes observed in Service Bus / Event Hubs
  traffic
  - [x] No new allocations on the hot path; checks are integer comparisons before the loop

  ## Risk

  Low. Behavior change is strictly *additional* rejection of malformed frames; well-formed traffic decodes identically. Worst-case false-positive is
  a peer that genuinely sends >65536 elements in one compound, which the AMQP 1.0 spec permits but no production broker does.

