### PR TITLE
fix(ci): build the test broker with .NET 10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,10 @@
 variables:
   GO111MODULE: 'on'
   AMQP_BROKER_ADDR: 'amqp://127.0.0.1:25672'
+  # Revision of Azure/azure-amqp used to build TestAmqpBroker.
+  # No released tag contains the .NET 10 broker yet, so this pins a commit.
+  AZURE_AMQP_COMMIT: '111de654e170de3ab6cefe150043458c67b6660d'
+  AZURE_AMQP_BROKER_TFM: 'net10.0'
 
 jobs:
   - job: 'goamqp'
@@ -55,22 +59,23 @@ jobs:
         displayName: 'Use .NET sdk'
         inputs:
           packageType: sdk
-          version: 8.0.x
+          version: 10.0.x
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
       - script: |
+          set -e
           git clone https://github.com/Azure/azure-amqp $(Pipeline.Workspace)/azure-amqp
-          git checkout v2.6.5
+          git -C $(Pipeline.Workspace)/azure-amqp checkout $(AZURE_AMQP_COMMIT)
           pushd $(Pipeline.Workspace)/azure-amqp/test/TestAmqpBroker
           dotnet restore
-          dotnet build
+          dotnet build -f $(AZURE_AMQP_BROKER_TFM)
         displayName: 'Clone and Build Broker'
 
       - script: |
           set -e
           export TEST_CORPUS=1
           echo '##[command]Starting broker at $(AMQP_BROKER_ADDR)'
-          dotnet $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/net8.0/TestAmqpBroker.dll $AMQP_BROKER_ADDR /headless &
+          dotnet $(Pipeline.Workspace)/azure-amqp/bin/Debug/TestAmqpBroker/$(AZURE_AMQP_BROKER_TFM)/TestAmqpBroker.dll $AMQP_BROKER_ADDR /headless &
           brokerPID=$!
           echo '##[section]Starting tests'
           go test -race -v -coverprofile=coverage.txt -covermode atomic ./... 2>&1 | tee gotestoutput.log 


### PR DESCRIPTION
## Summary

The `Clone and Build Broker` step fails on every pull request, so both Go legs go red regardless of the change under review.

## Motivation

`git checkout v2.6.5` runs before the `pushd` into the clone, so it targets the go-amqp working directory and fails with `error: pathspec 'v2.6.5' did not match any file(s) known to git`. The step has no `set -e`, so the failure is swallowed and the pin never applies. The broker builds from the azure-amqp default branch instead.

On 2026-07-27, azure-amqp commit `27b6f8218` set `global.json` to SDK 10.0.100 and moved `TestAmqpBroker` to `net48;net10.0`. This pipeline installs the 8.0.x SDK, so `dotnet restore` fails.

## Changes

- Run the checkout inside the clone with `git -C`, and add `set -e` so the step fails loudly.
- Install the 10.0.x SDK and build only the `net10.0` target.
- Start the broker from the `net10.0` output directory.
- Move the azure-amqp revision and the broker framework into `variables`.

No released azure-amqp tag carries the .NET 10 broker, so the revision pins commit `111de654e`. It can move to a tag once one ships.

## Test plan

CI on this pull request exercises the change. `Linux_Go125` and `Linux_Go126` are green, and the `Clone and Build Broker` and `Run Tests` steps both report succeeded.
