### PR TITLE
chore: add core AMQP owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 ############# 
 
 # Catch all for non-code project files and unowned files | folders
-*                        @richardpark-msft @jhendrixMSFT @rickwinter
+*                        @richardpark-msft @jhendrixMSFT @rickwinter @j7nw4r @sagar0207 @SwayGom @sjkwak @hmlam


### PR DESCRIPTION
## Summary

The catch-all owners are the ownership rule for this repository, and the people who work on the AMQP stack are not on it.

## Motivation

This repository is the Go core AMQP library, so the `*` entry owns the library itself rather than a set of unrelated files. Review requests reach only the three current owners today. The AMQP maintainers who own the equivalent libraries in the other Azure SDK languages find out about a change only when someone tells them.

## Changes

Add @j7nw4r, @sagar0207, @SwayGom, @sjkwak, and @hmlam to the catch-all entry. The current owners stay on the entry and keep their review rights.

## Validation

The change is one line.
